### PR TITLE
update(JS): web/javascript/reference/global_objects/date/tolocaledatestring

### DIFF
--- a/files/uk/web/javascript/reference/global_objects/date/tolocaledatestring/index.md
+++ b/files/uk/web/javascript/reference/global_objects/date/tolocaledatestring/index.md
@@ -6,7 +6,7 @@ browser-compat: javascript.builtins.Date.toLocaleDateString
 
 {{JSRef}}
 
-Метод **`toLocaleDateString()`** повертає рядок із чутливим до мови відображенням тієї частини вказаної дати, яка містить лише календарну дату, в часовому поясі користувацького агента. В тих реалізаціях, що мають підтримку [API `Intl.DateTimeFormat`](/uk/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat), цей метод просто викликає `Intl.DateTimeFormat`.
+Метод **`toLocaleDateString()`** (до рядка дати згідно з локаллю) примірників {{jsxref("Date")}} повертає рядок із чутливим до мови відображенням тієї частини вказаної дати, яка містить лише календарну дату, в часовій зоні користувацького агента. В тих реалізаціях, що мають підтримку [API `Intl.DateTimeFormat`](/uk/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat), цей метод просто викликає `Intl.DateTimeFormat`.
 
 Під час форматування великої кількості дат, краще створити окремий об'єкт {{jsxref("Intl.DateTimeFormat")}}, і використовувати його метод {{jsxref("Intl/DateTimeFormat/format", "format()")}}.
 


### PR DESCRIPTION
Оригінальний вміст: [Date.prototype.toLocaleDateString()@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleDateString), [сирці Date.prototype.toLocaleDateString()@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/global_objects/date/tolocaledatestring/index.md)

Нові зміни:
- [mdn/content@3cfd663](https://github.com/mdn/content/commit/3cfd663738e9963157d90f359789d675a6662ec2)
- [mdn/content@1794251](https://github.com/mdn/content/commit/1794251e4eb5fc82f37684278272e9db517e666f)
- [mdn/content@b5c766f](https://github.com/mdn/content/commit/b5c766f4eecb4fcf9d8ba175caddb94f7c3e9d20)