### PR TITLE
update(JS): web/javascript/reference/global_objects/array/includes

### DIFF
--- a/files/uk/web/javascript/reference/global_objects/array/includes/index.md
+++ b/files/uk/web/javascript/reference/global_objects/array/includes/index.md
@@ -34,7 +34,7 @@ includes(searchElement, fromIndex)
 
 ## Опис
 
-Метод `includes()` порівнює `searchElement` з елементами масиву за допомогою алгоритму [SameValueZero](/uk/docs/Web/JavaScript/Reference/Operators/Strict_equality). Усі нульові значення вважаються рівними, незалежно від свого знаку. (Тобто `-0` рівносильно `0`), але `false` _не_ вважається тотожним `0`. Може бути виконаний коректний пошук [`NaN`](/uk/docs/Web/JavaScript/Reference/Global_Objects/NaN).
+Метод `includes()` порівнює `searchElement` з елементами масиву за допомогою алгоритму [SameValueZero](/uk/docs/Web/JavaScript/Equality_comparisons_and_sameness#rivnist-iz-odnakovym-nulem). Усі нульові значення вважаються рівними, незалежно від свого знаку. (Тобто `-0` рівносильно `0`), але `false` _не_ вважається тотожним `0`. Може бути виконаний коректний пошук [`NaN`](/uk/docs/Web/JavaScript/Reference/Global_Objects/NaN).
 
 Бувши використаним на [розріджених масивах](/uk/docs/Web/JavaScript/Guide/Indexed_collections#rozridzheni-masyvy), метод `includes()` ітерує порожні комірки так, ніби вони містять значення `undefined`.
 
@@ -117,8 +117,10 @@ console.log(Array.prototype.includes.call(arrayLike, 1));
 ## Дивіться також
 
 - [Поліфіл для `Array.prototype.includes` у складі `core-js`](https://github.com/zloirock/core-js#ecmascript-array)
-- {{jsxref("TypedArray.prototype.includes()")}}
-- {{jsxref("String.prototype.includes()")}}
+- [Колекції з індексами](/uk/docs/Web/JavaScript/Guide/Indexed_collections)
+- {{jsxref("Array")}}
 - {{jsxref("Array.prototype.indexOf()")}}
 - {{jsxref("Array.prototype.find()")}}
 - {{jsxref("Array.prototype.findIndex()")}}
+- {{jsxref("TypedArray.prototype.includes()")}}
+- {{jsxref("String.prototype.includes()")}}


### PR DESCRIPTION
Оригінальний вміст: [Array.prototype.includes()@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Global_Objects/Array/includes), [сирці Array.prototype.includes()@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/global_objects/array/includes/index.md)

Нові зміни:
- [mdn/content@f5cac13](https://github.com/mdn/content/commit/f5cac13490a02793ce148fe0d77b796b1383dc0a)
- [mdn/content@34a34be](https://github.com/mdn/content/commit/34a34bee83fb4accf073ebc0c8cfc8eff956dc9b)