### PR TITLE
update(CSS): web/css/padding

### DIFF
--- a/files/uk/web/css/padding/index.md
+++ b/files/uk/web/css/padding/index.md
@@ -13,7 +13,7 @@ browser-compat: css.properties.padding
 
 {{CSSRef}}
 
-[Властивість-скорочення](/uk/docs/Web/CSS/Shorthand_properties) [CSS](/uk/docs/Web/CSS) **`padding`** (набивка) встановлює [розмах внутрішніх відступів](/uk/docs/Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model#padding_area) з усіх чотирьох сторін елемента за раз.
+[Властивість-скорочення](/uk/docs/Web/CSS/Shorthand_properties) [CSS](/uk/docs/Web/CSS) **`padding`** (набивка) встановлює [розмах внутрішніх відступів](/uk/docs/Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model#oblast-vnutrishnikh-vidstupiv) з усіх чотирьох сторін елемента за раз.
 
 {{EmbedInteractiveExample("pages/css/padding.html")}}
 


### PR DESCRIPTION
Оригінальний вміст: [padding@MDN](https://developer.mozilla.org/en-us/docs/Web/CSS/padding), [сирці padding@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/css/padding/index.md)

Нові зміни:
- [mdn/content@4e002d2](https://github.com/mdn/content/commit/4e002d26cb032c915aeee366f922f23cbacd8bf1)