### PR TITLE
update(JS): web/javascript/reference/operators/spread_syntax

### DIFF
--- a/files/uk/web/javascript/reference/operators/spread_syntax/index.md
+++ b/files/uk/web/javascript/reference/operators/spread_syntax/index.md
@@ -2,12 +2,6 @@
 title: Синтаксис розгортання (...)
 slug: Web/JavaScript/Reference/Operators/Spread_syntax
 page-type: javascript-operator
-tags:
-  - ECMAScript 2015
-  - Iterator
-  - JavaScript
-  - Language feature
-  - Reference
 browser-compat: javascript.operators.spread
 ---
 


### PR DESCRIPTION
Оригінальний вміст: [Синтаксис розгортання (...)@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Operators/Spread_syntax), [сирці Синтаксис розгортання (...)@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/operators/spread_syntax/index.md)

Нові зміни:
- [mdn/content@0f3738f](https://github.com/mdn/content/commit/0f3738f6b1ed1aa69395ff181207186e1ad9f4d8)
- [mdn/content@3bf2463](https://github.com/mdn/content/commit/3bf2463d6d13f1f4b388ff2a0daaea9da5e545eb)