### PR TITLE
update(CSS): web/css

### DIFF
--- a/files/uk/web/css/index.md
+++ b/files/uk/web/css/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'CSS: Каскадні таблиці стилів'
+title: "CSS: Каскадні таблиці стилів"
 slug: Web/CSS
 tags:
   - CSS
@@ -12,7 +12,7 @@ tags:
   - Style Sheets
   - Styles
   - Stylesheets
-  - 'l10n:priority'
+  - "l10n:priority"
 translation_of: Web/CSS
 ---
 
@@ -70,7 +70,7 @@ CSS належить до ключових мов **відкритого веб�
   - [Одиниці вимірювання і значення CSS](/uk/docs/Web/CSS/CSS_Values_and_Units) та [функціональні нотації](/uk/docs/Web/CSS/CSS_Functions)
   - [Блокова модель](/uk/docs/Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model) та [перекриття зовнішніх відступів](/uk/docs/Web/CSS/CSS_Box_Model/Mastering_margin_collapsing)
   - [Місткий блок](/uk/docs/Web/CSS/Containing_block)
-  - [Контекст перекриття](/uk/docs/Web/CSS/CSS_Positioning/Understanding_z_index/The_stacking_context 'Контекст нагромадження') та [блоково-форматований](/uk/docs/Web/Guide/CSS/Block_formatting_context 'Контекст блокового форматування') контекст
+  - [Контекст перекриття](/uk/docs/Web/CSS/CSS_Positioning/Understanding_z_index/The_stacking_context "Контекст нагромадження") та [блоково-форматований](/uk/docs/Web/Guide/CSS/Block_formatting_context "Контекст блокового форматування") контекст
   - [Початкові](/uk/docs/Web/CSS/initial_value), [обчислені](/uk/docs/Web/CSS/computed_value), [використані](/uk/docs/Web/CSS/used_value) та [дійсні](/uk/docs/Web/CSS/actual_value) значення
   - [Скорочені властивості CSS](/uk/docs/Web/CSS/Shorthand_properties)
   - [Flex-верстання у CSS](/uk/docs/Web/CSS/CSS_Flexible_Box_Layout)


### PR DESCRIPTION
Оригінальний вміст: [CSS: Каскадні таблиці стилів@MDN](https://developer.mozilla.org/en-us/docs/Web/CSS), [сирці CSS: Каскадні таблиці стилів@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/css/index.md)

Нові зміни:
- [mdn/content@c18a696](https://github.com/mdn/content/commit/c18a6962ea1103ea38dac413cff21e7387e6b1b8)