### PR TITLE
update(JS): web/javascript/reference/operators/await

### DIFF
--- a/files/uk/web/javascript/reference/operators/await/index.md
+++ b/files/uk/web/javascript/reference/operators/await/index.md
@@ -2,12 +2,6 @@
 title: await
 slug: Web/JavaScript/Reference/Operators/await
 page-type: javascript-operator
-tags:
-  - Function
-  - JavaScript
-  - Language feature
-  - Operator
-  - Primary Expression
 browser-compat: javascript.operators.await
 ---
 


### PR DESCRIPTION
Оригінальний вміст: [await@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Operators/await), [сирці await@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/operators/await/index.md)

Нові зміни:
- [mdn/content@0f3738f](https://github.com/mdn/content/commit/0f3738f6b1ed1aa69395ff181207186e1ad9f4d8)