### PR TITLE
update(JS): web/javascript/reference/global_objects/set

### DIFF
--- a/files/uk/web/javascript/reference/global_objects/set/index.md
+++ b/files/uk/web/javascript/reference/global_objects/set/index.md
@@ -2,15 +2,6 @@
 title: Set
 slug: Web/JavaScript/Reference/Global_Objects/Set
 page-type: javascript-class
-tags:
-  - Class
-  - ECMAScript 2015
-  - Global Objects
-  - JavaScript
-  - Object
-  - Reference
-  - set
-  - Polyfill
 browser-compat: javascript.builtins.Set
 ---
 
@@ -44,10 +35,14 @@ browser-compat: javascript.builtins.Set
 
 ## Властивості примірника
 
-- `Set.prototype[@@toStringTag]`
-  - : Початкове значення властивості [`@@toStringTag`](/uk/docs/Web/JavaScript/Reference/Global_Objects/Symbol/toStringTag) – рядок `"Set"`. Ця властивість використовується в {{jsxref("Object.prototype.toString()")}}.
+Ці властивості означені на `Set.prototype` і є спільними для всіх примірників `Set`.
+
+- {{jsxref("Object/constructor", "Set.prototype.constructor")}}
+  - : Функція-конструктор, що створила об'єкт-примірник. Для примірників `Set` початковим значенням є конструктор {{jsxref("Set/Set", "Set")}}.
 - {{jsxref("Set.prototype.size")}} (розмір)
   - : Повертає кількість значень, присутніх в об'єкті `Set`.
+- `Set.prototype[@@toStringTag]`
+  - : Початкове значення властивості [`@@toStringTag`](/uk/docs/Web/JavaScript/Reference/Global_Objects/Symbol/toStringTag) – рядок `"Set"`. Ця властивість використовується в {{jsxref("Object.prototype.toString()")}}.
 
 ## Методи примірника
 


### PR DESCRIPTION
Оригінальний вміст: [Set@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Global_Objects/Set), [сирці Set@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/global_objects/set/index.md)

Нові зміни:
- [mdn/content@d19dc31](https://github.com/mdn/content/commit/d19dc31570f62196a5837be38bd0b11c45e67b05)
- [mdn/content@f3df525](https://github.com/mdn/content/commit/f3df52530f974e26dd3b14f9e8d42061826dea20)
- [mdn/content@d61bfb9](https://github.com/mdn/content/commit/d61bfb9ae59aabab7ac17ba345035e260f28fc83)