### PR TITLE
update(JS): web/javascript/reference/global_objects/date/now

### DIFF
--- a/files/uk/web/javascript/reference/global_objects/date/now/index.md
+++ b/files/uk/web/javascript/reference/global_objects/date/now/index.md
@@ -25,7 +25,7 @@ Date.now()
 
 ### Знижена точність часу
 
-Для забезпечення захисту від часових атак і [створення цифрових відбитків](/uk/docs/Glossary/Fingerprinting), точні значення `Date.now()` можуть заокруглюватись залежно від налаштувань браузера. Наприклад, у Firefox опція `privacy.reduceTimerPrecision` — усталено ввімкнена, і усталено дорівнює 20 мкс у Firefox. Також можна увімкнути `privacy.resistFingerprinting`, і в цьому випадку точність дорівнюватиме 100 мс або значенню `privacy.resistFingerprinting.reduceTimerPrecision.microseconds` — тому з них, яке буде більшим.
+Для забезпечення захисту від часових атак і [створення цифрових відбитків](/uk/docs/Glossary/Fingerprinting), точні значення `Date.now()` можуть заокруглюватись залежно від налаштувань браузера. Наприклад, у Firefox опція `privacy.reduceTimerPrecision` — усталено ввімкнена, і усталено дорівнює 20 мкс у Firefox. Також можна увімкнути `privacy.resistFingerprinting`, і в цьому випадку точність дорівнюватиме 100 мс або значенню `privacy.resistFingerprinting.reduceTimerPrecision.microseconds` — залежно від того, яке з цих значень більше.
 
 ```js
 // знижена точність часу (2мс) у Firefox 60

--- a/files/uk/web/javascript/reference/global_objects/date/now/index.md
+++ b/files/uk/web/javascript/reference/global_objects/date/now/index.md
@@ -7,7 +7,7 @@ browser-compat: javascript.builtins.Date.now
 
 {{JSRef}}
 
-Статичний метод **`Date.now()`** (зараз) повертає число мілісекунд, що сплили від початку [епохи](/uk/docs/Web/JavaScript/Reference/Global_Objects/Date#epokha-ecmascript-i-mitky-chasu), котрий визначений як північ на початку 1 січня 1970 року за Всесвітнім координованим часом.
+Статичний метод **`Date.now()`** (зараз) повертає число мілісекунд, що сплили від початку [епохи](/uk/docs/Web/JavaScript/Reference/Global_Objects/Date#epokha-mitky-chasu-ta-nediisna-data), котрий визначений як північ на початку 1 січня 1970 року за Всесвітнім координованим часом.
 
 {{EmbedInteractiveExample("pages/js/date-now.html")}}
 
@@ -19,13 +19,13 @@ Date.now()
 
 ### Повернене значення
 
-Число, котре позначає число мілісекунд, яке сплило від початку [епохи](/uk/docs/Web/JavaScript/Reference/Global_Objects/Date#epokha-ecmascript-i-mitky-chasu), котрий визначено як північ на початку 1 січня 1970 року за Всесвітнім координованим часом.
+Число, котре представляє [мітку часу](/uk/docs/Web/JavaScript/Reference/Global_Objects/Date#epokha-mitky-chasu-ta-nediisna-data) поточної миті в мілісекундах.
 
-## Приклади
+## Опис
 
 ### Знижена точність часу
 
-Для забезпечення захисту від часових атак і [створення цифрових відбитків](/uk/docs/Glossary/Fingerprinting), точні значення `Date.now()` можуть заокруглюватись залежно від налаштувань браузера. Наприклад, у Firefox опція `privacy.reduceTimerPrecision` — усталено ввімкнена, і усталено дорівнює 20 мкс у версії Firefox 59; у версії 60 вона дорівнює вже 2 мс.
+Для забезпечення захисту від часових атак і [створення цифрових відбитків](/uk/docs/Glossary/Fingerprinting), точні значення `Date.now()` можуть заокруглюватись залежно від налаштувань браузера. Наприклад, у Firefox опція `privacy.reduceTimerPrecision` — усталено ввімкнена, і усталено дорівнює 20 мкс у Firefox. Також можна увімкнути `privacy.resistFingerprinting`, і в цьому випадку точність дорівнюватиме 100 мс або значенню `privacy.resistFingerprinting.reduceTimerPrecision.microseconds` — тому з них, яке буде більшим.
 
 ```js
 // знижена точність часу (2мс) у Firefox 60
@@ -43,7 +43,19 @@ Date.now();
 // …
 ```
 
-У Firefox також можна увімкнути `privacy.resistFingerprinting`, і в цьому випадку точність дорівнюватиме 100 мс або значенню `privacy.resistFingerprinting.reduceTimerPrecision.microseconds` — тому з них, яке буде більшим.
+## Приклади
+
+### Вимірювання часу, що минув
+
+`Date.now()` можна скористатися, щоб отримати поточний час у мілісекундах, а потім відняти попередній час, щоб дізнатися, скільки часу минуло між двома викликами.
+
+```js
+const start = Date.now();
+doSomeLongRunningProcess();
+console.log(`Time elapsed: ${Date.now() - start} ms`);
+```
+
+Для складніших сценаріїв можна замість цього скористатися [API продуктивності](/uk/docs/Web/API/Performance_API/High_precision_timing).
 
 ## Специфікації
 
@@ -55,6 +67,7 @@ Date.now();
 
 ## Дивіться також
 
-- [Поліфіл для `Date.now` у `core-js`](https://github.com/zloirock/core-js#ecmascript-date)
-- {{domxref("Performance.now()")}} — надає відмітки часу із субмілісекундною роздільною здатністю, для застосування з метою вимірювання продуктивності вебсторінок
-- {{domxref("console.time()")}} / {{domxref("console.timeEnd()")}}
+- [Поліфіл `Date.now` у складі `core-js`](https://github.com/zloirock/core-js#ecmascript-date)
+- {{domxref("Performance.now()")}}
+- {{domxref("console.time()")}}
+- {{domxref("console.timeEnd()")}}


### PR DESCRIPTION
Оригінальний вміст: [Date.now()@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Global_Objects/Date/now), [сирці Date.now()@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/global_objects/date/now/index.md)

Нові зміни:
- [mdn/content@3e2369d](https://github.com/mdn/content/commit/3e2369d97e2d6fbfe33a3c496a8edd90e0b539e2)