### PR TITLE
update(JS): web/javascript/reference/global_objects/date/now

### DIFF
--- a/files/uk/web/javascript/reference/global_objects/date/now/index.md
+++ b/files/uk/web/javascript/reference/global_objects/date/now/index.md
@@ -2,13 +2,6 @@
 title: Date.now()
 slug: Web/JavaScript/Reference/Global_Objects/Date/now
 page-type: javascript-static-method
-tags:
-  - Date
-  - JavaScript
-  - Method
-  - Reference
-  - Time
-  - Polyfill
 browser-compat: javascript.builtins.Date.now
 ---
 
@@ -30,19 +23,19 @@ Date.now()
 
 ## Приклади
 
-### Зменшена точність часу
+### Знижена точність часу
 
-Для забезпечення захисту від часових атак і створення цифрових відбитків, точні значення `Date.now()` можуть заокруглюватись залежно від налаштувань браузера. Наприклад, у Firefox опція `privacy.reduceTimerPrecision` — усталено ввімкнена, і усталено дорівнює 20 мкс у версії Firefox 59; у версії 60 вона дорівнює вже 2 мс.
+Для забезпечення захисту від часових атак і [створення цифрових відбитків](/uk/docs/Glossary/Fingerprinting), точні значення `Date.now()` можуть заокруглюватись залежно від налаштувань браузера. Наприклад, у Firefox опція `privacy.reduceTimerPrecision` — усталено ввімкнена, і усталено дорівнює 20 мкс у версії Firefox 59; у версії 60 вона дорівнює вже 2 мс.
 
 ```js
-// зменшена точність часу (2мс) у Firefox 60
+// знижена точність часу (2мс) у Firefox 60
 Date.now();
 // 1519211809934
 // 1519211810362
 // 1519211811670
 // …
 
-// зменшена точність часу із увімкненою опцією `privacy.resistFingerprinting`
+// знижена точність часу із увімкненою опцією `privacy.resistFingerprinting`
 Date.now();
 // 1519129853500
 // 1519129858900


### PR DESCRIPTION
Оригінальний вміст: [Date.now()@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Global_Objects/Date/now), [сирці Date.now()@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/global_objects/date/now/index.md)

Нові зміни:
- [mdn/content@80d4cfb](https://github.com/mdn/content/commit/80d4cfb4515b339111e175dbeb8d2b91fd3ee1a0)
- [mdn/content@6b72869](https://github.com/mdn/content/commit/6b728699f5f38f1070a94673b5e7afdb1102a941)
- [mdn/content@3f0cd84](https://github.com/mdn/content/commit/3f0cd840cd9575701c65b8c6a1e172a2b0c3bd62)