### PR TITLE
update(CSS): web/css/-moz-image-rect

### DIFF
--- a/files/uk/web/css/-moz-image-rect/index.md
+++ b/files/uk/web/css/-moz-image-rect/index.md
@@ -10,7 +10,7 @@ browser-compat: css.types.-moz-image-rect
 
 {{CSSRef}}{{Non-standard_Header}}{{SeeCompatTable}}
 
-Властивість [CSS](/uk/docs/Web/CSS) **`-moz-image-rect`** для {{CSSxRef("background-image")}} дає змогу використовувати частину більшого зображення як тло.
+Властивість [CSS](/uk/docs/Web/CSS) **`-moz-image-rect`** (Mozilla – прямокутник зображення) для {{CSSxRef("background-image")}} дає змогу використовувати частину більшого зображення як тло.
 
 ## Синтаксис
 
@@ -157,4 +157,4 @@ function rotate() {
 ## Дивіться також
 
 - [Розширення CSS від Mozilla](/uk/docs/Web/CSS/Mozilla_Extensions)
-- [Модуль CSS тла та меж](/uk/docs/Web/CSS/CSS_Backgrounds_and_Borders)
+- [Модуль CSS тла та меж](/uk/docs/Web/CSS/CSS_backgrounds_and_borders)


### PR DESCRIPTION
Оригінальний вміст: [-moz-image-rect@MDN](https://developer.mozilla.org/en-us/docs/Web/CSS/-moz-image-rect), [сирці -moz-image-rect@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/css/-moz-image-rect/index.md)

Нові зміни:
- [mdn/content@856b52f](https://github.com/mdn/content/commit/856b52f634b889084869d2ee0b8bb62c084be04d)