### PR TITLE
update(JS): web/javascript/reference

### DIFF
--- a/files/uk/web/javascript/reference/index.md
+++ b/files/uk/web/javascript/reference/index.md
@@ -187,6 +187,7 @@ tags:
 
 - {{jsxref("Statements/Empty", "Порожня інструкція", "", 1)}}
 - {{jsxref("Statements/block", "Блок", "", 1)}}
+- {{jsxref("Statements/Expression_statement", "Інструкція-вираз", "", 1)}}
 - {{jsxref("Statements/debugger", "debugger")}}
 - {{jsxref("Statements/export", "export")}}
 - {{jsxref("Statements/import", "import")}}


### PR DESCRIPTION
Оригінальний вміст: [Довідник з JavaScript@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference), [сирці Довідник з JavaScript@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/index.md)

Нові зміни:
- [mdn/content@71bf0a3](https://github.com/mdn/content/commit/71bf0a30bcd886499bf278c665633183a6658b29)