### PR TITLE
update(CSS): web/css/_colon_not

### DIFF
--- a/files/uk/web/css/_colon_not/index.md
+++ b/files/uk/web/css/_colon_not/index.md
@@ -35,7 +35,9 @@ browser-compat: css.selectors.not
 
 ## Приклади
 
-### Базовий набір прикладів :not()
+### Використання :not() на дійсних селекторах
+
+Цей приклад демонструє кілька простих випадків застосування `:not()`.
 
 #### HTML
 
@@ -84,9 +86,9 @@ h2 :not(span.foo) {
 
 #### Результат
 
-{{EmbedLiveSample('bazovyi-nabir-prykladiv-z-not', '100%', 320)}}
+{{EmbedLiveSample('vykorystannia-not-na-diisnykh-selektorakh', '100%', 320)}}
 
-### :not() із недійсними селекторами
+### Використання :not() на недійсних селекторах
 
 Цей приклад демонструє використання `:not()` з недійсними селекторами та те, як запобігти нечинності всього селектора.
 
@@ -119,7 +121,7 @@ p:is(:not(.foo), :not(:invalid-pseudo-class)) {
 
 #### Результат
 
-{{EmbedLiveSample('not-iz-nediisnymy-selektoramy', '100%', 320)}}
+{{EmbedLiveSample('vykorystannia-not-na-nediisnykh-selektorakh', '100%', 320)}}
 
 ## Специфікації
 
@@ -138,3 +140,5 @@ p:is(:not(.foo), :not(:invalid-pseudo-class)) {
   - {{cssxref(":has", ":has()")}}
   - {{cssxref(":is", ":is()")}}
   - {{cssxref(":where", ":where()")}}
+
+- [Як :not() утворює ланцюжки з багатьох селекторів](https://developer.mozilla.org/en-US/blog/css-not-pseudo-multiple-selectors/) на блозі MDN (2023)


### PR DESCRIPTION
Оригінальний вміст: [:not()@MDN](https://developer.mozilla.org/en-us/docs/Web/CSS/:not), [сирці :not()@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/css/_colon_not/index.md)

Нові зміни:
- [mdn/content@5e7d1f9](https://github.com/mdn/content/commit/5e7d1f9ae2cce0cb3f7693dfb8dc6e8d375b2231)
- [mdn/content@3c33463](https://github.com/mdn/content/commit/3c33463072905e81ac620dd9780313369029b498)
- [mdn/content@8f1943e](https://github.com/mdn/content/commit/8f1943e0c6d2ce523aa5901400cf20a2d1bcf32e)
- [mdn/content@8f74482](https://github.com/mdn/content/commit/8f74482bd023d33bf4846e3470f5ab432fdc7a32)
- [mdn/content@8daba6d](https://github.com/mdn/content/commit/8daba6d316e3b68f45e09c44da9b6942307ca555)