### PR TITLE
update(JS): web/javascript/reference/global_objects/string/match

### DIFF
--- a/files/uk/web/javascript/reference/global_objects/string/match/index.md
+++ b/files/uk/web/javascript/reference/global_objects/string/match/index.md
@@ -7,7 +7,7 @@ browser-compat: javascript.builtins.String.match
 
 {{JSRef}}
 
-Метод **`match()`** (парувати, шукати збіг) отримує результат зіставлення рядка з [регулярним виразом](/uk/docs/Web/JavaScript/Guide/Regular_Expressions).
+Метод **`match()`** (парувати, шукати збіг) отримує результат зіставлення рядка з [регулярним виразом](/uk/docs/Web/JavaScript/Guide/Regular_expressions).
 
 {{EmbedInteractiveExample("pages/js/string-match.html", "shorter")}}
 
@@ -83,7 +83,7 @@ console.log(matches);
 // ['A', 'B', 'C', 'D', 'E', 'a', 'b', 'c', 'd', 'e']
 ```
 
-> **Примітка:** також зверніть увагу на метод {{jsxref("String.prototype.matchAll()")}} та [Розширений пошук з прапорцями](/uk/docs/Web/JavaScript/Guide/Regular_Expressions#pohlyblenyi-poshuk-z-poznachkamy).
+> **Примітка:** також зверніть увагу на метод {{jsxref("String.prototype.matchAll()")}} та [Розширений пошук з прапорцями](/uk/docs/Web/JavaScript/Guide/Regular_expressions#pohlyblenyi-poshuk-z-poznachkamy).
 
 ### Застосування іменованих груп захоплення
 
@@ -144,7 +144,7 @@ str3.match(null); // повертає ["null"]
 console.log("123".match("1.3")); // [ "123" ]
 ```
 
-Є збіг, тому що `.` в регулярному виразі дає збіг з усіма символами. Щоб змусити `.` давати збіг лише з символом крапки, треба екранувати введення.
+Є збіг, тому що `.` в регулярному виразі дає збіг з будь-яким символом. Щоб змусити `.` давати збіг лише з символом крапки, треба екранувати введення.
 
 ```js
 console.log("123".match("1\\.3")); // null


### PR DESCRIPTION
Оригінальний вміст: [String.prototype.match()@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Global_Objects/String/match), [сирці String.prototype.match()@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/global_objects/string/match/index.md)

Нові зміни:
- [mdn/content@8a6bfb2](https://github.com/mdn/content/commit/8a6bfb2736b78904e81c94b82f86278031e65c80)
- [mdn/content@d85a7ba](https://github.com/mdn/content/commit/d85a7ba8cca98c2f6cf67a0c44f0ffd467532f20)