### PR TITLE
update(JS): web/javascript/reference/global_objects/date/now

### DIFF
--- a/files/uk/web/javascript/reference/global_objects/date/now/index.md
+++ b/files/uk/web/javascript/reference/global_objects/date/now/index.md
@@ -13,7 +13,7 @@ browser-compat: javascript.builtins.Date.now
 
 {{JSRef}}
 
-Статичний метод **`Date.now()`** (зараз) повертає число мілісекунд, що сплили від початку [епохи](/uk/docs/Web/JavaScript/Reference/Global_Objects/Date#the_ecmascript_epoch_and_timestamps), котрий визначений як північ на початку 1 січня 1970 року за Всесвітнім координованим часом.
+Статичний метод **`Date.now()`** (зараз) повертає число мілісекунд, що сплили від початку [епохи](/uk/docs/Web/JavaScript/Reference/Global_Objects/Date#epokha-ecmascript-i-mitky-chasu), котрий визначений як північ на початку 1 січня 1970 року за Всесвітнім координованим часом.
 
 {{EmbedInteractiveExample("pages/js/date-now.html")}}
 

--- a/files/uk/web/javascript/reference/global_objects/date/now/index.md
+++ b/files/uk/web/javascript/reference/global_objects/date/now/index.md
@@ -13,7 +13,7 @@ browser-compat: javascript.builtins.Date.now
 
 {{JSRef}}
 
-Статичний метод **`Date.now()`** (зараз) повертає число мілісекунд, що сплили з моменту 1 січня 1970 року, 00:00:00 за UTC (Всесвітнім координованим часом).
+Статичний метод **`Date.now()`** (зараз) повертає число мілісекунд, що сплили від початку [епохи](/uk/docs/Web/JavaScript/Reference/Global_Objects/Date#the_ecmascript_epoch_and_timestamps), котрий визначений як північ на початку 1 січня 1970 року за Всесвітнім координованим часом.
 
 {{EmbedInteractiveExample("pages/js/date-now.html")}}
 
@@ -25,7 +25,7 @@ Date.now()
 
 ### Повернене значення
 
-Число, котре позначає число мілісекунд, яке сплило від початку [епохи ECMAScript](/uk/docs/Web/JavaScript/Reference/Global_Objects/Date#epokha-ecmascript-i-mitky-chasu).
+Число, котре позначає число мілісекунд, яке сплило від початку [епохи](/uk/docs/Web/JavaScript/Reference/Global_Objects/Date#epokha-ecmascript-i-mitky-chasu), котрий визначено як північ на початку 1 січня 1970 року за Всесвітнім координованим часом.
 
 ## Приклади
 


### PR DESCRIPTION
Оригінальний вміст: [Date.now()@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Global_Objects/Date/now), [сирці Date.now()@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/global_objects/date/now/index.md)

Нові зміни:
- [mdn/content@7b72e7d](https://github.com/mdn/content/commit/7b72e7d4860bcac018713414df3ca7e941cb7bd3)
- [mdn/content@41a330f](https://github.com/mdn/content/commit/41a330fff5fbae13391f256df17e18eb47db73cb)