### PR TITLE
update(JS): web/javascript/reference/global_objects/string/includes

### DIFF
--- a/files/uk/web/javascript/reference/global_objects/string/includes/index.md
+++ b/files/uk/web/javascript/reference/global_objects/string/includes/index.md
@@ -7,7 +7,7 @@ browser-compat: javascript.builtins.String.includes
 
 {{JSRef}}
 
-Метод **`includes()`** (включає) виконує чутливий до регістру пошук для визначення, чи можна один рядок знайти всередині іншого, повертаючи `true` або `false` відповідно.
+Метод **`includes()`** (включає) значень {{jsxref("String")}} виконує чутливий до регістру пошук для визначення, чи можна переданий рядок знайти всередині поточного, повертаючи `true` або `false` відповідно.
 
 {{EmbedInteractiveExample("pages/js/string-includes.html", "shorter")}}
 


### PR DESCRIPTION
Оригінальний вміст: [String.prototype.includes()@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Global_Objects/String/includes), [сирці String.prototype.includes()@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/global_objects/string/includes/index.md)

Нові зміни:
- [mdn/content@b7ca46c](https://github.com/mdn/content/commit/b7ca46c94631967ecd9ce0fe36579be334a01275)