### PR TITLE
update(CSS): web/css/text-overflow

### DIFF
--- a/files/uk/web/css/text-overflow/index.md
+++ b/files/uk/web/css/text-overflow/index.md
@@ -223,7 +223,7 @@ for (const para of paras) {
 
 #### Результат
 
-{{EmbedLiveSample('syntaksys-dvoh-znachen', 600, 360)}}
+{{EmbedLiveSample('syntaksys-dvokh-znachen', 600, 360)}}
 
 ## Специфікації
 

--- a/files/uk/web/css/text-transform/index.md
+++ b/files/uk/web/css/text-transform/index.md
@@ -340,7 +340,7 @@ strong {
 
 Це демонструє те, як грецький символ сигми (`Σ`) перетворюється на звичайну малу сигму (`σ`) або на варіант для кінця слова (`ς`), залежно від контексту.
 
-{{EmbedLiveSample('pryklad-z-vykorystanniam-lowercase-hretska-', '100%', '100px')}}
+{{EmbedLiveSample('pryklad-z-vykorystanniam-lowercase-hretska-σ', '100%', '100px')}}
 
 ### Приклад з використанням "lowercase" (литовська мова)
 
@@ -426,7 +426,7 @@ strong {
 
 Японська півширинна катакана вживалася для представлення катакани 8-бітними кодами символів. На відміну від звичайних (повноширинних) символів катакани, літера зі знаком дзвінкості представляється у вигляді двох кодових точок: тіла літери й знака дзвінкості. `full-width` поєднує їх в одну кодову точку, коли перетворює такі символи на повноширинні.
 
-{{EmbedLiveSample('pryklad-z-vykorystanniam-full-width-yaponska-pivshyrynna-katakana', '100%', '175px')}}
+{{EmbedLiveSample('pryklad-z-vykorystanniam-full-width-iaponska-pivshyrynna-katakana', '100%', '175px')}}
 
 ### Приклад з використанням "full-size-kana"
 


### PR DESCRIPTION
Оригінальний вміст: [text-overflow@MDN](https://developer.mozilla.org/en-us/docs/Web/CSS/text-overflow), [сирці text-overflow@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/css/text-overflow/index.md)

Нові зміни:
- [mdn/content@cc1ba4c](https://github.com/mdn/content/commit/cc1ba4c4a1305874f36ea2a6dc43066b49bd79b0)

Випадково сюди докинув іще:

Оригінальний вміст: [text-transform@MDN](https://developer.mozilla.org/en-us/docs/Web/CSS/text-transform), [сирці text-transform@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/css/text-transform/index.md)

Нові зміни:
- [mdn/content@4e002d2](https://github.com/mdn/content/commit/4e002d26cb032c915aeee366f922f23cbacd8bf1)