### PR TITLE
update(JS): web/javascript/reference/global_objects/math/max

### DIFF
--- a/files/uk/web/javascript/reference/global_objects/math/max/index.md
+++ b/files/uk/web/javascript/reference/global_objects/math/max/index.md
@@ -17,7 +17,7 @@ browser-compat: javascript.builtins.Math.max
 Math.max()
 Math.max(value0)
 Math.max(value0, value1)
-Math.max(value0, value1, /* … ,*/ valueN)
+Math.max(value0, value1, /* …, */ valueN)
 ```
 
 ### Параметри


### PR DESCRIPTION
Оригінальний вміст: [Math.max()@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Global_Objects/Math/max), [сирці Math.max()@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/global_objects/math/max/index.md)

Нові зміни:
- [mdn/content@542ef6c](https://github.com/mdn/content/commit/542ef6cfd82288925e0a9238b47933f03e2dddca)