### PR TITLE
update(JS): web/javascript/reference/global_objects/string/includes

### DIFF
--- a/files/uk/web/javascript/reference/global_objects/string/includes/index.md
+++ b/files/uk/web/javascript/reference/global_objects/string/includes/index.md
@@ -2,13 +2,6 @@
 title: String.prototype.includes()
 slug: Web/JavaScript/Reference/Global_Objects/String/includes
 page-type: javascript-instance-method
-tags:
-  - JavaScript
-  - Method
-  - Prototype
-  - Reference
-  - String
-  - Polyfill
 browser-compat: javascript.builtins.String.includes
 ---
 


### PR DESCRIPTION
Оригінальний вміст: [String.prototype.includes()@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Global_Objects/String/includes), [сирці String.prototype.includes()@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/global_objects/string/includes/index.md)

Нові зміни:
- [mdn/content@f3df525](https://github.com/mdn/content/commit/f3df52530f974e26dd3b14f9e8d42061826dea20)