### PR TITLE
update(CSS): web/css/css_text/wrapping_text

### DIFF
--- a/files/uk/web/css/css_text/wrapping_text/index.md
+++ b/files/uk/web/css/css_text/wrapping_text/index.md
@@ -2,13 +2,6 @@
 title: Переведення на новий рядок і розривання тексту
 slug: Web/CSS/CSS_Text/Wrapping_Text
 page-type: guide
-tags:
-  - CSS
-  - CSS Text
-  - Guide
-  - overflow
-  - overflow-wrap
-  - word-break
 ---
 
 {{CSSRef}}


### PR DESCRIPTION
Оригінальний вміст: [Переведення на новий рядок і розривання тексту@MDN](https://developer.mozilla.org/en-us/docs/Web/CSS/CSS_Text/Wrapping_Text), [сирці Переведення на новий рядок і розривання тексту@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/css/css_text/wrapping_text/index.md)

Нові зміни:
- [mdn/content@55517b0](https://github.com/mdn/content/commit/55517b0d5025db08464af689874f388098e6aab8)