### PR TITLE
update(JS): web/javascript/reference/global_objects/parseint

### DIFF
--- a/files/uk/web/javascript/reference/global_objects/parseint/index.md
+++ b/files/uk/web/javascript/reference/global_objects/parseint/index.md
@@ -17,9 +17,9 @@ browser-compat: javascript.builtins.parseInt
 
 ## Синтаксис
 
-```js
-parseInt(string);
-parseInt(string, radix);
+```js-nolint
+parseInt(string)
+parseInt(string, radix)
 ```
 
 ### Параметри


### PR DESCRIPTION
Оригінальний вміст: [parseInt()@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Global_Objects/parseInt), [сирці parseInt()@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/global_objects/parseint/index.md)

Нові зміни:
- [mdn/content@ce29091](https://github.com/mdn/content/commit/ce2909126eb09e44c9f48d9f65d072acae827749)
- [mdn/content@968e6f1](https://github.com/mdn/content/commit/968e6f1f3b6f977a09e116a0ac552459b741eac3)