### PR TITLE
update(JS): web/javascript/reference/errors/not_defined

### DIFF
--- a/files/uk/web/javascript/reference/errors/not_defined/index.md
+++ b/files/uk/web/javascript/reference/errors/not_defined/index.md
@@ -2,10 +2,6 @@
 title: 'ReferenceError: "x" is not defined'
 slug: Web/JavaScript/Reference/Errors/Not_defined
 page-type: javascript-error
-tags:
-  - Error
-  - JavaScript
-  - ReferenceError
 ---
 
 {{jsSidebar("Errors")}}


### PR DESCRIPTION
Оригінальний вміст: [ReferenceError: "x" is not defined@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Errors/Not_defined), [сирці ReferenceError: "x" is not defined@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/errors/not_defined/index.md)

Нові зміни:
- [mdn/content@9c4fb23](https://github.com/mdn/content/commit/9c4fb236cd9ced12b1eb8e7696d8e6fcb8d8bad3)