### PR TITLE
update(CSS): web/css/cursor

### DIFF
--- a/files/uk/web/css/cursor/index.md
+++ b/files/uk/web/css/cursor/index.md
@@ -183,12 +183,7 @@ cursor: unset;
         <tr style="cursor: no-drop">
           <td><code>no-drop</code></td>
           <td>
-            <img
-              alt="піктограма вказівника і піктограма заборони"
-              class="lwrap"
-              src="no-drop.gif"
-              style="float: left"
-            />
+            <img src="no-drop.gif" alt="піктограма вказівника і піктограма заборони" />
           </td>
           <td>
             Елемент не може бути кинутим в поточному положенні.<br />{{bug("275173")}}: На Windows та macOS <code>no-drop</code> еквівалентно <code>not-allowed</code>.
@@ -230,7 +225,7 @@ cursor: unset;
         </tr>
         <tr style="cursor: row-resize">
           <td><code>row-resize</code></td>
-          <td><img src="row-resize.gif" alt="Дві тонкі паралельні горизонтальні лінії з невеликим стрілками вгору та вниз" /></td>
+          <td><img src="row-resize.gif" alt="дві тонкі паралельні горизонтальні лінії з невеликим стрілками вгору та вниз" /></td>
           <td>
             Елемент чи ряд може змінити розмір по вертикалі.
             Часто зображається у вигляді стрілок, напрямлених вгору та вниз із горизонтальною смугою між ними.


### PR DESCRIPTION
Оригінальний вміст: [cursor@MDN](https://developer.mozilla.org/en-us/docs/Web/CSS/cursor), [сирці cursor@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/css/cursor/index.md)

Нові зміни:
- [mdn/content@95fd426](https://github.com/mdn/content/commit/95fd4266c10c92c0f10f685947722a2d98b2020f)