### PR TITLE
update(JS): web/javascript/reference/global_objects/string/touppercase

### DIFF
--- a/files/uk/web/javascript/reference/global_objects/string/touppercase/index.md
+++ b/files/uk/web/javascript/reference/global_objects/string/touppercase/index.md
@@ -21,11 +21,6 @@ toUpperCase()
 
 Новий рядок, що містить значення рядка, на якому було викликано метод, переведене у верхній регістр.
 
-### Винятки
-
-- {{jsxref("TypeError")}}
-  - : Коли викликається на значеннях [`null`](/uk/docs/Web/JavaScript/Reference/Operators/null) чи {{jsxref("undefined")}}, наприклад, `String.prototype.toUpperCase.call(undefined)`.
-
 ## Опис
 
 Метод `toUpperCase()` повертає значення рядка, переведене у верхній регістр. Цей метод не впливає на значення початкового рядка, оскільки рядки в JavaScript є незмінними.


### PR DESCRIPTION
Оригінальний вміст: [String.prototype.toUpperCase()@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Global_Objects/String/toUpperCase), [сирці String.prototype.toUpperCase()@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/global_objects/string/touppercase/index.md)

Нові зміни:
- [mdn/content@a92a2bb](https://github.com/mdn/content/commit/a92a2bb31cf5d79808878701f0344a4eabf12963)