### PR TITLE
update(JS): web/javascript/reference/global_objects/string/startswith

### DIFF
--- a/files/uk/web/javascript/reference/global_objects/string/startswith/index.md
+++ b/files/uk/web/javascript/reference/global_objects/string/startswith/index.md
@@ -7,7 +7,7 @@ browser-compat: javascript.builtins.String.startsWith
 
 {{JSRef}}
 
-Метод **`startsWith()`** визначає, чи починається рядок символами з рядка-параметра, повертаючи `true` або `false` відповідно.
+Метод **`startsWith()`** (починається з підрядка) значень {{jsxref("String")}} визначає, чи починається його рядок символами з рядка-параметра, повертаючи `true` або `false` відповідно.
 
 {{EmbedInteractiveExample("pages/js/string-startswith.html")}}
 


### PR DESCRIPTION
Оригінальний вміст: [String.prototype.startsWith()@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Global_Objects/String/startsWith), [сирці String.prototype.startsWith()@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/global_objects/string/startswith/index.md)

Нові зміни:
- [mdn/content@b7ca46c](https://github.com/mdn/content/commit/b7ca46c94631967ecd9ce0fe36579be334a01275)