### PR TITLE
update(JS): web/javascript/reference/operators/typeof

### DIFF
--- a/files/uk/web/javascript/reference/operators/typeof/index.md
+++ b/files/uk/web/javascript/reference/operators/typeof/index.md
@@ -132,7 +132,7 @@ typeof func; // 'function'
 
 ### Потреба в дужках в синтаксисі
 
-Оператор `typeof` має вищий [пріоритет](/uk/docs/Web/JavaScript/Reference/Operators/Operator_Precedence), ніж бінарні оператори типу оператора додавання (`+`). Таким чином, для обчислення типу результату додавання необхідні дужки.
+Оператор `typeof` має вищий [пріоритет](/uk/docs/Web/JavaScript/Reference/Operators/Operator_precedence), ніж бінарні оператори типу оператора додавання (`+`). Таким чином, для обчислення типу результату додавання необхідні дужки.
 
 ```js
 // За допомогою дужок можна визначати тип даних цілих виразів.
@@ -150,7 +150,7 @@ typeof (someData + " Wisen"); // 'string'
 typeof undeclaredVariable; // "undefined"
 ```
 
-Проте застосування `typeof` на лексичних оголошеннях ({{JSxRef("Statements/let", "let")}} {{JSxRef("Statements/const", "const")}} і [`class`](/uk/docs/Web/JavaScript/Reference/Statements/class)), в одному блоці перед рядком оголошення, викине {{JSxRef("ReferenceError")}}. Змінні блокової видимості перебувають у _[темпоральній мертвій зоні](/uk/docs/Web/JavaScript/Reference/Statements/let#temporalna-mertva-zona-tmz)_ від початку блока до обробки ініціалізації, протягом чого така змінна викине помилку, якщо спробувати до неї звернутися.
+Проте застосування `typeof` на лексичних оголошеннях ({{JSxRef("Statements/let", "let")}} {{JSxRef("Statements/const", "const")}} і [`class`](/uk/docs/Web/JavaScript/Reference/Statements/class)), в одному блоці перед рядком оголошення, викине {{JSxRef("ReferenceError")}}. Змінні блокової видимості перебувають у _[темпоральній мертвій зоні](/uk/docs/Web/JavaScript/Reference/Statements/let#temporalna-mertva-zona-tdz)_ від початку блока до обробки ініціалізації, протягом чого така змінна викине помилку, якщо спробувати до неї звернутися.
 
 ```js example-bad
 typeof newLetVariable; // ReferenceError


### PR DESCRIPTION
Оригінальний вміст: [typeof@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Operators/typeof), [сирці typeof@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/operators/typeof/index.md)

Нові зміни:
- [mdn/content@d85a7ba](https://github.com/mdn/content/commit/d85a7ba8cca98c2f6cf67a0c44f0ffd467532f20)