### PR TITLE
Fix duplicated quotes in checked text

### DIFF
--- a/scripts/utils/check-file.js
+++ b/scripts/utils/check-file.js
@@ -45,10 +45,10 @@ function stripMacrosInterpolation(text) {
         return '';
       }
       debug(`Macros ${macrosName}: staying`);
-      return `"${lastParameter}"`;
+      return `${lastParameter}`;
     },
   );
-  return modifiedText.replace(/{{\s?\w+\(["']?([^"']+)["']?\)\s?}}/gim, '"$1"');
+  return modifiedText.replace(/{{\s?\w+\(["']?([^"']+)["']?\)\s?}}/gim, '$1');
 }
 
 function convertHtmlToText(html) {


### PR DESCRIPTION
Previous caused duplicated quotes around macros