### PR TITLE
update(JS): web/javascript/reference/global_objects/string/split

### DIFF
--- a/files/uk/web/javascript/reference/global_objects/string/split/index.md
+++ b/files/uk/web/javascript/reference/global_objects/string/split/index.md
@@ -20,10 +20,10 @@ browser-compat: javascript.builtins.String.split
 
 ## Синтаксис
 
-```js
-split();
-split(separator);
-split(separator, limit);
+```js-nolint
+split()
+split(separator)
+split(separator, limit)
 ```
 
 ### Параметри


### PR DESCRIPTION
Оригінальний вміст: [String.prototype.split()@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Global_Objects/String/split), [сирці String.prototype.split()@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/global_objects/string/split/index.md)

Нові зміни:
- [mdn/content@ce29091](https://github.com/mdn/content/commit/ce2909126eb09e44c9f48d9f65d072acae827749)
- [mdn/content@968e6f1](https://github.com/mdn/content/commit/968e6f1f3b6f977a09e116a0ac552459b741eac3)