### PR TITLE
update(JS): web/javascript/reference/operators/spread_syntax

### DIFF
--- a/files/uk/web/javascript/reference/operators/spread_syntax/index.md
+++ b/files/uk/web/javascript/reference/operators/spread_syntax/index.md
@@ -20,7 +20,7 @@ browser-compat: javascript.operators.spread
 
 ## Синтаксис
 
-```js
+```js-nolint
 myFunction(a, ...iterableObj, b)
 [1, ...iterableObj, '4', "п'ять", 6]
 { ...obj, key: 'значення' }


### PR DESCRIPTION
Оригінальний вміст: [Синтаксис розгортання (...)@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Operators/Spread_syntax), [сирці Синтаксис розгортання (...)@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/operators/spread_syntax/index.md)

Нові зміни:
- [mdn/content@1533276](https://github.com/mdn/content/commit/1533276490d15cff6ddcd201fc05562180058a99)
- [mdn/content@968e6f1](https://github.com/mdn/content/commit/968e6f1f3b6f977a09e116a0ac552459b741eac3)