### PR TITLE
update(JS): web/javascript/reference/global_objects/json/stringify

### DIFF
--- a/files/uk/web/javascript/reference/global_objects/json/stringify/index.md
+++ b/files/uk/web/javascript/reference/global_objects/json/stringify/index.md
@@ -41,7 +41,7 @@ JSON.stringify(value, replacer, space)
 
 ### Винятки
 
-- {{JSxRef("TypeError")}}
+- {{jsxref("TypeError")}}
   - : Викидається, коли виконується одна з двох умов:
     - `value` містить циклічне посилання.
     - Зустрічається значення {{jsxref("BigInt")}}.


### PR DESCRIPTION
Оригінальний вміст: [JSON.stringify()@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify), [сирці JSON.stringify()@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/global_objects/json/stringify/index.md)

Нові зміни:
- [mdn/content@a92a2bb](https://github.com/mdn/content/commit/a92a2bb31cf5d79808878701f0344a4eabf12963)