### PR TITLE
update(CSS): Web/CSS/-moz-outline-radius-topleft/

### DIFF
--- a/files/uk/web/css/-moz-outline-radius-topleft/index.md
+++ b/files/uk/web/css/-moz-outline-radius-topleft/index.md
@@ -18,7 +18,7 @@ browser-compat: css.properties.-moz-outline-radius-topleft
 
 ## Синтаксис
 
-Значення `-moz-outline-radius-topleft` &mdash; або {{cssxref("length", "&lt;length&gt;")}}, або [відсоткова частка](/uk/docs/Web/CSS/percentage) відповідних розмірів обрамленого блоку. Також може бути використана функція {{cssxref("calc()", "calc()")}}.
+Значення `-moz-outline-radius-topleft` — або [`<length>`](/uk/docs/Web/CSS/length), або [відсоткова частка](/uk/docs/Web/CSS/percentage) відповідних розмірів обрамленого блоку. Також може бути використана функція [`calc()`](/uk/docs/Web/CSS/calc).
 
 ### Значення
 

--- a/files/uk/web/css/-moz-outline-radius-topleft/index.md
+++ b/files/uk/web/css/-moz-outline-radius-topleft/index.md
@@ -56,7 +56,7 @@ p {
 
 #### Результат
 
-{{EmbedLiveSample("Examples")}}
+{{EmbedLiveSample("pryklady")}}
 
 ## Специфікації
 


### PR DESCRIPTION
Original content: https://developer.mozilla.org/en-us/docs/Web/CSS/-moz-outline-radius-topleft
нові зміни:
- [ed31c94](https://github.com/mdn/content/commit/ed31c948859a76e03d0b13ff8c6bbfb2478ced2a)