### PR TITLE
update(JS): web/javascript/reference/template_literals

### DIFF
--- a/files/uk/web/javascript/reference/template_literals/index.md
+++ b/files/uk/web/javascript/reference/template_literals/index.md
@@ -186,7 +186,7 @@ console.log(`Привіт``Світ`); // TypeError: "Привіт" is not a fun
 
 Єдиним винятком є необов'язкове зв'язування, котре викине синтаксичну помилку.
 
-```js example-bad
+```js-nolint example-bad
 console.log?.`Привіт`; // SyntaxError: Invalid tagged template on optional chain
 console?.log`Привіт`; // SyntaxError: Invalid tagged template on optional chain
 ```
@@ -290,7 +290,7 @@ console.log(identity`Привіт\n${2 + 3}!`);
 ```js
 const html = (strings, ...values) => String.raw({ raw: strings }, ...values);
 // Певні форматери форматують вміст цього літерала як HTML
-const doc = html`<!DOCTYPE html>
+const doc = html`<!doctype html>
   <html lang="uk">
     <head>
       <title>Привіт</title>
@@ -336,7 +336,7 @@ latex`\unicode`;
 
 Слід зауважити, що обмеження екранованих послідовностей було прибрано лише з _тегованих_ шаблонів, проте в _нетегованих_ літералах вони залишилися:
 
-```js example-bad
+```js-nolint example-bad
 const bad = `неправильна екранована послідовність: \unicode`;
 ```
 

--- a/files/uk/web/javascript/reference/template_literals/index.md
+++ b/files/uk/web/javascript/reference/template_literals/index.md
@@ -193,7 +193,7 @@ console?.log`Привіт`; // SyntaxError: Invalid tagged template on optional 
 
 Зверніть увагу, що ці два вирази усе ж є розбірливими. Це означає, що вони не будуть піддані [автоматичному доданню крапки з комою](/uk/docs/Web/JavaScript/Reference/Lexical_grammar#avtomatychne-vstavliannia-krapok-z-komoiu), котре додає крапку з комою для виправлення коду, котрий без цього є нерозбірливим.
 
-```js example-bad
+```jss-nolint example-bad
 // Усе ж синтаксична помилка
 const a = console?.log
 `Привіт`


### PR DESCRIPTION
Оригінальний вміст: [Шаблонні літерали (Шаблонні рядки)@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Template_literals), [сирці Шаблонні літерали (Шаблонні рядки)@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/template_literals/index.md)

Нові зміни:
- [mdn/content@d71b141](https://github.com/mdn/content/commit/d71b141d2d18b96639547856714df19cefacfebf)
- [mdn/content@4c26e8a](https://github.com/mdn/content/commit/4c26e8a3fb50d06963b06017f51ce19364350564)
- [mdn/content@05218bd](https://github.com/mdn/content/commit/05218bd05ab482d49ca659473851a285bcb104b0)