### PR TITLE
update(JS): web/javascript/reference/global_objects/string/split

### DIFF
--- a/files/uk/web/javascript/reference/global_objects/string/split/index.md
+++ b/files/uk/web/javascript/reference/global_objects/string/split/index.md
@@ -7,7 +7,7 @@ browser-compat: javascript.builtins.String.split
 
 {{JSRef}}
 
-Метод **`split()`** (розщепити) приймає патерн і ділить {{jsxref("String", "рядок")}} на впорядкований список підрядків шляхом пошуку переданого патерну, додання підрядків до масиву і повернення цього масиву.
+Метод **`split()`** (розщепити) значень {{jsxref("String")}} приймає патерн і ділить свій рядок на впорядкований список підрядків шляхом пошуку переданого патерну, додання підрядків до масиву і повернення цього масиву.
 
 {{EmbedInteractiveExample("pages/js/string-split.html", "taller")}}
 
@@ -83,7 +83,7 @@ function splitString(stringToSplit, separator) {
     "Масив містить",
     arrayOfStrings.length,
     "елементів:",
-    arrayOfStrings.join(" / ")
+    arrayOfStrings.join(" / "),
   );
 }
 


### PR DESCRIPTION
Оригінальний вміст: [String.prototype.split()@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Global_Objects/String/split), [сирці String.prototype.split()@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/global_objects/string/split/index.md)

Нові зміни:
- [mdn/content@b7ca46c](https://github.com/mdn/content/commit/b7ca46c94631967ecd9ce0fe36579be334a01275)
- [mdn/content@6d60617](https://github.com/mdn/content/commit/6d606174faaedaa5dee7b7ebd87602cd51e5dd7e)