### PR TITLE
update(JS): web/javascript/reference/global_objects/regexp/lastindex

### DIFF
--- a/files/uk/web/javascript/reference/global_objects/regexp/lastindex/index.md
+++ b/files/uk/web/javascript/reference/global_objects/regexp/lastindex/index.md
@@ -2,12 +2,6 @@
 title: "RegExp: lastIndex"
 slug: Web/JavaScript/Reference/Global_Objects/RegExp/lastIndex
 page-type: javascript-instance-data-property
-tags:
-  - JavaScript
-  - Property
-  - Reference
-  - RegExp
-  - Regular Expressions
 browser-compat: javascript.builtins.RegExp.lastIndex
 ---
 


### PR DESCRIPTION
Оригінальний вміст: [RegExp: lastIndex@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Global_Objects/RegExp/lastIndex), [сирці RegExp: lastIndex@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/global_objects/regexp/lastindex/index.md)

Нові зміни:
- [mdn/content@f3df525](https://github.com/mdn/content/commit/f3df52530f974e26dd3b14f9e8d42061826dea20)
- [mdn/content@d61bfb9](https://github.com/mdn/content/commit/d61bfb9ae59aabab7ac17ba345035e260f28fc83)