### PR TITLE
update(JS): web/javascript/reference/template_literals

### DIFF
--- a/files/uk/web/javascript/reference/template_literals/index.md
+++ b/files/uk/web/javascript/reference/template_literals/index.md
@@ -354,4 +354,4 @@ const bad = `неправильна екранована послідовніс�
 - {{jsxref("String")}}
 - {{jsxref("String.raw()")}}
 - [Лексична граматика](/uk/docs/Web/JavaScript/Reference/Lexical_grammar)
-- [Поглиблено про ES6: Шаблонні рядки](https://hacks.mozilla.org/2015/05/es6-in-depth-template-strings-2/) на hacks.mozilla.org (14 травня 2015 року)
+- [Поглиблено про ES6: Шаблонні рядки](https://hacks.mozilla.org/2015/05/es6-in-depth-template-strings-2/) на hacks.mozilla.org (2015)


### PR DESCRIPTION
Оригінальний вміст: [Шаблонні літерали (Шаблонні рядки)@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Template_literals), [сирці Шаблонні літерали (Шаблонні рядки)@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/template_literals/index.md)

Нові зміни:
- [mdn/content@3c33463](https://github.com/mdn/content/commit/3c33463072905e81ac620dd9780313369029b498)