### PR TITLE
update(JS): web/javascript/reference/global_objects/string/trimend

### DIFF
--- a/files/uk/web/javascript/reference/global_objects/string/trimend/index.md
+++ b/files/uk/web/javascript/reference/global_objects/string/trimend/index.md
@@ -1,24 +1,19 @@
 ---
 title: String.prototype.trimEnd()
 slug: Web/JavaScript/Reference/Global_Objects/String/trimEnd
-tags:
-  - JavaScript
-  - Method
-  - Prototype
-  - Reference
-  - String
-  - Polyfill
+page-type: javascript-instance-method
 browser-compat: javascript.builtins.String.trimEnd
 ---
+
 {{JSRef}}
 
-Метод **`trimEnd()`** видаляє пробільні символи з кінця рядка. Для цього методу також існує псевдонім `trimRight()`.
+Метод **`trimEnd()`** (обітнути кінець) видаляє пробільні символи з кінця рядка та повертає новий рядок, не змінюючи вихідний. Для цього методу також існує псевдонім `trimRight()`.
 
 {{EmbedInteractiveExample("pages/js/string-trimend.html")}}
 
 ## Синтаксис
 
-```js
+```js-nolint
 trimEnd()
 
 trimRight()
@@ -26,13 +21,13 @@ trimRight()
 
 ### Повернене значення
 
-Новий рядок, що містить значення початкового рядка `str`, у якого пробільні символи в кінці (з правого боку) — обрізані.
+Новий рядок, що містить значення початкового рядка `str`, у якого пробільні символи в кінці (з правого боку) — обрізані. Пробільні символи визначені як символи-[пробіли](/uk/docs/Web/JavaScript/Reference/Lexical_grammar#probily) плюс [символи кінця рядка](/uk/docs/Web/JavaScript/Reference/Lexical_grammar#symvoly-kintsia-riadka).
 
-Якщо кінець рядка `str` не містить пробільних символів, однаково повертається новий рядок (практично — копія рядка `str`), без викидання жодних винятків.
+Якщо кінець рядка `str` не містить пробільних символів, однаково повертається новий рядок (практично — копія рядка `str`).
 
 ### Вживання псевдонімів
 
-Для одноманітності з функціями, подібними до {{jsxref("String.prototype.padEnd")}}, функція має стандартизоване ім'я `trimEnd`. Щоправда, з міркувань сумісності вебу, метод `trimRight` залишається псевдонімом для `trimEnd`. В деяких рушіях це буквально означає:
+Після того, як метод {{jsxref("String/trim", "trim()")}} був стандартизований, рушії також реалізували нестандартний метод `trimRight`. Проте, заради одноманітності з {{jsxref("String/padEnd", "padEnd()")}}, коли цей метод було стандартизовано, було обрано назву `trimEnd`. У зв'язку з міркуваннями вебсумісності `trimRight` залишається псевдонімом `trimEnd`, і вони посилаються на той самий об'єкт-функцію. У деяких рушіях це означає:
 
 ```js
 String.prototype.trimRight.name === "trimEnd";
@@ -42,16 +37,17 @@ String.prototype.trimRight.name === "trimEnd";
 
 ### Застосування trimEnd()
 
-Наступний приклад виводить рядок `' foo'` в нижньому регістрі:
+Наступний приклад обтинає пробіли на кінці `str`, але не на початку.
 
 ```js
-var str = '   foo  ';
+<!-- markdownlint-disable-next-line -->
+let str = "   foo  ";
 
 console.log(str.length); // 8
 
 str = str.trimEnd();
 console.log(str.length); // 6
-console.log(str);        // '   foo'
+console.log(str); // '   foo'
 ```
 
 ## Специфікації


### PR DESCRIPTION
Оригінальний вміст: [String.prototype.trimEnd()@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Global_Objects/String/trimEnd), [сирці String.prototype.trimEnd()@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/global_objects/string/trimend/index.md)

Нові зміни:
- [mdn/content@f3df525](https://github.com/mdn/content/commit/f3df52530f974e26dd3b14f9e8d42061826dea20)
- [mdn/content@2eb202a](https://github.com/mdn/content/commit/2eb202adbe3d83292500ed46344d63fbbae410b5)
- [mdn/content@f979062](https://github.com/mdn/content/commit/f979062e46775350f739d13459a178d7402d6d8a)
- [mdn/content@cdc8fd7](https://github.com/mdn/content/commit/cdc8fd7feab0cf6fab5512b4847e420094302271)
- [mdn/content@ce29091](https://github.com/mdn/content/commit/ce2909126eb09e44c9f48d9f65d072acae827749)
- [mdn/content@968e6f1](https://github.com/mdn/content/commit/968e6f1f3b6f977a09e116a0ac552459b741eac3)
- [mdn/content@673f963](https://github.com/mdn/content/commit/673f9631dca2d92f0b987193d39f49cbf840347e)