### PR TITLE
update(JS): web/javascript/reference/operators/optional_chaining

### DIFF
--- a/files/uk/web/javascript/reference/operators/optional_chaining/index.md
+++ b/files/uk/web/javascript/reference/operators/optional_chaining/index.md
@@ -2,13 +2,6 @@
 title: Необов'язковий ланцюжок (?.)
 slug: Web/JavaScript/Reference/Operators/Optional_chaining
 page-type: javascript-operator
-tags:
-  - Chaining
-  - JavaScript
-  - Language feature
-  - Operator
-  - Optional chaining
-  - Reference
 browser-compat: javascript.operators.optional_chaining
 ---
 


### PR DESCRIPTION
Оригінальний вміст: [Необов'язковий ланцюжок (?.)@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Operators/Optional_chaining), [сирці Необов'язковий ланцюжок (?.)@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/operators/optional_chaining/index.md)

Нові зміни:
- [mdn/content@0f3738f](https://github.com/mdn/content/commit/0f3738f6b1ed1aa69395ff181207186e1ad9f4d8)