### PR TITLE
update(JS): web/javascript/reference/global_objects/string/repeat

### DIFF
--- a/files/uk/web/javascript/reference/global_objects/string/repeat/index.md
+++ b/files/uk/web/javascript/reference/global_objects/string/repeat/index.md
@@ -7,7 +7,7 @@ browser-compat: javascript.builtins.String.repeat
 
 {{JSRef}}
 
-Метод **`repeat()`** збирає і повертає новий рядок, який містить вказану кількість копій рядка, на якому його було викликано, з'єднаних докупи.
+Метод **`repeat()`** (повторювати) значень {{jsxref("String")}} збирає і повертає новий рядок, який містить вказану кількість копій свого рядка, зчеплену докупи.
 
 {{EmbedInteractiveExample("pages/js/string-repeat.html","shorter")}}
 


### PR DESCRIPTION
Оригінальний вміст: [String.prototype.repeat()@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Global_Objects/String/repeat), [сирці String.prototype.repeat()@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/global_objects/string/repeat/index.md)

Нові зміни:
- [mdn/content@b7ca46c](https://github.com/mdn/content/commit/b7ca46c94631967ecd9ce0fe36579be334a01275)