### PR TITLE
update(JS): web/javascript/reference/global_objects/array/length

### DIFF
--- a/files/uk/web/javascript/reference/global_objects/array/length/index.md
+++ b/files/uk/web/javascript/reference/global_objects/array/length/index.md
@@ -125,5 +125,8 @@ numbers.push(5); // // TypeError: Cannot assign to read only property 'length' o
 
 ## Дивіться також
 
+- [Колекції з індексами](/uk/docs/Web/JavaScript/Guide/Indexed_collections)
 - {{jsxref("Array")}}
+- [`TypedArray`: `length`](/uk/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/length)
+- [`String`: `length`](/uk/docs/Web/JavaScript/Reference/Global_Objects/String/length)
 - [RangeError: invalid array length](/uk/docs/Web/JavaScript/Reference/Errors/Invalid_array_length)


### PR DESCRIPTION
Оригінальний вміст: [Array: length@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Global_Objects/Array/length), [сирці Array: length@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/global_objects/array/length/index.md)

Нові зміни:
- [mdn/content@59c445f](https://github.com/mdn/content/commit/59c445ffa5b31083d0f54ba3ee5788b17b8b8329)
- [mdn/content@34a34be](https://github.com/mdn/content/commit/34a34bee83fb4accf073ebc0c8cfc8eff956dc9b)