### PR TITLE
update(JS): web/javascript/reference

### DIFF
--- a/files/uk/web/javascript/reference/index.md
+++ b/files/uk/web/javascript/reference/index.md
@@ -11,7 +11,7 @@ tags:
   - Landing page
   - Reference
   - es
-  - 'l10n:priority'
+  - "l10n:priority"
   - programming
 ---
 
@@ -133,17 +133,6 @@ tags:
 - {{JSxRef("Global_Objects/Intl/PluralRules", "Intl.PluralRules")}}
 - {{JSxRef("Global_Objects/Intl/RelativeTimeFormat", "Intl.RelativeTimeFormat")}}
 - {{JSxRef("Global_Objects/Intl/Segmenter", "Intl.Segmenter")}}
-
-### WebAssembly
-
-- {{JSxRef("WebAssembly")}}
-- {{JSxRef("WebAssembly.Module")}}
-- {{JSxRef("WebAssembly.Instance")}}
-- {{JSxRef("WebAssembly.Memory")}}
-- {{JSxRef("WebAssembly.Table")}}
-- {{JSxRef("WebAssembly.CompileError")}}
-- {{JSxRef("WebAssembly.LinkError")}}
-- {{JSxRef("WebAssembly.RuntimeError")}}
 
 ### Інші
 


### PR DESCRIPTION
Оригінальний вміст: [Довідник з JavaScript@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference), [сирці Довідник з JavaScript@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/index.md)

Нові зміни:
- [mdn/content@d606f8d](https://github.com/mdn/content/commit/d606f8dc936dcf766e1540f687eba8dc9dd9ed13)