### PR TITLE
update(JS): web/javascript/reference/global_objects/date/now

### DIFF
--- a/files/uk/web/javascript/reference/global_objects/date/now/index.md
+++ b/files/uk/web/javascript/reference/global_objects/date/now/index.md
@@ -10,6 +10,7 @@ tags:
   - Polyfill
 browser-compat: javascript.builtins.Date.now
 ---
+
 {{JSRef}}
 
 Статичний метод **`Date.now()`** (зараз) повертає число мілісекунд, що сплили з моменту 1 січня 1970 року, 00:00:00 за UTC (Всесвітнім координованим часом).
@@ -18,7 +19,7 @@ browser-compat: javascript.builtins.Date.now
 
 ## Синтаксис
 
-```js
+```js-nolint
 Date.now()
 ```
 
@@ -34,7 +35,7 @@ Date.now()
 
 ```js
 // зменшена точність часу (2мс) у Firefox 60
-Date.now()
+Date.now();
 // 1519211809934
 // 1519211810362
 // 1519211811670


### PR DESCRIPTION
Оригінальний вміст: [Date.now()@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Global_Objects/Date/now), [сирці Date.now()@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/global_objects/date/now/index.md)

Нові зміни:
- [mdn/content@d6ce8fc](https://github.com/mdn/content/commit/d6ce8fcbbc4a71ec9209f379e5ea9774bbf1f5ac)
- [mdn/content@9b38f88](https://github.com/mdn/content/commit/9b38f886d21c5d0a428f58acb20c4d0fc6c2e098)
- [mdn/content@968e6f1](https://github.com/mdn/content/commit/968e6f1f3b6f977a09e116a0ac552459b741eac3)