### PR TITLE
update(JS): web/javascript/reference

### DIFF
--- a/files/uk/web/javascript/reference/index.md
+++ b/files/uk/web/javascript/reference/index.md
@@ -155,8 +155,8 @@ tags:
 
 ### Керування потоком виконання
 
-- {{jsxref("Statements/block", "Block", "", 1)}}
-- {{jsxref("Statements/Empty", "Empty statement", "", 1)}}
+- {{jsxref("Statements/block", "Блок", "", 1)}}
+- {{jsxref("Statements/Empty", "Порожня інструкція", "", 1)}}
 - {{jsxref("Statements/break", "break")}}
 - {{jsxref("Statements/continue", "continue")}}
 - {{jsxref("Statements/if...else", "if...else")}}
@@ -219,8 +219,8 @@ tags:
 
 ### Вирази лівої сторони
 
-- {{JSxRef("Operators/Property_accessors", "Property accessors", "", 1)}}
-- {{JSxRef("Operators/Optional_chaining", "<code>?.</code> (Optional chaining)", "", 1)}}
+- {{JSxRef("Operators/Property_accessors", "Доступ до властивостей", "", 1)}}
+- [`?.` (Необов'язкове зв'язування)](/uk/docs/Web/JavaScript/Reference/Operators/Optional_chaining)
 - {{JSxRef("Operators/new", "new")}}
 - {{JSxRef("Operators/new%2Etarget", "new.target")}}
 - {{JSxRef("Operators/import%2Emeta", "import.meta")}}
@@ -309,8 +309,8 @@ tags:
 - {{JSxRef("Operators/Logical_AND_assignment", "&amp;&amp;=")}}
 - {{JSxRef("Operators/Logical_OR_assignment", "||=")}}
 - {{JSxRef("Operators/Logical_nullish_assignment", "??=")}}
-- {{JSxRef("Operators/Destructuring_assignment", "[a, b] = [1, 2]")}}
-- {{JSxRef("Operators/Destructuring_assignment", "{a, b} = {a:1, b:2}")}}
+- {{JSxRef("Operators/Destructuring_assignment", "[a, b] = arr")}}
+- {{JSxRef("Operators/Destructuring_assignment", "{ a, b } = obj")}}
 
 ### Оператор коми
 


### PR DESCRIPTION
Оригінальний вміст: [Довідник з JavaScript@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference), [сирці Довідник з JavaScript@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/index.md)

Нові зміни:
- [mdn/content@8d76e99](https://github.com/mdn/content/commit/8d76e99363dab6c2f8d31216b5b28620dd1e041f)