### PR TITLE
update(JS): web/javascript/reference/global_objects/string/replaceall

### DIFF
--- a/files/uk/web/javascript/reference/global_objects/string/replaceall/index.md
+++ b/files/uk/web/javascript/reference/global_objects/string/replaceall/index.md
@@ -23,7 +23,7 @@ replaceAll(pattern, replacement)
 
   - : може бути рядком чи об'єктом з методом [`Symbol.replace`](/uk/docs/Web/JavaScript/Reference/Global_Objects/Symbol/replace) – типовим зразком чого є [регулярні вирази](/uk/docs/Web/JavaScript/Reference/Global_Objects/RegExp). Будь-яке значення, котре не має метода `Symbol.replace`, буде зведено до рядка.
 
-    Якщо `pattern` [є регулярним виразом](/uk/docs/Web/JavaScript/Reference/Global_Objects/String/includes), то він мусить мати позначку глобальності (`g`), інакше – буде викинуто {{jsxref("TypeError")}}.
+    Якщо `pattern` [є регулярним виразом](/uk/docs/Web/JavaScript/Reference/Global_Objects/RegExp#osoblyva-obrobka-rehuliarnykh-vyraziv), то він мусить мати позначку глобальності (`g`), інакше – буде викинуто {{jsxref("TypeError")}}.
 
 - `replacement` (заміна)
   - : Може бути рядком чи функцією. Заміна має таку само семантику, як для [`String.prototype.replace()`](/uk/docs/Web/JavaScript/Reference/Global_Objects/String/replace).


### PR DESCRIPTION
Оригінальний вміст: [String.prototype.replaceAll()@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Global_Objects/String/replaceAll), [сирці String.prototype.replaceAll()@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/global_objects/string/replaceall/index.md)

Нові зміни:
- [mdn/content@6e3889b](https://github.com/mdn/content/commit/6e3889be77fa45d5823216d0cc61b4f7c4b99e1b)