### PR TITLE
update(JS): web/javascript/reference/global_objects/array/concat

### DIFF
--- a/files/uk/web/javascript/reference/global_objects/array/concat/index.md
+++ b/files/uk/web/javascript/reference/global_objects/array/concat/index.md
@@ -17,7 +17,7 @@ browser-compat: javascript.builtins.Array.concat
 concat()
 concat(value0)
 concat(value0, value1)
-concat(value0, value1, /* … ,*/ valueN)
+concat(value0, value1, /* …, */ valueN)
 ```
 
 ### Параметри
@@ -129,7 +129,13 @@ console.log([1, 2].concat([3, , 5])); // [1, 2, 3, порожньо, 5]
 ```js
 console.log(Array.prototype.concat.call({}, 1, 2, 3)); // [{}, 1, 2, 3]
 console.log(Array.prototype.concat.call(1, 2, 3)); // [ [Number: 1], 2, 3 ]
-const arrayLike = { [Symbol.isConcatSpreadable]: true, length: 2, 0: 1, 1: 2 };
+const arrayLike = {
+  [Symbol.isConcatSpreadable]: true,
+  length: 2,
+  0: 1,
+  1: 2,
+  2: 99, // ігнорується concat(), оскільки length – 2
+};
 console.log(Array.prototype.concat.call(arrayLike, 3, 4)); // [1, 2, 3, 4]
 ```
 


### PR DESCRIPTION
Оригінальний вміст: [Array.prototype.concat()@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Global_Objects/Array/concat), [сирці Array.prototype.concat()@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/global_objects/array/concat/index.md)

Нові зміни:
- [mdn/content@542ef6c](https://github.com/mdn/content/commit/542ef6cfd82288925e0a9238b47933f03e2dddca)
- [mdn/content@59c445f](https://github.com/mdn/content/commit/59c445ffa5b31083d0f54ba3ee5788b17b8b8329)