### PR TITLE
update(JS): web/javascript/reference/global_objects/object/assign

### DIFF
--- a/files/uk/web/javascript/reference/global_objects/object/assign/index.md
+++ b/files/uk/web/javascript/reference/global_objects/object/assign/index.md
@@ -68,8 +68,8 @@ console.log(copy); // { a: 1 }
 function test() {
   'use strict';
 
-  let obj1 = { a: 0, b: { c: 0 } };
-  let obj2 = Object.assign({}, obj1);
+  const obj1 = { a: 0, b: { c: 0 } };
+  const obj2 = Object.assign({}, obj1);
   console.log(JSON.stringify(obj2)); // { "a": 0, "b": { "c": 0}}
 
   obj1.a = 1;
@@ -86,7 +86,7 @@ function test() {
 
   // Глибоке клонування
   obj1 = { a: 0, b: { c: 0 } };
-  let obj3 = JSON.parse(JSON.stringify(obj1));
+  const obj3 = JSON.parse(JSON.stringify(obj1));
   obj1.a = 4;
   obj1.b.c = 4;
   console.log(JSON.stringify(obj3)); // { "a": 0, "b": { "c": 0}}
@@ -203,14 +203,14 @@ console.log(copy);
 // Ось фінкція присвоєння, яка капіює дескриптори цілком
 function completeAssign(target, ...sources) {
   sources.forEach((source) => {
-    let descriptors = Object.keys(source).reduce((descriptors, key) => {
+    const descriptors = Object.keys(source).reduce((descriptors, key) => {
       descriptors[key] = Object.getOwnPropertyDescriptor(source, key);
       return descriptors;
     }, {});
 
     // Як усталено, Object.assign копіює також перелічувані символи
     Object.getOwnPropertySymbols(source).forEach((sym) => {
-      let descriptor = Object.getOwnPropertyDescriptor(source, sym);
+      const descriptor = Object.getOwnPropertyDescriptor(source, sym);
       if (descriptor.enumerable) {
         descriptors[sym] = descriptor;
       }


### PR DESCRIPTION
Оригінальний вміст: [Object.assign()@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Global_Objects/Object/assign), [сирці Object.assign()@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/global_objects/object/assign/index.md)

Нові зміни:
- [mdn/content@d6f63f6](https://github.com/mdn/content/commit/d6f63f6e41146f459e21046af1c51fadb772de70)