### PR TITLE
update(JS): web/javascript/reference/global_objects/date/tolocalestring

### DIFF
--- a/files/uk/web/javascript/reference/global_objects/date/tolocalestring/index.md
+++ b/files/uk/web/javascript/reference/global_objects/date/tolocalestring/index.md
@@ -6,7 +6,7 @@ browser-compat: javascript.builtins.Date.toLocaleString
 
 {{JSRef}}
 
-Метод **`toLocaleString()`** (до рядка згідно з локаллю) повертає рядок з чутливим до мови представленням дати. У реалізаціях без підтримки [API `Intl.DateTimeFormat`](/uk/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat) цей метод просто викликає `Intl.DateTimeFormat`.
+Метод **`toLocaleString()`** (до рядка згідно з локаллю) примірників {{jsxref("Date")}} повертає рядок з чутливим до мови представленням дати. У реалізаціях без підтримки [API `Intl.DateTimeFormat`](/uk/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat) цей метод просто викликає `Intl.DateTimeFormat`.
 
 {{EmbedInteractiveExample("pages/js/date-tolocalestring.html")}}
 


### PR DESCRIPTION
Оригінальний вміст: [Date.prototype.toLocaleString()@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleString), [сирці Date.prototype.toLocaleString()@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/global_objects/date/tolocalestring/index.md)

Нові зміни:
- [mdn/content@3cfd663](https://github.com/mdn/content/commit/3cfd663738e9963157d90f359789d675a6662ec2)