### PR TITLE
update(glossary): glossary/shallow_copy

### DIFF
--- a/files/uk/glossary/shallow_copy/index.md
+++ b/files/uk/glossary/shallow_copy/index.md
@@ -4,49 +4,54 @@ slug: Glossary/Shallow_copy
 page-type: glossary-definition
 ---
 
-{{MDNSidebar}}
+{{GlossarySidebar}}
 
-**Поверхнева копія** об'єкта – це копія, чиї властивості поділяють ті самі [посилання](/uk/docs/Glossary/Object_reference) (вказують на ті самі значення), що й властивості вихідного об'єкта, котрий було скопійовано. Як наслідок, при зміні як вихідного об'єкта, так і копії, може статися видозміна обох об'єктів – таким чином, може трапитись ненавмисне змінювання джерела або копії, котре не було очікуваним. Ця логіка відрізняється від логіки [глибокого копіювання](/uk/docs/Glossary/Deep_copy), при якому вихідний об'єкт і копія є цілковито незалежними.
+**Поверхнева копія** об'єкта – це копія, чиї властивості поділяють ті самі [посилання](/uk/docs/Glossary/Object_reference) (вказують на ті самі значення), що й властивості вихідного об'єкта, котрий було скопійовано. Як наслідок, при зміні як вихідного об'єкта, так і копії, може статися видозміна обох об'єктів. Ця логіка відрізняється від логіки [глибокого копіювання](/uk/docs/Glossary/Deep_copy), при якому вихідний об'єкт і копія є цілковито незалежними.
 
-При поверхневому копіюванні важливо розуміти, що вибіркове змінювання значення спільної властивості наявного в об'єкті елемента – відрізняється від присвоювання наявному елементові цілковито нового значення.
+Більш формально висловлюючись, два об'єкти `o1` і `o2` є поверхневими копіями одне одного, якщо:
 
-Наприклад, якщо в поверхневій копії об'єкта-масиву, що зветься `copy`, значенням елемента `copy[0]` є `{"list":["butter","flour"]}`, і виконати `copy[0].list = ["oil","flour"]`, то відповідний елемент вихідного об'єкта так само зміниться, адже відбудеться вибіркове змінювання властивості об'єкта, котрий є спільним і для вихідного об'єкта, і для його поверхневої копії.
+1. Вони не одним і тим же об'єктом (`o1 !== o2`).
+2. Властивості `o1` і `o2` мають однакові імена в однаковому порядку.
+3. Значення їхніх властивостей – рівні.
+4. Їхні ланцюжки прототипів – рівні.
 
-Проте якщо замість цього зробити `copy[0] = {"list":["oil","flour"]}`, то тоді відповідний елемент вихідного об'єкта **не зміниться** — адже в такому випадку відбувається не просто вибіркове змінювання властивості наявного елемента масиву, котрий є спільним для поверхневої копії та вихідного об'єкта, а фактично присвоювання цілковито нового значення цьому елементові масиву – `copy[0]`, лише в поверхневу копію.
+Дивіться також [визначення _структурної рівносильності_](/uk/docs/Glossary/Deep_copy).
 
-Усі вбудовані операції копіювання об'єктів у JavaScript ([синтаксис розгортання](/uk/docs/Web/JavaScript/Reference/Operators/Spread_syntax), [`Array.prototype.concat()`](/uk/docs/Web/JavaScript/Reference/Global_Objects/Array/concat), [`Array.prototype.slice()`](/uk/docs/Web/JavaScript/Reference/Global_Objects/Array/slice), [`Array.from()`](/uk/docs/Web/JavaScript/Reference/Global_Objects/Array/from), [`Object.assign()`](/uk/docs/Web/JavaScript/Reference/Global_Objects/Object/assign) і [`Object.create()`](/uk/docs/Web/JavaScript/Reference/Global_Objects/Object/create)) створюють поверхневі копії, а не глибокі.
+Копія об'єкта, в котрого всі властивості мають примітивні значення, відповідає і визначенню [глибокої копії](/uk/docs/Glossary/Deep_copy), і визначенню поверхневої. Проте дещо безглуздо говорити про глибину такої копії, адже вона не має вкладених властивостей, а про глибоке копіювання зазвичай говорять в контексті внесення змін до таких вкладених властивостей.
 
