### PR TITLE
update(JS): web/javascript/reference/global_objects/array/isarray

### DIFF
--- a/files/uk/web/javascript/reference/global_objects/array/isarray/index.md
+++ b/files/uk/web/javascript/reference/global_objects/array/isarray/index.md
@@ -16,6 +16,8 @@ browser-compat: javascript.builtins.Array.isArray
 
 Статичний метод **`Array.isArray()`** ("чи є масивом") з'ясовує, чи є передане значення примірником {{jsxref("Array")}}.
 
+{{EmbedInteractiveExample("pages/js/array-isarray.html")}}
+
 ## Синтаксис
 
 ```js-nolint


### PR DESCRIPTION
Оригінальний вміст: [Array.isArray()@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Global_Objects/Array/isArray), [сирці Array.isArray()@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/global_objects/array/isarray/index.md)

Нові зміни:
- [mdn/content@1c70095](https://github.com/mdn/content/commit/1c70095257ba7f6d1195d1d33340e234dfc80b3e)
- [mdn/content@13dc8d7](https://github.com/mdn/content/commit/13dc8d707abd26319eba06d9c48630eb25e9adb9)

Залежить від:
* https://github.com/webdoky/interactive-examples/pull/77