### PR TITLE
update(HTML): web/html/element/span

### DIFF
--- a/files/uk/web/html/element/span/index.md
+++ b/files/uk/web/html/element/span/index.md
@@ -1,87 +1,19 @@
 ---
 title: "<span>: Елемент відрізка вмісту"
 slug: Web/HTML/Element/span
-tags:
-  - Element
-  - HTML
-  - HTML text-level semantics
-  - HTML:Потоковий вміст
-  - Reference
-  - Web
+page-type: html-element
 browser-compat: html.elements.span
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
-Елемент [HTML](/uk/docs/Web/HTML) **`<span>`** (розмах, відрізок, проліт, інтервал) – це узагальнений рядковий контейнер для оповідального вмісту, котрий по суті нічого не представляє. Він може застосовуватися для групування елементів для потреб оформлення (за допомогою атрибутів {{htmlattrxref("class")}} і {{htmlattrxref("id")}}), або через те, що вони поділяють значення атрибутів, як то {{htmlattrxref("lang")}}. Повинен застосовуватися лише тоді, коли жодний семантичний елемент не є доречним. `<span>` вельми подібний до елемента {{HTMLElement("div")}}, крім того, що {{HTMLElement("div")}} є [елементом блокового рівня](/uk/docs/Web/HTML/Block-level_elements), а `<span>` – [рядковий елемент](/uk/docs/Web/HTML/Inline_elements).
+Елемент [HTML](/uk/docs/Web/HTML) **`<span>`** (розмах, відрізок, проліт, інтервал) – це узагальнений рядковий контейнер для оповідального вмісту, котрий по суті нічого не представляє. Він може застосовуватися для групування елементів для потреб оформлення (за допомогою атрибутів [`class`](/uk/docs/Web/HTML/Global_attributes#class) і [`id`](/uk/docs/Web/HTML/Global_attributes#id)), або через те, що вони поділяють значення атрибутів, як то [`lang`](/uk/docs/Web/HTML/Global_attributes#lang). Повинен застосовуватися лише тоді, коли жодний семантичний елемент не є доречним. `<span>` вельми подібний до елемента {{HTMLElement("div")}}, крім того, що {{HTMLElement("div")}} є [елементом блокового рівня](/uk/docs/Web/HTML/Block-level_elements), а `<span>` – [рядковий елемент](/uk/docs/Web/HTML/Inline_elements).
 
 {{EmbedInteractiveExample("pages/tabbed/span.html", "tabbed-shorter")}}
 
-<table class="properties">
-  <tbody>
-    <tr>
-      <th scope="row">
-        <a href="/uk/docs/Web/Guide/HTML/Content_categories"
-          >Категорії вмісту</a
-        >
-      </th>
-      <td>
-        <a href="/uk/docs/Web/Guide/HTML/Content_categories#flow_content"
-          >Потоковий вміст</a
-        >,
-        <a href="/uk/docs/Web/Guide/HTML/Content_categories#phrasing_content"
-          >оповідальний вміст</a
-        >.
-      </td>
-    </tr>
-    <tr>
-      <th scope="row">Дозволений вміст</th>
-      <td>
-        <a href="/uk/docs/Web/Guide/HTML/Content_categories#phrasing_content"
-          >Оповідальний вміст</a
-        >.
-      </td>
-    </tr>
-    <tr>
-      <th scope="row">Упускання тега</th>
-      <td>{{no_tag_omission}}</td>
-    </tr>
-    <tr>
-      <th scope="row">Дозволені батьківські елементи</th>
-      <td>
-        Усі елементи, що приймають
-        <a href="/uk/docs/Web/Guide/HTML/Content_categories#phrasing_content"
-          >оповідальний вміст</a
-        > або
-        <a href="/uk/docs/Web/Guide/HTML/Content_categories#flow_content"
-          >потоковий вміст</a
-        >.
-      </td>
-    </tr>
-    <tr>
-      <th scope="row">Неявна роль ARIA</th>
-      <td>
-        <a href="https://www.w3.org/TR/html-aria/#dfn-no-corresponding-role"
-          >Немає відповідної ролі</a
-        >
-      </td>
-    </tr>
-    <tr>
-      <th scope="row">Дозволені ролі ARIA</th>
-      <td>Усі</td>
-    </tr>
-    <tr>
-      <th scope="row">Інтерфейс DOM</th>
-      <td>
-        {{domxref("HTMLSpanElement")}}
-      </td>
-    </tr>
-  </tbody>
-</table>
+## Атрибути
 
-## Атрибут
-
-Цей елемент включає лише [глобальні атрибути](/uk/docs/Web/HTML/Global_attributes).
+Цей елемент приймає лише [глобальні атрибути](/uk/docs/Web/HTML/Global_attributes).
 
 ## Приклад
 
@@ -90,10 +22,10 @@ browser-compat: html.elements.span
 #### HTML
 
 ```html
-<p><span>Трохи тексту</span></p>
+<p><span>Якийсь текст</span></p>
 ```
 
-#### Result
+#### Результат
 
 {{EmbedLiveSample('pryklad-1')}}
 
@@ -120,6 +52,70 @@ li span {
 #### Результат
 
 {{EmbedLiveSample('pryklad-2')}}
+
+## Технічний підсумок
+
+<table class="properties">
+  <tbody>
+    <tr>
+      <th scope="row">
+        <a href="/uk/docs/Web/HTML/Content_categories"
+          >Категорії вмісту</a
+        >
+      </th>
+      <td>
+        <a href="/uk/docs/Web/HTML/Content_categories#potokovyi-vmist"
+          >Потоковий вміст</a
+        >,
+        <a href="/uk/docs/Web/HTML/Content_categories#opovidalnyi-vmist"
+          >оповідальний вміст</a
+        >.
+      </td>
+    </tr>
+    <tr>
+      <th scope="row">Дозволений вміст</th>
+      <td>
+        <a href="/uk/docs/Web/HTML/Content_categories#opovidalnyi-vmist"
+          >Оповідальний вміст</a
+        >.
+      </td>
+    </tr>
+    <tr>
+      <th scope="row">Упускання тега</th>
+      <td>{{no_tag_omission}}</td>
+    </tr>
+    <tr>
+      <th scope="row">Дозволені батьківські елементи</th>
+      <td>
+        Усі елементи, що приймають
+        <a href="/uk/docs/Web/HTML/Content_categories#opovidalnyi-vmist"
+          >оповідальний вміст</a
+        > або
+        <a href="/uk/docs/Web/HTML/Content_categories#potokovyi-vmist"
+          >потоковий вміст</a
+        >.
+      </td>
+    </tr>
+    <tr>
+      <th scope="row">Неявна роль ARIA</th>
+      <td>
+        <a href="https://www.w3.org/TR/html-aria/#dfn-no-corresponding-role"
+          >Немає відповідної ролі</a
+        >
+      </td>
+    </tr>
+    <tr>
+      <th scope="row">Дозволені ролі ARIA</th>
+      <td>Усі</td>
+    </tr>
+    <tr>
+      <th scope="row">Інтерфейс DOM</th>
+      <td>
+        {{domxref("HTMLSpanElement")}}
+      </td>
+    </tr>
+  </tbody>
+</table>
 
 ## Специфікації
 


### PR DESCRIPTION
Оригінальний вміст: [&lt;span>: Елемент відрізка вмісту@MDN](https://developer.mozilla.org/en-us/docs/Web/HTML/Element/span), [сирці &lt;span>: Елемент відрізка вмісту@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/html/element/span/index.md)

Нові зміни:
- [mdn/content@d3cdafc](https://github.com/mdn/content/commit/d3cdafcdb4d22e5c55771501e7c80451a96aa032)
- [mdn/content@ba96f2f](https://github.com/mdn/content/commit/ba96f2f183353872db6d9242c7d2dffe2dbc0c35)
- [mdn/content@818221f](https://github.com/mdn/content/commit/818221f587f6d4514dcc5c2b015297805f2c1a8b)
- [mdn/content@3c92596](https://github.com/mdn/content/commit/3c925962d641d83660a3c28d3e9a0627a7996183)
- [mdn/content@4a2b6ca](https://github.com/mdn/content/commit/4a2b6cafbf9bc5b006eedbdf0e9fdf2c8626d5b6)
- [mdn/content@0f2d4cf](https://github.com/mdn/content/commit/0f2d4cfa06ad3c58f07a7be525188ac14d83603d)
- [mdn/content@7d86bc5](https://github.com/mdn/content/commit/7d86bc540b9aa3d8d4a8d3109667f73d0b3ff701)