### PR TITLE
update(CSS): web/css/value_definition_syntax

### DIFF
--- a/files/uk/web/css/value_definition_syntax/index.md
+++ b/files/uk/web/css/value_definition_syntax/index.md
@@ -414,7 +414,7 @@ _Помножувач оклику_ після групи вказує, що г�
   - [Синтаксис CSS](/uk/docs/Web/CSS/Syntax)
   - [Коментарі](/uk/docs/Web/CSS/Comments)
   - [Специфічність](/uk/docs/Web/CSS/Specificity)
-  - [Успадкування](/uk/docs/Web/CSS/inheritance)
+  - [Успадкування](/uk/docs/Web/CSS/Inheritance)
   - [Рамкова модель](/uk/docs/Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model)
   - [Способи компонування](/uk/docs/Web/CSS/Layout_mode)
   - [Моделі візуального форматування](/uk/docs/Web/CSS/Visual_formatting_model)


### PR DESCRIPTION
Оригінальний вміст: [Синтаксис визначення значення@MDN](https://developer.mozilla.org/en-us/docs/Web/CSS/Value_definition_syntax), [сирці Синтаксис визначення значення@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/css/value_definition_syntax/index.md)

Нові зміни:
- [mdn/content@13c58b0](https://github.com/mdn/content/commit/13c58b0430c3972566ea2d3a254129c18b1ed800)