### PR TITLE
web/css/-moz-outline-radius-*/index.md

### DIFF
--- a/files/uk/web/css/-moz-outline-radius-bottomleft/index.md
+++ b/files/uk/web/css/-moz-outline-radius-bottomleft/index.md
@@ -1,0 +1,75 @@
+---
+title: '-moz-outline-radius-bottomleft'
+slug: Web/CSS/-moz-outline-radius-bottomleft
+tags:
+  - CSS
+  - CSS Property
+  - NeedsCompatTable
+  - NeedsContent
+  - Non-standard
+  - Reference
+  - recipe:css-property
+browser-compat: css.properties.-moz-outline-radius-bottomleft
+---
+
+{{CSSRef}}{{deprecated_header}}
+
+У застосунках Mozilla властивість [CSS](/uk/docs/Web/CSS) **`-moz-outline-radius-bottomleft`** може використовуватись для закруглення нижнього лівого кута {{cssxref("outline")}} елемента.
+
+## Синтаксис
+
+Значення `-moz-outline-radius-bottomleft` &mdash; або {{cssxref("length", "&lt;length&gt;")}}, або [відсоткова частка](/uk/docs/Web/CSS/percentage) відповідних розмірів обрамленого блоку. Також може бути використана функція {{cssxref("calc()", "calc()")}}.
+
+### Значення
+
+- `<довжина>`
+  - : Радіус кола, що визначає вигин нижнього та лівого країв елемента, вказаний у вигляді {{cssxref("length", "&lt;довжини&gt;")}}.
+- `<відсотки>`
+  - : Радіус кола, що визначає закруглення нижнього лівого кута елемента, вказаний у вигляді [відсоткових величин](/uk/docs/Web/CSS/percentage) відносно нижньої та лівої сторін обрамленого блоку.
+
+## Формальне визначення
+
+{{cssinfo}}
+
+## Формальний синтаксис
+
+{{csssyntax}}
+
+## Приклади
+
+### Закруглення обрису
+
+Оскільки це Firefox-специфічна властивість, цей приклад не покаже очікуваного ефекту при перегляді у браузерах, відмінних від Firefox.
+
+#### HTML
+
+```html
+<p>Зверніть увагу на нижній лівий кут параграфа.</p>
+```
+
+#### CSS
+
+```css
+p {
+  margin: 10px;
+  border: solid cyan;
+  outline: dotted green;
+  -moz-outline-radius-bottomleft: 2em;
+}
+```
+
+#### Результат
+
+{{EmbedLiveSample("Rounding_a_outline")}}
+
+## Специфікації
+
+Не є частиною жодного стандарту.
+
+## Сумісність із браузерами
+
+{{Compat}}
+
+## Дивіться також
+
+- Перегляньте властивість {{cssxref("-moz-outline-radius")}}, аби отримати більше інформації.

--- a/files/uk/web/css/-moz-outline-radius-bottomright/index.md
+++ b/files/uk/web/css/-moz-outline-radius-bottomright/index.md
@@ -1,0 +1,73 @@
+---
+title: '-moz-outline-radius-bottomright'
+slug: Web/CSS/-moz-outline-radius-bottomright
+tags:
+  - CSS
+  - CSS Property
+  - NeedsCompatTable
+  - NeedsContent
+  - Non-standard
+  - Reference
+  - recipe:css-property
+browser-compat: css.properties.-moz-outline-radius-bottomright
+---
+
+{{CSSRef}}{{deprecated_header}}
+
+У застосунках Mozilla властивість [CSS](/uk/docs/Web/CSS) **`-moz-outline-radius-bottomright`** може використовуватись для закруглення нижнього правого кута {{cssxref("outline")}} елемента.
+
+## Синтаксис
+
+Значення `-moz-outline-radius-bottomright` &mdash; або {{cssxref("length", "&lt;length&gt;")}}, або [відсоткова частка](/uk/docs/Web/CSS/percentage) відповідних розмірів обрамленого блоку. Також може бути використана функція {{cssxref("calc()", "calc()")}}.
+
+### Значення
+
+- `<довжина>`
+  - : Радіус кола, що визначає вигин нижнього та правого країв елемента, вказаний у вигляді {{cssxref("length", "&lt;довжини&gt;")}}.
+- `<відсотки>`
+  - : Радіус кола, що визначає закруглення нижнього правого кута елемента, вказаний у вигляді [відсоткових величин](/uk/docs/Web/CSS/percentage) відносно нижньої та правої сторін обрамленого блоку.
+
+## Формальне визначення
+
+{{CSSInfo}}
+
+## Формальний синтаксис
+
+{{csssyntax}}
+
+## Приклади
+
+### HTML
+
+```html
+<p>Зверніть увагу на нижній правий кут параграфа.</p>
+```
+
+### CSS
+
+```css
+p {
+  margin: 5px;
+  border: solid cyan;
+  outline: dotted red;
+  -moz-outline-radius-bottomright: 2em;
+}
+```
+
+#### Результат
+
+{{EmbedLiveSample("Examples")}}
+
+> **Зверніть увагу:** Попередній приклад не покаже очікуваного ефекту при перегляді його у браузері, відмінному від Firefox.
+
+## Специфікації
+
+Не є частиною жодного стандарту.
+
+## Сумісність із браузерами
+
+{{Compat}}
+
+## Дивіться також
+
+- Перегляньте властивість {{cssxref("-moz-outline-radius")}}, аби отримати більше інформації.

