### PR TITLE
update(HTML): web/html/element/input/date

### DIFF
--- a/files/uk/web/html/element/input/date/index.md
+++ b/files/uk/web/html/element/input/date/index.md
@@ -25,53 +25,6 @@ browser-compat: html.elements.input.type_date
 
 Користувацький інтерфейс введення в цілому відрізняється між браузерами; зверніться до [Сумісності з браузерами](#sumisnist-iz-brauzeramy) по детальнішу інформацію. В непідтримуваних браузерах контрольний елемент зводиться до [`<input type="text">`](/uk/docs/Web/HTML/Element/input/text).
 
-<table class="properties">
-  <tbody>
-    <tr>
-      <td><strong><a href="#znachennia">Значення</a></strong></td>
-      <td>
-        Рядок, що представляє дату в форматі YYYY-MM-DD,
-        або є пустим
-      </td>
-    </tr>
-    <tr>
-      <td><strong>Події</strong></td>
-      <td>
-        {{domxref("HTMLElement/change_event", "change")}} та
-        {{domxref("HTMLElement/input_event", "input")}}
-      </td>
-    </tr>
-    <tr>
-      <td><strong>Підтримувані загальні атрибути</strong></td>
-      <td>
-        {{htmlattrxref("autocomplete", "input")}},
-        {{htmlattrxref("list", "input")}},
-        {{htmlattrxref("readonly", "input")}} і
-        {{htmlattrxref("step", "input")}}
-      </td>
-    </tr>
-    <tr>
-      <td><strong>Атрибути IDL</strong></td>
-      <td>
-        <code>list</code>, <code>value</code>, <code>valueAsDate</code>,
-        <code>valueAsNumber</code>.
-      </td>
-    </tr>
-    <tr>
-      <td><strong>Інтерфейс DOM</strong></td>
-      <td><p>{{domxref("HTMLInputElement")}}</p></td>
-    </tr>
-    <tr>
-      <td><strong>Методи</strong></td>
-      <td>
-        {{domxref("HTMLInputElement.select", "select()")}},
-        {{domxref("HTMLInputElement.stepDown", "stepDown()")}},
-        {{domxref("HTMLInputElement.stepUp", "stepUp()")}}
-      </td>
-    </tr>
-  </tbody>
-</table>
-
 ## Значення
 
 Рядок, що представляє дату, введену в поле. Має формат згідно з ISO8601, він описаний у [Форматі рядків дат](/uk/docs/Web/HTML/Date_and_time_formats#riadky-dat).
@@ -485,6 +438,55 @@ daySelect.onchange = () => {
 ```
 
 > **Примітка:** Слід пам'ятати, що певні роки містять 53 тижні (дивіться [Скільки тижнів у році (англ.)](https://en.wikipedia.org/wiki/ISO_week_date#Weeks_per_year))! Це слід враховувати при промисловій розробці застосунків.
+
+## Технічний підсумок
+
+<table class="properties">
+  <tbody>
+    <tr>
+      <td><strong><a href="#znachennia">Значення</a></strong></td>
+      <td>
+        Рядок, що представляє дату в форматі YYYY-MM-DD,
+        або є порожнім
+      </td>
+    </tr>
+    <tr>
+      <td><strong>Події</strong></td>
+      <td>
+        {{domxref("HTMLElement/change_event", "change")}} та
+        {{domxref("HTMLElement/input_event", "input")}}
+      </td>
+    </tr>
+    <tr>
+      <td><strong>Підтримувані загальні атрибути</strong></td>
+      <td>
+        {{htmlattrxref("autocomplete", "input")}},
+        {{htmlattrxref("list", "input")}},
+        {{htmlattrxref("readonly", "input")}} і
+        {{htmlattrxref("step", "input")}}
+      </td>
+    </tr>
+    <tr>
+      <td><strong>Атрибути IDL</strong></td>
+      <td>
+        <code>list</code>, <code>value</code>, <code>valueAsDate</code>,
+        <code>valueAsNumber</code>.
+      </td>
+    </tr>
+    <tr>
+      <td><strong>Інтерфейс DOM</strong></td>
+      <td><p>{{domxref("HTMLInputElement")}}</p></td>
+    </tr>
+    <tr>
+      <td><strong>Методи</strong></td>
+      <td>
+        {{domxref("HTMLInputElement.select", "select()")}},
+        {{domxref("HTMLInputElement.stepDown", "stepDown()")}},
+        {{domxref("HTMLInputElement.stepUp", "stepUp()")}}
+      </td>
+    </tr>
+  </tbody>
+</table>
 
 ## Специфікації
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "check:debug": "DEBUG=true yarn run check",
     "gotobranch": "./scripts/gotobranch.sh",
     "postinstall": "docker build . -t lt-custom",
-    "rebuild": "docker build . --no-cache -t lt-custom",
+    "rebuild": "yarn postinstall --no-cache && (docker rm ltc || true)",
     "fix": "eslint . --fix",
     "lint": "eslint ."
   },


### PR DESCRIPTION
Оригінальний вміст: [&lt;input type="date">@MDN](https://developer.mozilla.org/en-us/docs/Web/HTML/Element/input/date), [сирці &lt;input type="date">@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/html/element/input/date/index.md)

Нові зміни:
- [mdn/content@f1a92fa](https://github.com/mdn/content/commit/f1a92fac204a75e5ceab49294734c5f2ddeed870)