### PR TITLE
update(CSS): Web/CSS/-moz-outline-radius-bottomleft/

### DIFF
--- a/files/uk/web/css/-moz-outline-radius-bottomleft/index.md
+++ b/files/uk/web/css/-moz-outline-radius-bottomleft/index.md
@@ -18,7 +18,7 @@ browser-compat: css.properties.-moz-outline-radius-bottomleft
 
 ## Синтаксис
 
-Значення `-moz-outline-radius-bottomleft` &mdash; або {{cssxref("length", "&lt;length&gt;")}}, або [відсоткова частка](/uk/docs/Web/CSS/percentage) відповідних розмірів обрамленого блоку. Також може бути використана функція {{cssxref("calc()", "calc()")}}.
+Значення `-moz-outline-radius-bottomleft` &mdash; або {{cssxref("length", "&lt;length&gt;")}}, або [відсоткова частка](/uk/docs/Web/CSS/percentage) відповідних розмірів обрамленого блоку. Також може бути використана функція {{cssxref("calc", "calc()")}}.
 
 ### Значення
 

--- a/files/uk/web/css/-moz-outline-radius-bottomleft/index.md
+++ b/files/uk/web/css/-moz-outline-radius-bottomleft/index.md
@@ -60,7 +60,7 @@ p {
 
 #### Результат
 
-{{EmbedLiveSample("Rounding_a_outline")}}
+{{EmbedLiveSample("zakruhlennia-obrysu")}}
 
 ## Специфікації
 


### PR DESCRIPTION
Original content: https://developer.mozilla.org/en-us/docs/Web/CSS/-moz-outline-radius-bottomleft
нові зміни:
- [56da604](https://github.com/mdn/content/commit/56da604e4fc9c926015751a990496f0284bf4e41)