### PR TITLE
update(JS): web/javascript/reference/operators/optional_chaining

### DIFF
--- a/files/uk/web/javascript/reference/operators/optional_chaining/index.md
+++ b/files/uk/web/javascript/reference/operators/optional_chaining/index.md
@@ -14,7 +14,7 @@ browser-compat: javascript.operators.optional_chaining
 
 {{JSSidebar("Operators")}}
 
-**Оператор необов'язкового ланцюжка (`?.`)** звертається до властивості об'єкта або викликає функцію. Якщо об'єкт, до якого відбувається звертання, або функція, що викликається – {{jsxref("undefined")}} або [`null`](/uk/docs/Web/JavaScript/Reference/Operators/null), то замість викидання помилки – повертається {{jsxref("undefined")}}.
+**Оператор необов'язкового ланцюжка (`?.`)** звертається до властивості об'єкта або викликає функцію. Якщо об'єкт, до якого відбувається звертання, або функція, що викликається за допомогою цього оператора, – {{jsxref("undefined")}} або [`null`](/uk/docs/Web/JavaScript/Reference/Operators/null), то замість викидання помилки – вираз закорочується й обчислюється в {{jsxref("undefined")}}.
 
 {{EmbedInteractiveExample("pages/js/expressions-optionalchainingoperator.html", "taller")}}
 


### PR DESCRIPTION
Оригінальний вміст: [Необов'язковий ланцюжок (?.)@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Operators/Optional_chaining), [сирці Необов'язковий ланцюжок (?.)@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/operators/optional_chaining/index.md)

Нові зміни:
- [mdn/content@3a4d5de](https://github.com/mdn/content/commit/3a4d5dedf85f43f3ea09231c1dc04b60edd87626)