### PR TITLE
update(JS): web/javascript/reference/operators/await

### DIFF
--- a/files/uk/web/javascript/reference/operators/await/index.md
+++ b/files/uk/web/javascript/reference/operators/await/index.md
@@ -344,4 +344,4 @@ withAwait();
 - {{jsxref("Statements/async_function", "async function")}}
 - [Вираз `async function`](/uk/docs/Web/JavaScript/Reference/Operators/async_function)
 - {{jsxref("AsyncFunction")}}
-- [await зовнішнього рівня](https://v8.dev/features/top-level-await) на v8.dev (8 жовтня 2019 року)
+- [await зовнішнього рівня](https://v8.dev/features/top-level-await) на v8.dev (2019)


### PR DESCRIPTION
Оригінальний вміст: [await@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Operators/await), [сирці await@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/operators/await/index.md)

Нові зміни:
- [mdn/content@3c33463](https://github.com/mdn/content/commit/3c33463072905e81ac620dd9780313369029b498)