### PR TITLE
update(CSS): web/css/grid-template-columns

### DIFF
--- a/files/uk/web/css/grid-template-columns/index.md
+++ b/files/uk/web/css/grid-template-columns/index.md
@@ -87,9 +87,9 @@ grid-template-columns: unset;
 
 - {{cssxref("repeat", "repeat( [ &lt;positive-integer&gt; | auto-fill | auto-fit ] , &lt;track-list&gt; )")}}
   - : Представляє повторюваний фрагмент списку доріжки й дає змогу визначити багато колонок, що утворюють циклічний патерн, у більш компактному вигляді.
-- [`masonry`](/uk/docs/Web/CSS/CSS_Grid_Layout/Masonry_Layout) {{Experimental_Inline}}
+- [`masonry`](/uk/docs/Web/CSS/CSS_grid_layout/Masonry_layout) {{Experimental_Inline}}
   - : Значення masonry вказує на те, що ця вісь повинна компонуватися згідно з алгоритмом кладки.
-- [`subgrid`](/uk/docs/Web/CSS/CSS_Grid_Layout/Subgrid)
+- [`subgrid`](/uk/docs/Web/CSS/CSS_grid_layout/Subgrid)
   - : Значення `subgrid` вказує на те, що сітка займе за цією віссю розширену частку своєї батьківської сітки. Замість явного задання, розміри рядів і колонок сітки будуть взяті з означення батьківської сітки.
 
 > **Застереження:** Значення `masonry` походить із Рівня 3 Специфікації сітки й наразі має лише експериментальну реалізацію в Firefox, приховану за прапорцем.
@@ -150,6 +150,6 @@ grid-template-columns: unset;
 ## Дивіться також
 
 - Пов'язані властивості CSS: {{cssxref("grid-template-rows")}}, {{cssxref("grid-template-areas")}}, {{cssxref("grid-template")}}
-- Посібник з сіткового компонування: _[Базові концепції сіткового компонування – сіткові доріжки](/uk/docs/Web/CSS/CSS_Grid_Layout/Basic_Concepts_of_Grid_Layout#sitkovi-dorizhky)_
+- Посібник з сіткового компонування: _[Базові концепції сіткового компонування – сіткові доріжки](/uk/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#sitkovi-dorizhky)_
 - Відеоурок: _[Визначення сітки (англ.)](https://gridbyexample.com/video/series-define-a-grid/)_
-- [Subgrid](/uk/docs/Web/CSS/CSS_Grid_Layout/Subgrid)
+- [Subgrid](/uk/docs/Web/CSS/CSS_grid_layout/Subgrid)


### PR DESCRIPTION
Оригінальний вміст: [grid-template-columns@MDN](https://developer.mozilla.org/en-us/docs/Web/CSS/grid-template-columns), [сирці grid-template-columns@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/css/grid-template-columns/index.md)

Нові зміни:
- [mdn/content@5e7d1f9](https://github.com/mdn/content/commit/5e7d1f9ae2cce0cb3f7693dfb8dc6e8d375b2231)