### PR TITLE
update(JS): web/javascript/reference/operators/optional_chaining

### DIFF
--- a/files/uk/web/javascript/reference/operators/optional_chaining/index.md
+++ b/files/uk/web/javascript/reference/operators/optional_chaining/index.md
@@ -75,7 +75,7 @@ const result = someInterface.customMethod?.();
 
 ### Необов'язковий ланцюжок з виразами
 
-Також оператор необов'язкового ланцюжка можна використовувати вкупі з [записом квадратних дужок](/uk/docs/Web/JavaScript/Reference/Operators/Property_accessors#zapys-kvadratnykh-duzhok), котрий дає змогу передати як ім'я властивості – вираз:
+Також оператор необов'язкового ланцюжка можна використовувати вкупі з [записом квадратних дужок](/uk/docs/Web/JavaScript/Reference/Operators/Property_accessors#duzhkova-notatsiia), котрий дає змогу передати як ім'я властивості – вираз:
 
 ```js
 const nestedProp = obj?.["prop" + "Name"];
@@ -95,7 +95,7 @@ printMagicIndex(); // undefined; якби не ?., тут викинуло б п
 
 Не можна намагатися присвоїти результат виразові необов'язкового ланцюжка:
 
-```js example-bad
+```js-nolint example-bad
 const object = {};
 object?.property = 1; // SyntaxError: Invalid left-hand side in assignment
 ```

--- a/files/uk/web/javascript/reference/operators/optional_chaining/index.md
+++ b/files/uk/web/javascript/reference/operators/optional_chaining/index.md
@@ -238,4 +238,4 @@ printCustomerCity({
 
 ## Дивіться також
 
-- [Оператор null-злиття](/uk/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing)
+- [Оператор null-злиття (`??`)](/uk/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing)


### PR DESCRIPTION
Оригінальний вміст: [Необов'язковий ланцюжок (?.)@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Operators/Optional_chaining), [сирці Необов'язковий ланцюжок (?.)@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/operators/optional_chaining/index.md)

Нові зміни:
- [mdn/content@f616cb6](https://github.com/mdn/content/commit/f616cb604af851f77f8cd59368e94ee3e43a8838)
- [mdn/content@4c26e8a](https://github.com/mdn/content/commit/4c26e8a3fb50d06963b06017f51ce19364350564)
- [mdn/content@5d58478](https://github.com/mdn/content/commit/5d584785ceb6feb0f585597ae29c8bf65d5e1888)