### PR TITLE
update(JS): web/javascript/reference/global_objects/string/match

### DIFF
--- a/files/uk/web/javascript/reference/global_objects/string/match/index.md
+++ b/files/uk/web/javascript/reference/global_objects/string/match/index.md
@@ -20,8 +20,8 @@ browser-compat: javascript.builtins.String.match
 
 ## Синтаксис
 
-```js
-match(regexp);
+```js-nolint
+match(regexp)
 ```
 
 ### Параметри


### PR DESCRIPTION
Оригінальний вміст: [String.prototype.match()@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Global_Objects/String/match), [сирці String.prototype.match()@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/global_objects/string/match/index.md)

Нові зміни:
- [mdn/content@ce29091](https://github.com/mdn/content/commit/ce2909126eb09e44c9f48d9f65d072acae827749)
- [mdn/content@968e6f1](https://github.com/mdn/content/commit/968e6f1f3b6f977a09e116a0ac552459b741eac3)