--- a/files/uk/web/css/-moz-outline-radius-topleft/index.md
+++ b/files/uk/web/css/-moz-outline-radius-topleft/index.md
@@ -1,0 +1,71 @@
+---
+title: '-moz-outline-radius-topleft'
+slug: Web/CSS/-moz-outline-radius-topleft
+tags:
+  - CSS
+  - CSS Property
+  - NeedsCompatTable
+  - NeedsContent
+  - Non-standard
+  - Reference
+  - recipe:css-property
+browser-compat: css.properties.-moz-outline-radius-topleft
+---
+
+{{CSSRef}}{{deprecated_header}}
+
+У застосунках Mozilla властивість [CSS](/uk/docs/Web/CSS) **`-moz-outline-radius-topleft`** може використовуватись для закруглення верхнього лівого кута {{cssxref("outline")}} елемента.
+
+## Синтаксис
+
+Значення `-moz-outline-radius-topleft` &mdash; або {{cssxref("length", "&lt;length&gt;")}}, або [відсоткова частка](/uk/docs/Web/CSS/percentage) відповідних розмірів обрамленого блоку. Також може бути використана функція {{cssxref("calc()", "calc()")}}.
+
+### Значення
+
+- `<довжина>`
+  - : Радіус кола, що визначає вигин верхнього та лівого країв елемента, вказаний у вигляді {{cssxref("length", "&lt;довжини&gt;")}}.
+- `<відсотки>`
+  - : Радіус кола, що визначає закруглення верхнього лівого кута елемента, вказаний у вигляді [відсоткових величин](/uk/docs/Web/CSS/percentage) відносно верхньої та лівої сторін обрамленого блоку.
+
+## Формальне визначення
+
+{{CSSInfo}}
+
+## Формальний синтаксис
+
+{{csssyntax}}
+
+## Приклади
+
+### HTML
+
+```html
+<p>Зверніть увагу на верхній лівий кут параграфа.</p>
+```
+
+### CSS
+
+```css
+p {
+  margin: 5px;
+  border: solid cyan;
+  outline: dotted red;
+  -moz-outline-radius-topleft: 2em;
+}
+```
+
+#### Результат
+
+{{EmbedLiveSample("Examples")}}
+
+## Специфікації
+
+Не є частиною жодного стандарту.
+
+## Сумісність із браузерами
+
+{{Compat}}
+
+## Дивіться також
+
+- Перегляньте властивість {{cssxref("-moz-outline-radius")}}, аби отримати більше інформації.

--- a/files/uk/web/css/-moz-outline-radius-topright/index.md
+++ b/files/uk/web/css/-moz-outline-radius-topright/index.md
@@ -1,0 +1,73 @@
+---
+title: '-moz-outline-radius-topright'
+slug: Web/CSS/-moz-outline-radius-topright
+tags:
+  - CSS
+  - CSS Property
+  - NeedsCompatTable
+  - NeedsContent
+  - Non-standard
+  - Reference
+  - recipe:css-property
+browser-compat: css.properties.-moz-outline-radius-topright
+---
+
+{{CSSRef}}{{deprecated_header}}
+
+У застосунках Mozilla властивість [CSS](/uk/docs/Web/CSS) **`-moz-outline-radius-topright`** може використовуватись для закруглення верхнього правого кута {{cssxref("outline")}} елемента.
+
+## Синтаксис
+
+Значення `-moz-outline-radius-topright` &mdash; або {{cssxref("length", "&lt;length&gt;")}}, або [відсоткова частка](/uk/docs/Web/CSS/percentage) відповідних розмірів обрамленого блоку. Також може бути використана функція {{cssxref("calc()", "calc()")}}.
+
+### Значення
+
+- `<довжина>`
+  - : Радіус кола, що визначає вигин верхнього та правого країв елемента, вказаний у вигляді {{cssxref("length", "&lt;довжини&gt;")}}.
+- `<відсотки>`
+  - : Радіус кола, що визначає закруглення верхнього правого кута елемента, вказаний у вигляді [відсоткових величин](/uk/docs/Web/CSS/percentage) відносно верхньої та правої сторін обрамленого блоку.
+
+## Формальне визначення
+
+{{CSSInfo}}
+
+## Формальний синтаксис
+
+{{csssyntax}}
+
+## Приклади
+
+### HTML
+
+```html
+<p>Зверніть увагу на верхній правий кут параграфа.</p>
+```
+
+### CSS
+
+```css
+p {
+  margin: 5px;
+  border: solid cyan;
+  outline: dotted red;
+  -moz-outline-radius-topright: 2em;
+}
+```
+
+#### Результат
+
+{{EmbedLiveSample("Examples")}}
+
+> **Зверніть увагу:** Попередній приклад не покаже очікуваного ефекту при перегляді його у браузері, відмінному від Firefox.
+
+## Специфікації
+
+Не є частиною жодного стандарту.
+
+## Сумісність із браузерами
+
+{{Compat}}
+
+## Дивіться також
+
+- Перегляньте властивість {{cssxref("-moz-outline-radius")}}, аби отримати більше інформації.


### PR DESCRIPTION
Original content:
* https://developer.mozilla.org/en-US/docs/Web/CSS/-moz-outline-radius-bottomleft
* https://developer.mozilla.org/en-US/docs/Web/CSS/-moz-outline-radius-bottomright
* https://developer.mozilla.org/en-US/docs/Web/CSS/-moz-outline-radius-topleft
* https://developer.mozilla.org/en-US/docs/Web/CSS/-moz-outline-radius-topright
