### PR TITLE
update(HTML): web/html/element/video

### DIFF
--- a/files/uk/web/html/element/video/index.md
+++ b/files/uk/web/html/element/video/index.md
@@ -1,6 +1,7 @@
 ---
 title: "<video>: Елемент вбудованого відео"
 slug: Web/HTML/Element/video
+page-type: html-element
 tags:
   - Element
   - HTML
@@ -206,7 +207,7 @@ browser-compat: html.elements.video
     </tr>
     <tr>
       <td>
-        {{domxref("HTMLMediaElement.playing_event", 'playing ')}}
+        {{domxref("HTMLMediaElement.playing_event", 'playing')}}
       </td>
       <td>
         Відтворення готово розпочатися, бувши призупиненим чи відкладеним через нестачу даних.
@@ -517,7 +518,7 @@ AddType video/webm .webm
     </tr>
     <tr>
       <th scope="row">Дозволені ролі ARIA</th>
-      <td>{{ARIARole("application")}}</td>
+      <td><a href="/uk/docs/Web/Accessibility/ARIA/Roles/application_role"><code>application</code></a></td>
     </tr>
     <tr>
       <th scope="row">Інтерфейс DOM</th>


### PR DESCRIPTION
Оригінальний вміст: [&lt;video>: Елемент вбудованого відео@MDN](https://developer.mozilla.org/en-us/docs/Web/HTML/Element/video), [сирці &lt;video>: Елемент вбудованого відео@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/html/element/video/index.md)

Нові зміни:
- [mdn/content@96a3f02](https://github.com/mdn/content/commit/96a3f02a83c5624f2210f602eb2220831e86cd01)
- [mdn/content@4a2b6ca](https://github.com/mdn/content/commit/4a2b6cafbf9bc5b006eedbdf0e9fdf2c8626d5b6)