### PR TITLE
update(JS): web/javascript/reference/global_objects/array/map

### DIFF
--- a/files/uk/web/javascript/reference/global_objects/array/map/index.md
+++ b/files/uk/web/javascript/reference/global_objects/array/map/index.md
@@ -14,37 +14,20 @@ browser-compat: javascript.builtins.Array.map
 ## Синтаксис
 
 ```js-nolint
-// Стрілкова функція
-map((element) => { /* … */ })
-map((element, index) => { /* … */ })
-map((element, index, array) => { /* … */ })
-
-// Функція зворотного виклику
 map(callbackFn)
 map(callbackFn, thisArg)
-
-// Функція зворотного виклику, оголошена на місці
-map(function(element) { /* … */ })
-map(function(element, index) { /* … */ })
-map(function(element, index, array){ /* … */ })
-map(function(element, index, array) { /* … */ }, thisArg)
 ```
 
 ### Параметри
 
 - `callbackFn`
-
-  - : Функція для виклику на кожному елементі масиву. Її повернене значення додається окремим елементом у новий масив.
-
-    Ця функція викликається із наступними аргументами:
-
+  - : Функція для виклику на кожному елементі масиву. Її повернене значення додається окремим елементом у новий масив. Ця функція викликається із наступними аргументами:
     - `element`
       - : Поточний елемент масиву, який зараз опрацьовується.
     - `index`
       - : Порядковий номер поточного елемента масиву, який зараз обробляється.
     - `array`
       - : Масив, на якому було викликано метод `map()`.
-
 - `thisArg` {{optional_inline}}
   - : Значення для використання як `this` при виконанні `callbackFn`. Більше про це в [ітеративних методах](/uk/docs/Web/JavaScript/Reference/Global_Objects/Array#iteratyvni-metody).
 
@@ -259,6 +242,9 @@ const filteredNumbers = numbers.map((num, index) => {
 ## Дивіться також
 
 - [Поліфіл `Array.prototype.map` у `core-js`](https://github.com/zloirock/core-js#ecmascript-array)
+- [Колекції з індексами](/uk/docs/Web/JavaScript/Guide/Indexed_collections)
+- {{jsxref("Array")}}
 - {{jsxref("Array.prototype.forEach()")}}
-- Об'єкт {{jsxref("Map")}}
 - {{jsxref("Array.from()")}}
+- {{jsxref("TypedArray.prototype.map()")}}
+- {{jsxref("Map")}}


### PR DESCRIPTION
Оригінальний вміст: [Array.prototype.map()@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Global_Objects/Array/map), [сирці Array.prototype.map()@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/global_objects/array/map/index.md)

Нові зміни:
- [mdn/content@34a34be](https://github.com/mdn/content/commit/34a34bee83fb4accf073ebc0c8cfc8eff956dc9b)
- [mdn/content@c517363](https://github.com/mdn/content/commit/c51736321bee582320a6aed38f969e9f28a2fcd8)