### PR TITLE
update(JS): web/javascript/reference/global_objects/array/splice

### DIFF
--- a/files/uk/web/javascript/reference/global_objects/array/splice/index.md
+++ b/files/uk/web/javascript/reference/global_objects/array/splice/index.md
@@ -18,9 +18,9 @@ browser-compat: javascript.builtins.Array.splice
 ```js-nolint
 splice(start)
 splice(start, deleteCount)
-splice(start, deleteCount, item0)
-splice(start, deleteCount, item0, item1)
-splice(start, deleteCount, item0, item1, /* …, */ itemN)
+splice(start, deleteCount, item1)
+splice(start, deleteCount, item1, item2)
+splice(start, deleteCount, item1, item2, /* …, */ itemN)
 ```
 
 ### Параметри
@@ -41,7 +41,7 @@ splice(start, deleteCount, item0, item1, /* …, */ itemN)
 
     Якщо `deleteCount` — `0` або від'ємне число, жоден елемент не видалиться. В цьому випадку необхідно вказати принаймні один новий елемент (див. далі).
 
-- `item0`, …, `itemN` {{optional_inline}}
+- `item1`, …, `itemN` {{optional_inline}}
   - : Елементи, які буде додано до масиву, починаючи з індексу `start`.
     Якщо не вказано жодного, `splice()` лише видалить елементи з масиву.
 

--- a/files/uk/web/javascript/reference/global_objects/array/splice/index.md
+++ b/files/uk/web/javascript/reference/global_objects/array/splice/index.md
@@ -7,7 +7,7 @@ browser-compat: javascript.builtins.Array.splice
 
 {{JSRef}}
 
-Метод **`splice()`** (зростити) змінює вміст масиву шляхом видалення чи заміни наявних елементів і/або додавання нових [на місці (англ.)](https://en.wikipedia.org/wiki/In-place_algorithm).
+Метод **`splice()`** (зростити) примірників {{jsxref("Array")}} змінює вміст масиву шляхом видалення чи заміни наявних елементів чи додавання нових [на місці](https://en.wikipedia.org/wiki/In-place_algorithm).
 
 Щоб створити новий масив, в якому частина видалена чи замінена, не змінюючи вихідний масив, слід скористатися {{jsxref("Array/toSpliced", "toSpliced()")}}. Щоб отримати доступ до частини масиву без його зміни, дивіться {{jsxref("Array.prototype.slice()", "slice()")}}.
 

--- a/files/uk/web/javascript/reference/global_objects/array/splice/index.md
+++ b/files/uk/web/javascript/reference/global_objects/array/splice/index.md
@@ -20,7 +20,7 @@ splice(start)
 splice(start, deleteCount)
 splice(start, deleteCount, item0)
 splice(start, deleteCount, item0, item1)
-splice(start, deleteCount, item0, item1, /* … ,*/ itemN)
+splice(start, deleteCount, item0, item1, /* …, */ itemN)
 ```
 
 ### Параметри


### PR DESCRIPTION
Оригінальний вміст: [Array.prototype.splice()@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Global_Objects/Array/splice), [сирці Array.prototype.splice()@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/global_objects/array/splice/index.md)

Нові зміни:
- [mdn/content@88d71e5](https://github.com/mdn/content/commit/88d71e500938fa8ca969fe4fe3c80a5abe23d767)
- [mdn/content@b7ca46c](https://github.com/mdn/content/commit/b7ca46c94631967ecd9ce0fe36579be334a01275)
- [mdn/content@542ef6c](https://github.com/mdn/content/commit/542ef6cfd82288925e0a9238b47933f03e2dddca)