### PR TITLE
update(CSS): web/css/background-image

### DIFF
--- a/files/uk/web/css/background-image/index.md
+++ b/files/uk/web/css/background-image/index.md
@@ -35,7 +35,7 @@ background-image: linear-gradient(
     to bottom,
     rgba(255, 255, 0, 0.5),
     rgba(0, 0, 255, 0.5)
-  ), url('catfront.png');
+  ), url("catfront.png");
 
 /* Глобальні значення */
 background-image: inherit;
@@ -95,11 +95,11 @@ p {
 }
 
 div {
-  background-image: url('mdn_logo_only_color.png');
+  background-image: url("mdn_logo_only_color.png");
 }
 
 .catsandstars {
-  background-image: url('startransparent.gif'), url('catfront.png');
+  background-image: url("startransparent.gif"), url("catfront.png");
   background-color: transparent;
 }
 ```


### PR DESCRIPTION
Оригінальний вміст: [background-image@MDN](https://developer.mozilla.org/en-us/docs/Web/CSS/background-image), [сирці background-image@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/css/background-image/index.md)

Нові зміни:
- [mdn/content@88866ee](https://github.com/mdn/content/commit/88866ee128116bd07235f5d3531152d5686a1e6d)
- [mdn/content@31a11c2](https://github.com/mdn/content/commit/31a11c2af1ecf81524971f85424b0462334be3c4)
- [mdn/content@05a6149](https://github.com/mdn/content/commit/05a61497f79c7bf5ffaf8fe7d94b36d5a0b9626e)