### PR TITLE
update(JS): web/javascript/reference/global_objects/array/reduce

### DIFF
--- a/files/uk/web/javascript/reference/global_objects/array/reduce/index.md
+++ b/files/uk/web/javascript/reference/global_objects/array/reduce/index.md
@@ -72,8 +72,8 @@ reduce(function(accumulator, currentValue, currentIndex, array) { /* … */ }, i
 
 - `initialValue` {{optional_inline}}
   - : Значення, яким ініціалізується `accumulator` під час першого виконання функції зворотного виклику.
-    Якщо `initialValue` задане, це призводить до ініціалізації `currentValue` першим значенням із масиву.
-    Якщо ж `initialValue` _не_ задано, то `accumulator` ініціалізується першим елементом масиву, а `currentValue` — другим.
+    Якщо `initialValue` задане, то `callbackFn` почне виконання з першим значенням масиву як `currentValue`.
+    Якщо `initialValue` _не_ задане, то `accumulator` ініціалізується першим значенням масиву, і `callbackFn` починає виконання з другого значення масиву як `currentValue`. В такому випадку, якщо масив – порожній (тобто немає першого значення, аби повернути його як `accumulator`), викидається помилка.
 
 ### Повернене значення
 


### PR DESCRIPTION
Оригінальний вміст: [Array.prototype.reduce()@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Global_Objects/Array/reduce), [сирці Array.prototype.reduce()@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/global_objects/array/reduce/index.md)

Нові зміни:
- [mdn/content@ca683ff](https://github.com/mdn/content/commit/ca683fff22025a37e6d30b697a0481f6dac2eb44)