### PR TITLE
update(JS): web/javascript/reference/operators/typeof

### DIFF
--- a/files/uk/web/javascript/reference/operators/typeof/index.md
+++ b/files/uk/web/javascript/reference/operators/typeof/index.md
@@ -9,6 +9,7 @@ tags:
   - Unary
 browser-compat: javascript.operators.typeof
 ---
+
 {{JSSidebar("Operators")}}
 
 Оператор **`typeof`** ("тип ...") повертає рядок, який вказує на тип операнда, без його обчислення.
@@ -20,8 +21,9 @@ browser-compat: javascript.operators.typeof
 Оператор `typeof`, за яким слідує його операнд:
 
 ```js
-typeof operand
-typeof(operand)
+typeof operand;
+<!-- markdownlint-disable-next-line -->
+typeof(operand);
 ```
 
 ### Параметри
@@ -33,17 +35,17 @@ typeof(operand)
 
 Таблиця нижче наводить всі можливі повернені значення `typeof`. Більше інформації про типи та примітиви можна знайти на сторінці, присвяченій [структурам даних JavaScript](/uk/docs/Web/JavaScript/Data_structures).
 
-| Тип                                                                                              | Результат                               |
-| ------------------------------------------------------------------------------------------------ | --------------------------------------- |
-| [Undefined](/uk/docs/Glossary/undefined)                                                         | `"undefined"`                           |
-| [Null](/uk/docs/Glossary/Null)                                                                   | `"object"` (див. [нижче](#typeof_null)) |
-| [Boolean](/uk/docs/Glossary/Boolean)                                                             | `"boolean"`                             |
-| [Number](/uk/docs/Glossary/Number)                                                               | `"number"`                              |
-| [BigInt](/uk/docs/Glossary/BigInt) (з'явився в ECMAScript 2020)                                  | `"bigint"`                              |
-| [String](/uk/docs/Glossary/String)                                                               | `"string"`                              |
-| [Symbol](/uk/docs/Glossary/Symbol) (з'явився в ECMAScript 2015)                                  | `"symbol"`                              |
-| Об'єкт [Function](/uk/docs/Glossary/Function) (реалізовує метод [[Call]] в термінах ECMA-262)    | `"function"`                            |
-| Будь-який інший об'єкт                                                                           | `"object"`                              |
+| Тип                                                                                                                                                                    | Результат                               |
+| ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------- |
+| [Undefined](/uk/docs/Glossary/undefined)                                                                                                                               | `"undefined"`                           |
+| [Null](/uk/docs/Glossary/Null)                                                                                                                                         | `"object"` (див. [нижче](#typeof_null)) |
+| [Boolean](/uk/docs/Glossary/Boolean)                                                                                                                                   | `"boolean"`                             |
+| [Number](/uk/docs/Glossary/Number)                                                                                                                                     | `"number"`                              |
+| [BigInt](/uk/docs/Glossary/BigInt)                                                                                                                                     | `"bigint"`                              |
+| [String](/uk/docs/Glossary/String)                                                                                                                                     | `"string"`                              |
+| [Symbol](/uk/docs/Web/JavaScript/Reference/Global_Objects/Symbol)                                                                                                      | `"symbol"`                              |
+| Об'єкт [Function](/uk/docs/Glossary/Function) (реалізовує [[Call]] у термінах ECMA-262; [класи](/uk/docs/Web/JavaScript/Reference/Statements/class) також є функціями) | `"function"`                            |
+| Будь-який інший об'єкт                                                                                                                                                 | `"object"`                              |
 
 > **Примітка:** ECMAScript 2019 та старіші вільні реалізації `typeof`
 > повертають будь-які визначені реалізацією рядкові значення для нестандартних
@@ -60,12 +62,12 @@ typeof(operand)
 // Числа
 typeof 37 === 'number';
 typeof 3.14 === 'number';
-typeof(42) === 'number';
+typeof 42 === 'number';
 typeof Math.LN2 === 'number';
 typeof Infinity === 'number';
 typeof NaN === 'number'; // Не дивлячись на те, що це "Not-A-Number"
-typeof Number('1') === 'number';      // Конструктор Number намагається перетворити значення на числа
-typeof Number('shoe') === 'number';   // навіть ті, які неможливо привести до числа
+typeof Number('1') === 'number'; // Конструктор Number намагається перетворити значення на числа
+typeof Number('shoe') === 'number'; // навіть ті, які неможливо привести до числа
 
 typeof 42n === 'bigint';
 
@@ -74,6 +76,7 @@ typeof '' === 'string';
 typeof 'bla' === 'string';
 typeof `шаблонний літерал` === 'string';
 typeof '1' === 'string'; // зауважте, що число всередині рядка все ж має рядковий тип
+<!-- markdownlint-disable-next-line -->
 typeof (typeof 1) === 'string'; // typeof завжди повертає рядок
 typeof String(1) === 'string'; // конструктор String перетворює все на рядок, безпечніше за toString
 
@@ -81,12 +84,12 @@ typeof String(1) === 'string'; // конструктор String перетвор
 typeof true === 'boolean';
 typeof false === 'boolean';
 typeof Boolean(1) === 'boolean'; // конструктор Boolean() перетворює значення залежно від того, істинні вони чи хибні
-typeof !!(1) === 'boolean'; // подвійний виклик оператора ! (логічне НЕ) еквівалентно виклику конструктора Boolean()
+typeof !!1 === 'boolean'; // подвійний виклик оператора ! (логічне НЕ) еквівалентно виклику конструктора Boolean()
 
 // Символи
-typeof Symbol() === 'symbol'
-typeof Symbol('foo') === 'symbol'
-typeof Symbol.iterator === 'symbol'
+typeof Symbol() === 'symbol';
+typeof Symbol('foo') === 'symbol';
+typeof Symbol.iterator === 'symbol';
 
 // Undefined
 typeof undefined === 'undefined';
@@ -94,7 +97,7 @@ typeof declaredButUndefinedVariable === 'undefined';
 typeof undeclaredVariable === 'undefined';
 
 // Об'єкти
-typeof {a: 1} === 'object';
+typeof { a: 1 } === 'object';
 
 // Для розрізнення звичайних об'єктів від масивів слід
 // застосовувати Array.isArray або Object.prototype.toString.call
@@ -109,12 +112,12 @@ typeof new Number(1) === 'object';
 typeof new String('abc') === 'object';
 
 // Функції
-typeof function() {} === 'function';
+typeof function () {} === 'function';
 typeof class C {} === 'function';
 typeof Math.sin === 'function';
 ```
 
-### `typeof null`
+### typeof null
 
 ```js
 // Ця рівність зберігається з часів створення JavaScript
@@ -125,26 +128,28 @@ typeof null === 'object';
 
 Було запропоновано виправлення для ECMAScript (як "opt-in" — можливість, яку можна було б увімкнути), проте [його відхилили](https://web.archive.org/web/20160331031419/http://wiki.ecmascript.org:80/doku.php?id=harmony:typeof_null). Результатом його прийняття була б рівність `typeof null === 'null'`.
 
-### Застосування оператора `new`
+### Застосування оператора new
 
 ```js
 // Всі функції-конструктори, за винятком конструктора Function, завжди матимуть тип 'object'
-let str = new String('String');
-let num = new Number(100);
+const str = new String('String');
+const num = new Number(100);
 
 typeof str; // Поверне 'object'
 typeof num; // Поверне 'object'
 
-let func = new Function();
+const func = new Function();
 
 typeof func; // Поверне 'function'
 ```
 
 ### Потреба в дужках в синтаксисі
 
+Оператор `typeof` має вищий [пріоритет](/uk/docs/Web/JavaScript/Reference/Operators/Operator_Precedence), ніж бінарні оператори типу оператора додавання (`+`). Таким чином, для обчислення типу результату додавання необхідні дужки.
+
 ```js
 // За допомогою дужок можна визначати тип даних цілих виразів.
-let iData = 99;
+const iData = 99;
 
 typeof iData + ' Wisen'; // 'number Wisen'
 typeof (iData + ' Wisen'); // 'string'
@@ -156,7 +161,7 @@ typeof (iData + ' Wisen'); // 'string'
 
 ```js
 typeof /s/ === 'function'; // Chrome 1-12 — не відповідає ECMAScript 5.1
-typeof /s/ === 'object';   // Firefox 5+  — згідно ECMAScript 5.1
+typeof /s/ === 'object'; // Firefox 5+  — згідно ECMAScript 5.1
 ```
 
 ### Помилки
@@ -174,7 +179,7 @@ typeof newClass; // ReferenceError
 
 let newLetVariable;
 const newConstVariable = 'hello';
-class newClass{};
+class newClass {}
 ```
 
 ### Винятки
@@ -188,31 +193,45 @@ typeof document.all === 'undefined';
 
 Хоча специфікація дає змогу мати користувацькі теги типу для нестандартних екзотичних об'єктів, вона вимагає, щоб ці теги відрізнялися від раніше заданих. Випадок з `document.all`, що має тип `'undefined'`, класифіковано у вебстандартах як "навмисне порушення" первісного стандарту ECMA JavaScript.
 
-### Застосування в реальному світі
+### Власний метод, що отримує більш конкретний тип
 
-Оператор `typeof` дуже корисний, проте він не настільки універсальний, наскільки це може бути потрібно. Наприклад, `typeof([])` дорівнює `'object'`, так само як `typeof(new Date())`, `typeof(/abc/)` та ін.
+Оператор `typeof` дуже корисний, проте він не настільки універсальний, наскільки це може бути потрібно. Наприклад, `typeof []` дорівнює `'object'`, так само як `typeof new Date()`, `typeof /abc/` тощо.
 
-Для більшої специфічности під час перевірки типів можна зробити таку обгортку над `typeof` для використання в робочому коді (за умови, що `obj` існує):
+Для більшої конкретики при перевірці типів, нижче представлена самописна функція `type(value)`, котра здебільшого імітує логіку `typeof`, але для непримітивних значень (наприклад, об‘єктів та функцій) повертає більш гранульоване ім‘я типу, коли це можливо.
 
 ```js
-  function type(obj, showFullClass) {
-
-    // отримує toPrototypeString() від obj (обробляє всі типи)
-    if (showFullClass && typeof obj === "object") {
-        return Object.prototype.toString.call(obj);
-    }
-    if (obj == null) { return (obj + '').toLowerCase(); } // неявне перетворення toString()
-
-    var deepType = Object.prototype.toString.call(obj).slice(8,-1).toLowerCase();
-    if (deepType === 'generatorfunction') { return 'function' }
-
-    // Запобігає занадто специфічному результату (наприлад, [object HTMLDivElement], та ін.)
-    // Враховує подібний до функції Regexp (Android <=2.3), подібний до функції елемент <object> (Chrome <=57, Firefox <=52), та ін.
-    // String.prototype.match підтримується всюди.
-
-    return deepType.match(/^(array|bigint|date|error|function|generator|regexp|symbol)$/) ? deepType :
-       (typeof obj === 'object' || typeof obj === 'function') ? 'object' : typeof obj;
+function type(value) {
+  if (typeof value !== 'object' && typeof value !== 'function') {
+    return typeof value;
   }
+  if (value === null) {
+    return 'null';
+  }
+  if (
+    Object.getPrototypeOf(value) === Function.prototype &&
+    /^class/.test(String(value))
+  ) {
+    return 'class';
+  }
+  // Symbol.toStringTag часто вказує "ім‘я для виведення" класу об‘єкта
+  if (
+    Symbol.toStringTag in value &&
+    typeof value[Symbol.toStringTag] === 'string'
+  ) {
+    return value[Symbol.toStringTag];
+  }
+  // Ім‘я конструктора; наприклад: `Array`, `GeneratorFunction`,
+  // `Number`, `String`, `Boolean` чи `MyCustomObject`
+  if (
+    typeof value.constructor.name === 'string' &&
+    value.constructor.name !== ''
+  ) {
+    return value.constructor.name;
+  }
+  // В цій точці немає надійного способа отримати тип значення,
+  // тож використовується базова реалізація.
+  return typeof value;
+}
 ```
 
 Для перевірки недійсних змінних, які в іншому випадку викинули б {{JSxRef("ReferenceError")}}, слід застосовувати `typeof nonExistentVar === 'undefined'`.
@@ -230,14 +249,14 @@ typeof document.all === 'undefined';
 Велика кількість системних об'єктів у середовищі IE 6, 7, та 8 — об'єкти, а не функції. Наприклад:
 
 ```js
-typeof alert === 'object'
+typeof alert === 'object';
 ```
 
 Деякі нестандартні властивості IE повертають інші значення ([tc39/ecma262#1440 (коментар - англ.)](https://github.com/tc39/ecma262/issues/1440#issuecomment-461963872)):
 
 ```js
-typeof window.external.AddSearchProvider === "unknown";
-typeof window.external.IsSearchProviderInstalled === "unknown";
+typeof window.external.AddSearchProvider === 'unknown';
+typeof window.external.IsSearchProviderInstalled === 'unknown';
 ```
 
 ## Дивіться також


### PR DESCRIPTION
Оригінальний вміст: [typeof@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Operators/typeof), [сирці typeof@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/operators/typeof/index.md)

Нові зміни:
- [mdn/content@e242a2c](https://github.com/mdn/content/commit/e242a2cab621925ba685ba710108f2ad182b6f31)