### PR TITLE
update(JS): web/javascript/reference/global_objects/array/shift

### DIFF
--- a/files/uk/web/javascript/reference/global_objects/array/shift/index.md
+++ b/files/uk/web/javascript/reference/global_objects/array/shift/index.md
@@ -41,7 +41,7 @@ shift()
 ```js
 const myFish = ["янгол", "клоун", "мандаринка", "осетер"];
 
-console.log("myFish до:", JSON.stringify(myFish));
+console.log("myFish до:", myFish);
 // myFish до: ['янгол', 'клоун', 'мандаринка', 'осетер'];
 
 const shifted = myFish.shift();
@@ -97,7 +97,10 @@ console.log(plainObj);
 
 ## Дивіться також
 
+- [Колекції з індексами](/uk/docs/Web/JavaScript/Guide/Indexed_collections)
+- {{jsxref("Array")}}
 - {{jsxref("Array.prototype.push()")}}
 - {{jsxref("Array.prototype.pop()")}}
 - {{jsxref("Array.prototype.unshift()")}}
 - {{jsxref("Array.prototype.concat()")}}
+- {{jsxref("Array.prototype.splice()")}}


### PR DESCRIPTION
Оригінальний вміст: [Array.prototype.shift()@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Global_Objects/Array/shift), [сирці Array.prototype.shift()@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/global_objects/array/shift/index.md)

Нові зміни:
- [mdn/content@a0d8bf7](https://github.com/mdn/content/commit/a0d8bf75a0161ea0b1853c16b7a303e210a89264)
- [mdn/content@34a34be](https://github.com/mdn/content/commit/34a34bee83fb4accf073ebc0c8cfc8eff956dc9b)