### PR TITLE
update(JS): web/javascript/reference/global_objects/string/include

### DIFF
--- a/files/uk/web/javascript/reference/global_objects/string/includes/index.md
+++ b/files/uk/web/javascript/reference/global_objects/string/includes/index.md
@@ -10,17 +10,18 @@ tags:
   - Polyfill
 browser-compat: javascript.builtins.String.includes
 ---
+
 {{JSRef}}
 
-Метод **`includes()`** виконує чутливий до регістру пошук для визначення, чи можна один рядок знайти всередині іншого, повертаючи `true` або `false` відповідно.
+Метод **`includes()`** (включає) виконує чутливий до регістру пошук для визначення, чи можна один рядок знайти всередині іншого, повертаючи `true` або `false` відповідно.
 
 {{EmbedInteractiveExample("pages/js/string-includes.html", "shorter")}}
 
 ## Синтаксис
 
 ```js
-includes(searchString)
-includes(searchString, position)
+includes(searchString);
+includes(searchString, position);
 ```
 
 ### Параметри
@@ -43,42 +44,28 @@ includes(searchString, position)
 Метод `includes()` чутливий до регістру. Для прикладу, наступний вираз поверне `false`:
 
 ```js
-'Синій кит'.includes('синій')  // повертає false
+'Синій кит'.includes('синій'); // повертає false
 ```
 
-## Поліфіл
-
-Цей метод було додано специфікацією ECMAScript 2015, і він поки що може не бути присутнім у всіх реалізаціях JavaScript.
-
-Однак, його можна легко відтворити через такий поліфіл:
+Це обмеження можна обійти, привівши і вихідний рядок, і шуканий, до нижнього регістру:
 
 ```js
-if (!String.prototype.includes) {
-  String.prototype.includes = function(search, start) {
-    'use strict';
-
-    if (search instanceof RegExp) {
-      throw TypeError('first argument must not be a RegExp');
-    }
-    if (start === undefined) { start = 0; }
-    return this.indexOf(search, start) !== -1;
-  };
-}
+'Синій кит'.toLowerCase().includes('синій'); // повертає true
 ```
 
 ## Приклади
 
-### Застосування методу `includes()`
+### Застосування методу includes()
 
 ```js
-const str = 'Чи бути, чи не бути — ось питання.'
+const str = 'Чи бути, чи не бути — ось питання.';
 
-console.log(str.includes('Чи бути'))        // true
-console.log(str.includes('питання'))     // true
-console.log(str.includes('не існує'))  // false
-console.log(str.includes('Чи бути', 1))     // false
-console.log(str.includes('ЧИ БУТИ'))        // false
-console.log(str.includes(''))             // true
+console.log(str.includes('Чи бути')); // true
+console.log(str.includes('питання')); // true
+console.log(str.includes('не існує')); // false
+console.log(str.includes('Чи бути', 1)); // false
+console.log(str.includes('ЧИ БУТИ')); // false
+console.log(str.includes('')); // true
 ```
 
 ## Специфікації
@@ -91,7 +78,7 @@ console.log(str.includes(''))             // true
 
 ## Дивіться також
 
-- Поліфіл методу `String.prototype.includes` доступний у [`core-js`](https://github.com/zloirock/core-js#ecmascript-string-and-regexp)
+- [Поліфіл методу `String.prototype.includes` у складі `core-js`](https://github.com/zloirock/core-js#ecmascript-string-and-regexp)
 - {{jsxref("Array.prototype.includes()")}}
 - {{jsxref("TypedArray.prototype.includes()")}}
 - {{jsxref("String.prototype.indexOf()")}}


### PR DESCRIPTION
Оригінальний вміст: [String.prototype.includes()@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Global_Objects/String/includes), [сирці String.prototype.includes()@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/global_objects/string/includes/index.md)

Нові зміни:
- [mdn/content@94e0453](https://github.com/mdn/content/commit/94e04537fb2f29fc347865e84a0a12100f251b1c)
- [mdn/content@edaa4af](https://github.com/mdn/content/commit/edaa4aff4cf7532efdcba6014b9316aad2a5b6f1)
- [mdn/content@88508eb](https://github.com/mdn/content/commit/88508ebe5c73264be2cf03f1a949d8099d68d1ea)