### PR TITLE
update(JS): web/javascript/reference/global_objects/encodeuricomponent

### DIFF
--- a/files/uk/web/javascript/reference/global_objects/encodeuricomponent/index.md
+++ b/files/uk/web/javascript/reference/global_objects/encodeuricomponent/index.md
@@ -93,16 +93,16 @@ function encodeRFC3986URIComponent(str) {
 }
 ```
 
-### Кодування самотнього старшого сурогату викидає помилку
+### Кодування самотнього сурогату викидає помилку
 
 Викидається помилка {{jsxref("URIError")}}, якщо спробувати закодувати сурогат, який не є частиною пари старшого та молодшого сурогатів. Наприклад:
 
 ```js
 // Пара старший-молодший – ОК
 encodeURIComponent("\uD800\uDFFF"); // "%F0%90%8F%BF"
-// Самотній старший сурогат викидає помилку "URIError: malformed URI sequence"
+// Самотня старшосурогатна кодова одиниця викидає помилку "URIError: malformed URI sequence"
 encodeURIComponent("\uD800");
-// Самотній молодший сурогат викидає помилку "URIError: malformed URI sequence"
+// Самотня старшосурогатна кодова одиниця викидає помилку "URIError: malformed URI sequence"
 encodeURIComponent("\uDFFF");
 ```
 


### PR DESCRIPTION
Оригінальний вміст: [encodeURIComponent()@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent), [сирці encodeURIComponent()@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/global_objects/encodeuricomponent/index.md)

Нові зміни:
- [mdn/content@96450d8](https://github.com/mdn/content/commit/96450d8307ee9b78290cbdeea9f93d89efc07c8a)