### PR TITLE
update(JS): web/javascript/reference/operators

### DIFF
--- a/files/uk/web/javascript/reference/operators/index.md
+++ b/files/uk/web/javascript/reference/operators/index.md
@@ -226,9 +226,8 @@ browser-compat: javascript.operators
   - : Присвоєння з логічним OR.
 - {{JSxRef("Operators/Logical_nullish_assignment", "??=")}}
   - : Логічне нульове присвоєння.
-- {{JSxRef("Operators/Destructuring_assignment", "[a, b] = [1, 2]")}}
-  {{JSxRef("Operators/Destructuring_assignment", "{a, b} = {a:1, b:2}")}}
-  - : Присвоєння з деструктуризацією дозволяє призначити властивості масиву чи об'єкта змінним, з використанням синтаксису, який виглядає подібно до літералів масивів та об'єктів.
+- [`[a, b] = arr`, `{ a, b } = obj`](/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment)
+  - : Присвоєння з деструктуризацією дає змогу призначити властивості масиву чи об'єкта змінним, з використанням синтаксису, який має подібний до літералів масивів та об'єктів вигляд.
 
 ### Оператор кома
 


### PR DESCRIPTION
Оригінальний вміст: [Вирази та оператори@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Operators), [сирці Вирази та оператори@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/operators/index.md)

Нові зміни:
- [mdn/content@8d76e99](https://github.com/mdn/content/commit/8d76e99363dab6c2f8d31216b5b28620dd1e041f)