### PR TITLE
update(JS): web/javascript/reference/global_objects/string/slice

### DIFF
--- a/files/uk/web/javascript/reference/global_objects/string/slice/index.md
+++ b/files/uk/web/javascript/reference/global_objects/string/slice/index.md
@@ -18,9 +18,9 @@ browser-compat: javascript.builtins.String.slice
 
 ## Синтаксис
 
-```js
-slice(indexStart);
-slice(indexStart, indexEnd);
+```js-nolint
+slice(indexStart)
+slice(indexStart, indexEnd)
 ```
 
 ### Параметри
@@ -45,7 +45,7 @@ slice(indexStart, indexEnd);
 - Якщо `indexStart` опущено, невизначений або не може бути перетворений на число (за допомогою {{jsxref('Number', 'Number(indexStart)')}}), то він вважається еквівалентним `0`.
 - Якщо `indexEnd` опущено, невизначений або не може бути перетворений на число (за допомогою {{jsxref('Number', 'Number(indexEnd)')}}), або якщо `indexEnd >= str.length`, то `slice()` вибирає символи до самого кінця рядка.
 - Якщо `indexEnd < 0`, то індекс рахується від кінця рядка. Більш формально висловлюючись, в цьому випадку підрядок закінчується на `max(indexEnd + str.length, 0)`.
-- Якщо після нормалізації від‘ємних значень `indexEnd <= indexStart` (наприклад, `indexEnd` вказує на символ, що стоїть перед `indexStart`), то повертається порожній рядок.
+- Якщо після нормалізації від'ємних значень `indexEnd <= indexStart` (наприклад, `indexEnd` вказує на символ, що стоїть перед `indexStart`), то повертається порожній рядок.
 
 ## Приклади
 


### PR DESCRIPTION
Оригінальний вміст: [String.prototype.slice()@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Global_Objects/String/slice), [сирці String.prototype.slice()@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/global_objects/string/slice/index.md)

Нові зміни:
- [mdn/content@ce29091](https://github.com/mdn/content/commit/ce2909126eb09e44c9f48d9f65d072acae827749)
- [mdn/content@968e6f1](https://github.com/mdn/content/commit/968e6f1f3b6f977a09e116a0ac552459b741eac3)