### PR TITLE
update(JS): web/javascript/reference/global_objects/string/includes

### DIFF
--- a/files/uk/web/javascript/reference/global_objects/string/includes/index.md
+++ b/files/uk/web/javascript/reference/global_objects/string/includes/index.md
@@ -28,7 +28,7 @@ includes(searchString, position)
 ### Параметри
 
 - `searchString`
-  - : Рядок, який необхідно знайти всередині початкового рядка `str`. Не може бути регулярним виразом.
+  - : Рядок, який необхідно знайти всередині початкового рядка `str`. Не може [бути регулярним виразом](/uk/docs/Web/JavaScript/Reference/Global_Objects/RegExp#osoblyva-obrobka-rehuliarnykh-vyraziv). Усі значення, що не є регулярними виразами, [зводяться до рядків](/uk/docs/Web/JavaScript/Reference/Global_Objects/String#zvedennia-do-riadka), тож опускання цього параметра або передача в ньому `undefined` змушує `includes()` шукати рядок `"undefined"`, а це рідко саме те, що потрібно.
 - `position` {{optional_inline}}
   - : Номер позиції всередині рядка, з якої розпочнеться пошук шуканого рядка `searchString`. (Усталено дорівнює `0`.)
 


### PR DESCRIPTION
Оригінальний вміст: [String.prototype.includes()@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Global_Objects/String/includes), [сирці String.prototype.includes()@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/global_objects/string/includes/index.md)

Нові зміни:
- [mdn/content@989bcd8](https://github.com/mdn/content/commit/989bcd8266f53d0134d26c5bb307c08718a60162)