### PR TITLE
update(JS): web/javascript/reference/errors/not_defined

### DIFF
--- a/files/uk/web/javascript/reference/errors/not_defined/index.md
+++ b/files/uk/web/javascript/reference/errors/not_defined/index.md
@@ -10,7 +10,7 @@ page-type: javascript-error
 
 ## Повідомлення
 
-```
+```plain
 ReferenceError: "x" is not defined (браузери на основі V8 і Firefox)
 ReferenceError: Can't find variable: x (Safari)
 ```


### PR DESCRIPTION
Оригінальний вміст: [ReferenceError: "x" is not defined@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Errors/Not_defined), [сирці ReferenceError: "x" is not defined@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/errors/not_defined/index.md)

Нові зміни:
- [mdn/content@6d60617](https://github.com/mdn/content/commit/6d606174faaedaa5dee7b7ebd87602cd51e5dd7e)
- [mdn/content@d3ecccf](https://github.com/mdn/content/commit/d3ecccf144b2e051f57dc49b141e46250b95d783)
- [mdn/content@942a529](https://github.com/mdn/content/commit/942a529383ee7ee3996fb234187641c08935f3ff)