### PR TITLE
update(JS): web/javascript/reference/operators/optional_chaining

### DIFF
--- a/files/uk/web/javascript/reference/operators/optional_chaining/index.md
+++ b/files/uk/web/javascript/reference/operators/optional_chaining/index.md
@@ -13,7 +13,7 @@ browser-compat: javascript.operators.optional_chaining
 
 {{JSSidebar("Operators")}}
 
-Оператор **необов'язкового ланцюжка** (**`?.`**) звертається до властивості об'єкта або викликає функцію. Якщо об'єкт – {{jsxref("undefined")}} або [`null`](/uk/docs/Web/JavaScript/Reference/Operators/null), то замість викидання помилки – повертається {{jsxref("undefined")}}.
+**Оператор необов'язкового ланцюжка (`?.`)** звертається до властивості об'єкта або викликає функцію. Якщо об'єкт – {{jsxref("undefined")}} або [`null`](/uk/docs/Web/JavaScript/Reference/Operators/null), то замість викидання помилки – повертається {{jsxref("undefined")}}.
 
 {{EmbedInteractiveExample("pages/js/expressions-optionalchainingoperator.html", "taller")}}
 


### PR DESCRIPTION
Оригінальний вміст: [Необов'язковий ланцюжок (?.)@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Operators/Optional_chaining), [сирці Необов'язковий ланцюжок (?.)@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/operators/optional_chaining/index.md)

Нові зміни:
- [mdn/content@0ad08fe](https://github.com/mdn/content/commit/0ad08fe1d8830f11e0314733f56e391affc1fe94)