### PR TITLE
update(JS): web/javascript/reference/global_objects/object/assign

### DIFF
--- a/files/uk/web/javascript/reference/global_objects/object/assign/index.md
+++ b/files/uk/web/javascript/reference/global_objects/object/assign/index.md
@@ -46,7 +46,7 @@ Object.assign(target, ...sources);
 
 В разі помилки (наприклад, якщо властивість недоступна для запису) викидається {{jsxref("TypeError")}}, а об'єкт `target` залишається модифікованим, якщо якісь властивості були вже додані до виникнення помилки.
 
-> **Примітка:** `Object.assign()` не викидає помилок на таких донорах, як {{jsxref("null")}} чи {{jsxref("undefined")}}.
+> **Примітка:** `Object.assign()` не викидає помилок на таких донорах, як [`null`](/uk/docs/Web/JavaScript/Reference/Operators/null) чи {{jsxref("undefined")}}.
 
 ## Приклади
 


### PR DESCRIPTION
Оригінальний вміст: [Object.assign()@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Global_Objects/Object/assign), [сирці Object.assign()@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/global_objects/object/assign/index.md)

Нові зміни:
- [mdn/content@3381c87](https://github.com/mdn/content/commit/3381c87b92394ef5c68b72d40367d93c796e0870)
- [mdn/content@8bf018f](https://github.com/mdn/content/commit/8bf018f0a39d012a0d98afe3f15e0ed0fb7c8ce5)