### PR TITLE
update(JS): web/javascript/reference/global_objects/date

### DIFF
--- a/files/uk/web/javascript/reference/global_objects/date/index.md
+++ b/files/uk/web/javascript/reference/global_objects/date/index.md
@@ -2,14 +2,6 @@
 title: Date
 slug: Web/JavaScript/Reference/Global_Objects/Date
 page-type: javascript-class
-tags:
-  - Class
-  - Date
-  - Epoch
-  - JavaScript
-  - Time
-  - Unix Epoch
-  - timeStamp
 browser-compat: javascript.builtins.Date
 ---
 
@@ -54,6 +46,13 @@ browser-compat: javascript.builtins.Date
 
 - {{jsxref("Date.UTC()")}}
   - : Приймає ті ж аргументи, що й найдовша форма конструктора (тобто від 2 до 7 аргументів) і повертає кількість мілісекунд від 1 січня 1970 року, 00:00:00 UTC, без врахування високосних секунд.
+
+## Властивості примірника
+
+Ці властивості означені на `Date.prototype` і є спільними для всіх примірників `Date`.
+
+- {{jsxref("Object/constructor", "Date.prototype.constructor")}}
+  - : Функція-конструктор, що створила об'єкт-примірник. Для примірників `Date` початковим значенням є конструктор {{jsxref("Date/Date", "Date")}}.
 
 ## Методи примірника
 


### PR DESCRIPTION
Оригінальний вміст: [Date@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Global_Objects/Date), [сирці Date@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/global_objects/date/index.md)

Нові зміни:
- [mdn/content@d19dc31](https://github.com/mdn/content/commit/d19dc31570f62196a5837be38bd0b11c45e67b05)
- [mdn/content@6b72869](https://github.com/mdn/content/commit/6b728699f5f38f1070a94673b5e7afdb1102a941)