### PR TITLE
update(JS): web/javascript/reference/global_objects/json/stringify

### DIFF
--- a/files/uk/web/javascript/reference/global_objects/json/stringify/index.md
+++ b/files/uk/web/javascript/reference/global_objects/json/stringify/index.md
@@ -20,10 +20,10 @@ browser-compat: javascript.builtins.JSON.stringify
 
 ## Синтаксис
 
-```js
-JSON.stringify(value);
-JSON.stringify(value, replacer);
-JSON.stringify(value, replacer, space);
+```js-nolint
+JSON.stringify(value)
+JSON.stringify(value, replacer)
+JSON.stringify(value, replacer, space)
 ```
 
 ### Параметри


### PR DESCRIPTION
Оригінальний вміст: [JSON.stringify()@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify), [сирці JSON.stringify()@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/global_objects/json/stringify/index.md)

Нові зміни:
- [mdn/content@d6ce8fc](https://github.com/mdn/content/commit/d6ce8fcbbc4a71ec9209f379e5ea9774bbf1f5ac)
- [mdn/content@9b38f88](https://github.com/mdn/content/commit/9b38f886d21c5d0a428f58acb20c4d0fc6c2e098)