### PR TITLE
update(JS): web/javascript/reference/statements/switch

### DIFF
--- a/files/uk/web/javascript/reference/statements/switch/index.md
+++ b/files/uk/web/javascript/reference/statements/switch/index.md
@@ -96,7 +96,7 @@ switch (foo) {
 
 Пункти `case` і `default` подібні до [міток](/uk/docs/Web/JavaScript/Reference/Statements/label): вони вказують місця, куди контроль плину виконання може перестрибнути. Проте вони не створюють самі по собі лексичних [областей видимості](/uk/docs/Glossary/Scope) (так само як не виконують автоматично виходу – як показано вище). Наприклад:
 
-```js
+```js example-bad
 const action = 'say_hello';
 switch (action) {
   case 'say_hello':
@@ -163,7 +163,7 @@ switch (expr) {
     console.log('Манго та папайя — по $2.79 за кіло.');
     break;
   default:
-    console.log('Вибачте, у нас закінчились ' + expr + '.');
+    console.log(`Вибачте, у нас закінчились ${expr}.`);
 }
 
 console.log('Чи є щось іще, що ми могли б вам запропонувати?');


### PR DESCRIPTION
Оригінальний вміст: [switch@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Statements/switch), [сирці switch@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/statements/switch/index.md)

Нові зміни:
- [mdn/content@60d3161](https://github.com/mdn/content/commit/60d3161003eaa7af8cfac51ac79ae8c5d0a16361)
- [mdn/content@8a5ab92](https://github.com/mdn/content/commit/8a5ab92ceab8fe1b8f44597381cf3fd996e252e9)