-## Приклад
+При поверхневому копіюванні копіюються лише властивості найвищого рівня, але не значення вкладених об'єктів. Таким чином:
 
-Для прикладу – наступний приклад, у якому створюється об'єкт-масив `ingredients_list`, а тоді створюється `ingredients_list_copy` – шляхом копіювання цього об'єкта `ingredients_list`.
+- Повторне присвоєння властивостей копії найвищого рівня не впливає на вихідний об'єкт.
+- Повторне присвоєння властивостей вкладених у копію об'єктів впливає на вихідний об'єкт.
+
+У JavaScript усі стандартні вбудовані операції копіювання об'єктів ([синтаксис розгортання](/uk/docs/Web/JavaScript/Reference/Operators/Spread_syntax), [`Array.prototype.concat()`](/uk/docs/Web/JavaScript/Reference/Global_Objects/Array/concat), [`Array.prototype.slice()`](/uk/docs/Web/JavaScript/Reference/Global_Objects/Array/slice), [`Array.from()`](/uk/docs/Web/JavaScript/Reference/Global_Objects/Array/from), [`Object.assign()`](/uk/docs/Web/JavaScript/Reference/Global_Objects/Object/assign) і [`Object.create()`](/uk/docs/Web/JavaScript/Reference/Global_Objects/Object/create)) утворюють поверхневі копії, а не глибокі.
+
+Для прикладу – наступний приклад, у якому створюється об'єкт-масив `ingredientsList`, а потім шляхом копіювання цього об'єкта `ingredientsList` створюється об'єкт `ingredientsListCopy`.
 
 ```js
-let ingredients_list = ["локшина", { list: ["яйця", "борошно", "вода"] }];
+const ingredientsList = ["локшина", { list: ["яйця", "борошно", "вода"] }];
 
-let ingredients_list_copy = Array.from(ingredients_list);
-console.log(JSON.stringify(ingredients_list_copy));
+const ingredientsListCopy = Array.from(ingredientsList);
+console.log(ingredientsListCopy);
 // ["локшина",{"list":["яйця","борошно","вода"]}]
 ```
 
-Змінювання значення у властивості `list` всередині `ingredients_list_copy` також призведе до змін властивості `list` у вихідному об'єкті `ingredients_list`.
+Повторне присвоєння значення вкладеної властивості буде помітно на обох об'єктах.
 
 ```js
-ingredients_list_copy[1].list = ["рисове борошно", "вода"];
-console.log(ingredients_list[1].list);
+ingredientsListCopy[1].list = ["рисове борошно", "вода"];
+console.log(ingredientsList[1].list);
 // Array [ "рисове борошно", "вода" ]
-console.log(JSON.stringify(ingredients_list));
-// ["локшина",{"list":["рисове борошно","вода"]}]
 ```
 
-Присвоєння першому елементові `ingredients_list_copy` цілковито нового значення не призведе до жодних змін у першому елементі вихідного об'єкта `ingredients_list`.
+Re-assigning the value of a top-level property (the `0` index in this case) will only be visible in the changed object.
 
 ```js
-ingredients_list_copy[0] = "рисова локшина";
-console.log(ingredients_list[0]);
-// локшина
-console.log(JSON.stringify(ingredients_list_copy));
+ingredientsListCopy[0] = "рисова локшина";
+console.log(ingredientsList[0]);
+console.log(JSON.stringify(ingredientsListCopy));
 // ["рисова локшина",{"list":["рисове борошно","вода"]}]
-console.log(JSON.stringify(ingredients_list));
+console.log(JSON.stringify(ingredientsList));
 // ["локшина",{"list":["рисове борошно","вода"]}]
 ```
 


### PR DESCRIPTION
Оригінальний вміст: [Поверхневе копіювання@MDN](https://developer.mozilla.org/en-us/docs/Glossary/Shallow_copy), [сирці Поверхневе копіювання@GitHub](https://github.com/mdn/content/blob/main/files/en-us/glossary/shallow_copy/index.md)

Нові зміни:
- [mdn/content@1c285ca](https://github.com/mdn/content/commit/1c285cab12ee953a74d38a0800951126b48e1a81)
- [mdn/content@ada5fa5](https://github.com/mdn/content/commit/ada5fa5ef15eadd44b549ecf906423b4a2092f34)