### PR TITLE
update(JS): web/javascript/reference/global_objects/string/includes

### DIFF
--- a/files/uk/web/javascript/reference/global_objects/string/includes/index.md
+++ b/files/uk/web/javascript/reference/global_objects/string/includes/index.md
@@ -19,21 +19,26 @@ browser-compat: javascript.builtins.String.includes
 
 ## Синтаксис
 
-```js
-includes(searchString);
-includes(searchString, position);
+```js-nolint
+includes(searchString)
+includes(searchString, position)
 ```
 
 ### Параметри
 
 - `searchString`
-  - : Рядок, який необхідно знайти всередині початкового рядка `str`.
+  - : Рядок, який необхідно знайти всередині початкового рядка `str`. Не може бути регулярним виразом.
 - `position` {{optional_inline}}
   - : Номер позиції всередині рядка, з якої розпочнеться пошук шуканого рядка `searchString`. (Усталено дорівнює `0`.)
 
 ### Повернене значення
 
 Повертає **`true`**, якщо шуканий рядок було знайдено будь-де всередині початкового рядка, і **`false`**, якщо рядок знайдено не було.
+
+### Винятки
+
+- {{jsxref("TypeError")}}
+  - : Якщо `searchString` [є регулярним виразом](/uk/docs/Web/JavaScript/Reference/Global_Objects/RegExp#osoblyva-obrobka-rehuliarnykh-vyraziv).
 
 ## Опис
 


### PR DESCRIPTION
Оригінальний вміст: [String.prototype.includes()@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Global_Objects/String/includes), [сирці String.prototype.includes()@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/global_objects/string/includes/index.md)

Нові зміни:
- [mdn/content@ce29091](https://github.com/mdn/content/commit/ce2909126eb09e44c9f48d9f65d072acae827749)
- [mdn/content@968e6f1](https://github.com/mdn/content/commit/968e6f1f3b6f977a09e116a0ac552459b741eac3)
- [mdn/content@3fe8522](https://github.com/mdn/content/commit/3fe8522d9432bd9bf068b937292a3f7499b461af)