### PR TITLE
update(JS): web/javascript/reference/global_objects/regexp

### DIFF
--- a/files/uk/web/javascript/reference/global_objects/regexp/index.md
+++ b/files/uk/web/javascript/reference/global_objects/regexp/index.md
@@ -1,14 +1,7 @@
 ---
-title: RegExp
+title: RegExp (регулярний вираз)
 slug: Web/JavaScript/Reference/Global_Objects/RegExp
 page-type: javascript-class
-tags:
-  - Class
-  - JavaScript
-  - Reference
-  - RegExp
-  - Regular Expressions
-  - Polyfill
 browser-compat: javascript.builtins.RegExp
 ---
 
@@ -123,6 +116,10 @@ re.exec("bar"); // [ 'bar', index: 0, input: 'bar', groups: undefined ]
 
 ## Властивості примірника
 
+Ці властивості означені на `RegExp.prototype` і є спільними для всіх примірників `RegExp`.
+
+- {{jsxref("Object/constructor", "RegExp.prototype.constructor")}}
+  - : Функція-конструктор, що створила об'єкт-примірник. Для примірників `RegExp` початковим значенням є конструктор {{jsxref("RegExp/RegExp", "RegExp")}}.
 - {{JSxRef("RegExp.prototype.flags")}} (позначки)
   - : Рядок, що містить позначки об'єкта `RegExp`.
 - {{JSxRef("RegExp.prototype.dotAll")}} (точка все)
@@ -141,7 +138,10 @@ re.exec("bar"); // [ 'bar', index: 0, input: 'bar', groups: undefined ]
   - : Чи є пошук липким.
 - {{JSxRef("RegExp.prototype.unicode")}}
   - : Чи ввімкнені можливості Unicode.
-- {{jsxref("RegExp.prototype.lastIndex")}} (останній індекс)
+
+Ці властивості є власними властивостями кожного окремого примірника `RegExp`.
+
+- {{jsxref("RegExp/lastIndex", "lastIndex")}} (останній індекс)
   - : Індекс, з якого почнеться наступний пошук збігу.
 
 ## Методи примірника
@@ -310,7 +310,7 @@ order.match(new RegExp(`\\b(${breakfasts.join("|")})\\b`, "g"));
 // група: undefined
 ```
 
-Зверніть увагу, що заради сумісності `RegExp.$N` й далі повертає порожній рядок, а не `undefined` ([вада 1053944](https://bugzilla.mozilla.org/show_bug.cgi?id=1053944)).
+Зверніть увагу, що заради сумісності `RegExp.$N` й далі повертає порожній рядок, а не `undefined` ([вада 1053944](https://bugzil.la/1053944)).
 
 ## Дивіться також
 


### PR DESCRIPTION
Оригінальний вміст: [RegExp@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Global_Objects/RegExp), [сирці RegExp@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/global_objects/regexp/index.md)

Нові зміни:
- [mdn/content@c6dbc4f](https://github.com/mdn/content/commit/c6dbc4ff96451887b908b46c8e70bcfec1c2c48c)
- [mdn/content@d19dc31](https://github.com/mdn/content/commit/d19dc31570f62196a5837be38bd0b11c45e67b05)
- [mdn/content@f3df525](https://github.com/mdn/content/commit/f3df52530f974e26dd3b14f9e8d42061826dea20)
- [mdn/content@77cd8a3](https://github.com/mdn/content/commit/77cd8a3f1e17d578b2ee62903b1cc47e81878312)
- [mdn/content@d61bfb9](https://github.com/mdn/content/commit/d61bfb9ae59aabab7ac17ba345035e260f28fc83)