### PR TITLE
update(JS): web/javascript/reference/global_objects/string/substring

### DIFF
--- a/files/uk/web/javascript/reference/global_objects/string/substring/index.md
+++ b/files/uk/web/javascript/reference/global_objects/string/substring/index.md
@@ -12,7 +12,7 @@ browser-compat: javascript.builtins.String.substring
 
 {{JSRef}}
 
-Метод **`substring()`** повертає частину рядка `string` між вказаними індексами початку та кінця, або до кінця рядка — якщо кінцевий індекс не вказано.
+Метод **`substring()`** повертає частину рядка `string` від початкового (включно) і до кінцевого індексу (не включно), або до кінця рядка, якщо кінцевий індекс не задано.
 
 {{EmbedInteractiveExample("pages/js/string-substring.html")}}
 


### PR DESCRIPTION
Оригінальний вміст: [String.prototype.substring()@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Global_Objects/String/substring), [сирці String.prototype.substring()@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/global_objects/string/substring/index.md)

Нові зміни:
- [mdn/content@507c05f](https://github.com/mdn/content/commit/507c05f8ab2cf94be7aac5a9e534979f0303af4b)
- [mdn/content@7b72e7d](https://github.com/mdn/content/commit/7b72e7d4860bcac018713414df3ca7e941cb7bd3)