### PR TITLE
update(JS): web/javascript/reference/global_objects/string/repeat

### DIFF
--- a/files/uk/web/javascript/reference/global_objects/string/repeat/index.md
+++ b/files/uk/web/javascript/reference/global_objects/string/repeat/index.md
@@ -28,8 +28,8 @@ repeat(count)
 
 ### Винятки
 
-- {{jsxref("Errors/Negative_repetition_count", "RangeError")}}: вказана кількість повторів має бути невід'ємним числом.
-- {{jsxref("Errors/Resulting_string_too_large", "RangeError")}}: вказана кількість повторів має бути скінченною, і не повинна переповнювати максимальний розмір рядка.
+- {{jsxref("RangeError")}}
+  - : Викидається, коли `count` є від'ємним, або коли `count` перевищує максимальну довжину рядка.
 
 ## Приклади
 


### PR DESCRIPTION
Оригінальний вміст: [String.prototype.repeat()@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Global_Objects/String/repeat), [сирці String.prototype.repeat()@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/global_objects/string/repeat/index.md)

Нові зміни:
- [mdn/content@a92a2bb](https://github.com/mdn/content/commit/a92a2bb31cf5d79808878701f0344a4eabf12963)