### PR TITLE
update(JS): web/javascript/reference/global_objects/math/max

### DIFF
--- a/files/uk/web/javascript/reference/global_objects/math/max/index.md
+++ b/files/uk/web/javascript/reference/global_objects/math/max/index.md
@@ -2,16 +2,6 @@
 title: Math.max()
 slug: Web/JavaScript/Reference/Global_Objects/Math/max
 page-type: javascript-static-method
-tags:
-  - JavaScript
-  - Math
-  - Method
-  - Maximum
-  - Reference
-  - Largest
-  - Largest Number
-  - Largest Value
-  - max
 browser-compat: javascript.builtins.Math.max
 ---
 


### PR DESCRIPTION
Оригінальний вміст: [Math.max()@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Global_Objects/Math/max), [сирці Math.max()@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/global_objects/math/max/index.md)

Нові зміни:
- [mdn/content@fcd80ee](https://github.com/mdn/content/commit/fcd80ee4c8477b6f73553bfada841781cf74cf46)