### PR TITLE
update(JS): web/javascript/reference/global_objects/string/localecompare

### DIFF
--- a/files/uk/web/javascript/reference/global_objects/string/localecompare/index.md
+++ b/files/uk/web/javascript/reference/global_objects/string/localecompare/index.md
@@ -7,7 +7,7 @@ browser-compat: javascript.builtins.String.localeCompare
 
 {{JSRef}}
 
-Метод **`localeCompare()`** повертає число, яке вказує, чи переданий рядок під час сортування повинен стояти перед, після, або є еквівалентним до початкового рядка. В реалізаціях, що підтримують [API `Intl.Collator`](/uk/docs/Web/JavaScript/Reference/Global_Objects/Intl/Collator), цей метод просто викликає `Intl.Collator`.
+Метод **`localeCompare()`** (порівняти за локаллю) значень {{jsxref("String")}} повертає число, яке вказує, чи переданий рядок під час сортування повинен стояти перед, після, або є еквівалентним до поточного рядка. В реалізаціях, що підтримують [API `Intl.Collator`](/uk/docs/Web/JavaScript/Reference/Global_Objects/Intl/Collator), цей метод просто викликає `Intl.Collator`.
 
 Для порівняння великої кількості рядків (наприклад, під час сортування великих масивів) краще створити окремий об'єкт {{jsxref("Intl.Collator")}} і застосувати функцію, яка надається його методом {{jsxref("Intl/Collator/compare", "compare()")}}.
 


### PR DESCRIPTION
Оригінальний вміст: [String.prototype.localeCompare()@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Global_Objects/String/localeCompare), [сирці String.prototype.localeCompare()@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/global_objects/string/localecompare/index.md)

Нові зміни:
- [mdn/content@b7ca46c](https://github.com/mdn/content/commit/b7ca46c94631967ecd9ce0fe36579be334a01275)