### PR TITLE
update(HTML): web/html/element/textarea

### DIFF
--- a/files/uk/web/html/element/textarea/index.md
+++ b/files/uk/web/html/element/textarea/index.md
@@ -285,7 +285,6 @@ textarea:valid {
 - {{HTMLElement("optgroup")}}
 - {{HTMLElement("option")}}
 - {{HTMLElement("input")}}
-- {{HTMLElement("keygen")}}
 - {{HTMLElement("fieldset")}}
 - {{HTMLElement("output")}}
 - {{HTMLElement("progress")}}


### PR DESCRIPTION
Оригінальний вміст: [&lt;textarea>: Елемент текстової області@MDN](https://developer.mozilla.org/en-us/docs/Web/HTML/Element/textarea), [сирці &lt;textarea>: Елемент текстової області@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/html/element/textarea/index.md)

Нові зміни:
- [mdn/content@c302e71](https://github.com/mdn/content/commit/c302e71520c9df718363d8ce81d93568ff84be14)