### PR TITLE
update(JS): web/javascript/reference/global_objects/array/length

### DIFF
--- a/files/uk/web/javascript/reference/global_objects/array/length/index.md
+++ b/files/uk/web/javascript/reference/global_objects/array/length/index.md
@@ -11,13 +11,15 @@ browser-compat: javascript.builtins.Array.length
 
 {{JSRef}}
 
-Властивість **`length`** (довжина) об'єкта, котрий є примірником типу `Array`, задає чи повертає число елементів у такому масиві. Значення є беззнаковим 32-бітовим цілим числом, котре завжди більше за найбільший індекс елемента масиву.
+Властивість **`length`** (довжина) об'єкта `Array`, що представляє число елементів у такому масиві. Значення є беззнаковим 32-бітовим цілим числом, котре завжди більше за найбільший індекс елемента масиву.
 
 {{EmbedInteractiveExample("pages/js/array-length.html","shorter")}}
 
+{{js_property_attributes(1, 0, 0)}}
+
 ## Опис
 
-Значення властивості `length` – ціле невід'ємне число зі значенням, котре не перевищує 2 у 32 степені (2^32).
+Значення властивості `length` – невід'ємне ціле число зі значенням, меншим ніж 2<sup>32</sup>.
 
 ```js
 const listA = [1, 2, 3];
@@ -29,14 +31,20 @@ console.log(listA.length);
 console.log(listB.length);
 // 6
 
-listB.length = 4294967296; //2 у 32 степені = 4294967296
+listB.length = 2 ** 32; // 4294967296
 // RangeError: Invalid array length
 
-const listC = new Array(-100); //від'ємна довжина
+const listC = new Array(-100); // Від'ємні числа не дозволені
 // RangeError: Invalid array length
 ```
 
-Будь-якої миті можна обрізати масив, змінивши значення `length`. Якщо таким чином розширити масив, то число фактичних елементів зросте; наприклад, якщо присвоїти `length` 3, коли насправді елементів 2, то в масиві стане 3 елементи, і як наслідок – третій елемент буде неітерованою порожньою коміркою.
+Об'єкт масиву відстежує властивість `length` і автоматично синхронізує її значення зі своїм вмістом. Що означає:
+
+- Присвоєння `length` значення, меншого за поточну довжину, обрізає масив: елементи поза новою довжиною – видаляються.
+- Присвоєння за будь-яким індексом масиву (невід'ємним цілим числом, меншим ніж 2<sup>32</sup>) поза поточною довжиною розширює масив: властивість `length` збільшується, аби відповідати новому найбільшому індексові.
+- Присвоєння `length` недійсного значення (наприклад, від'ємного числа чи взагалі не числа) викидає виняток `RangeError`.
+
+Коли `length` присвоюється значення, більше за поточну довжину, то масив розширюється шляхом додавання [порожніх комірок](/uk/docs/Web/JavaScript/Guide/Indexed_collections#rozridzheni-masyvy), а не реальних значень `undefined`. Порожні комірки можуть по-особливому взаємодіяти з методами масивів; дивіться [методи масиву й порожні комірки](/uk/docs/Web/JavaScript/Reference/Global_Objects/Array#metody-masyvu-y-porozhni-komirky).
 
 ```js
 const arr = [1, 2];
@@ -52,13 +60,7 @@ arr.forEach((element) => console.log(element));
 // 2
 ```
 
-Як бачимо, властивість `length` не обов'язково показує число визначених значень у масиві. Дивіться також [Взаємозв'язок між `length` та числовими властивостями](/uk/docs/Web/JavaScript/Reference/Global_Objects/Array#vzaiemozviazok-mizh-dovzhynoiu-ta-chyslovymy-vlastyvostiamy).
-
-{{js_property_attributes(1, 0, 0)}}
-
-- `Writable`: Якщо значення цього атрибута `false`, то значення властивості не може бути змінено.
-- `Configurable`: Якщо значення цього атрибута `false`, то всі спроби видалити цю властивість чи змінити її атрибути (`Writable`, `Configurable` чи `Enumerable`) будуть неуспішними.
-- `Enumerable`: Якщо значення цього атрибута `true`, ця властивість буде ітерована циклами [`for`](/uk/docs/Web/JavaScript/Reference/Statements/for) і [`for...in`](/uk/docs/Web/JavaScript/Reference/Statements/for...in).
+Також дивіться [Взаємини між `length` і числовими властивостями](/uk/docs/Web/JavaScript/Reference/Global_Objects/Array#vzaiemyny-mizh-length-i-chyslovymy-vlastyvostiamy).
 
 ## Приклади
 
@@ -88,14 +90,29 @@ if (numbers.length > 3) {
 
 console.log(numbers); // [1, 2, 3]
 console.log(numbers.length); // 3
+console.log(numbers[3]); // undefined; решта елементів видалена
 ```
 
 ### Створення порожнього масиву фіксованої довжини
+
+Присвоєння `length` значення, більшого за поточну довжину, утворює [розріджений масив](/uk/docs/Web/JavaScript/Guide/Indexed_collections#rozridzheni-masyvy).
 
 ```js
 const numbers = [];
 numbers.length = 3;
 console.log(numbers); // [порожньо x 3]
+```
+
+### Масив з недоступною для запису length
+
+Властивість `length` автоматично оновлюється масивом, коли елементи додаються поза поточною довжиною. Якщо зробити властивість `length` недоступною для запису, то масив не зможе її оновити. Це у [суворому режимі](/uk/docs/Web/JavaScript/Reference/Strict_mode) призведе до помилки.
+
+```js
+"use strict";
+const numbers = [1, 2, 3, 4, 5];
+Object.defineProperty(numbers, "length", { writable: false });
+numbers[5] = 6; // TypeError: Cannot assign to read only property 'length' of object '[object Array]'
+numbers.push(5); // // TypeError: Cannot assign to read only property 'length' of object '[object Array]'
 ```
 
 ## Специфікації


### PR DESCRIPTION
Оригінальний вміст: [Array.prototype.length@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Global_Objects/Array/length), [сирці Array.prototype.length@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/global_objects/array/length/index.md)

Нові зміни:
- [mdn/content@777880a](https://github.com/mdn/content/commit/777880aba2abfb6ac3b0783b1d85e8ec3b4ef6af)