### PR TITLE
update(JS): web/javascript/reference/global_objects/encodeuricomponent

### DIFF
--- a/files/uk/web/javascript/reference/global_objects/encodeuricomponent/index.md
+++ b/files/uk/web/javascript/reference/global_objects/encodeuricomponent/index.md
@@ -37,7 +37,7 @@ encodeURIComponent(uriComponent)
 
 `encodeURIComponent()` використовує такий же алгоритм кодування, як описаний для {{jsxref("encodeURI()")}}. Він екранує усі символи, **окрім**:
 
-```
+```plain
 A–Z a–z 0–9 - _ . ! ~ * ' ( )
 ```
 
@@ -54,7 +54,7 @@ A–Z a–z 0–9 - _ . ! ~ * ' ( )
 ```js
 const fileName = "my file(2).txt";
 const header = `Content-Disposition: attachment; filename*=UTF-8''${encodeRFC5987ValueChars(
-  fileName
+  fileName,
 )}`;
 
 console.log(header);
@@ -69,12 +69,12 @@ function encodeRFC5987ValueChars(str) {
       // RFC5987 – ні, тому цей символ немає потреби екранувати.
       .replace(
         /['()*]/g,
-        (c) => `%${c.charCodeAt(0).toString(16).toUpperCase()}`
+        (c) => `%${c.charCodeAt(0).toString(16).toUpperCase()}`,
       )
       // Наступне не обов'язково для процентного кодування згідно з RFC5987,
       // тож можна дозволити трохи кращу прочитність по той бік дроту: |`^
       .replace(/%(7C|60|5E)/g, (str, hex) =>
-        String.fromCharCode(parseInt(hex, 16))
+        String.fromCharCode(parseInt(hex, 16)),
       )
   );
 }
@@ -88,7 +88,7 @@ function encodeRFC5987ValueChars(str) {
 function encodeRFC3986URIComponent(str) {
   return encodeURIComponent(str).replace(
     /[!'()*]/g,
-    (c) => `%${c.charCodeAt(0).toString(16).toUpperCase()}`
+    (c) => `%${c.charCodeAt(0).toString(16).toUpperCase()}`,
   );
 }
 ```

--- a/files/uk/web/javascript/reference/global_objects/encodeuricomponent/index.md
+++ b/files/uk/web/javascript/reference/global_objects/encodeuricomponent/index.md
@@ -93,6 +93,21 @@ function encodeRFC3986URIComponent(str) {
 }
 ```
 
+### Кодування самотнього старшого сурогату викидає помилку
+
+Викидається помилка {{jsxref("URIError")}}, якщо спробувати закодувати сурогат, який не є частиною пари старшого та молодшого сурогатів. Наприклад:
+
+```js
+// Пара старший-молодший – ОК
+encodeURIComponent("\uD800\uDFFF"); // "%F0%90%8F%BF"
+// Самотній старший сурогат викидає помилку "URIError: malformed URI sequence"
+encodeURIComponent("\uD800");
+// Самотній молодший сурогат викидає помилку "URIError: malformed URI sequence"
+encodeURIComponent("\uDFFF");
+```
+
+Можна скористатися методом {{jsxref("String.prototype.toWellFormed()")}}, котрий замінює самотні сурогати на символ заміни Unicode (U+FFFD), щоб уникнути цієї помилки. Також можна скористатися методом {{jsxref("String.prototype.isWellFormed()")}}, щоб перевірити, чи містить рядок самотні сурогати, перед тим, як передати його у `encodeURIComponent()`.
+
 ## Специфікації
 
 {{Specifications}}


### PR DESCRIPTION
Оригінальний вміст: [encodeURIComponent()@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent), [сирці encodeURIComponent()@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/global_objects/encodeuricomponent/index.md)

Нові зміни:
- [mdn/content@6d60617](https://github.com/mdn/content/commit/6d606174faaedaa5dee7b7ebd87602cd51e5dd7e)
- [mdn/content@5635446](https://github.com/mdn/content/commit/5635446aa0127d686183ddd4fd5adcc34be567da)
- [mdn/content@b5c766f](https://github.com/mdn/content/commit/b5c766f4eecb4fcf9d8ba175caddb94f7c3e9d20)
- [mdn/content@6a0f955](https://github.com/mdn/content/commit/6a0f9553932823cd0c4dcf695d4b4813474964fb)
- [mdn/content@e7685be](https://github.com/mdn/content/commit/e7685be472849835c84b7835f8a4613e1abc6b10)