### PR TITLE
update(CSS): web/css/css_selectors

### DIFF
--- a/files/uk/web/css/css_selectors/index.md
+++ b/files/uk/web/css/css_selectors/index.md
@@ -58,7 +58,7 @@ spec-urls: https://drafts.csswg.org/selectors/
 - {{CSSXref(":last-of-type")}}
 - {{CSSXref(":link")}}
 - {{CSSXref(":local-link")}}
-- `:matches()` (застарілий історичний селектор-псевдонім для {{CSSXref( ":is", ":is()")}})
+- `:matches()` (застарілий історичний селектор-псевдонім для {{CSSXref(":is", ":is()")}})
 - {{CSSXref(":modal")}}
 - {{CSSXref(":muted")}}
 - {{CSSXref(":not", ":not()")}}
@@ -145,14 +145,14 @@ spec-urls: https://drafts.csswg.org/selectors/
 
 - Псевдоклас {{CSSXref(":popover-open")}}
 
-- Модуль контексту CSS
+- Модуль [Контексту CSS](/uk/docs/Web/CSS/CSS_scoping)
 
   - Псевдоклас {{CSSXref(":host")}}
   - Псевдоклас {{CSSXref(":host_function", ":host()")}}
   - Псевдоклас {{cssxref(":host-context", ":host-context()")}}
   - Псевдоелемент {{CSSXref("::slotted")}}
 
-- [Модуль псевдоелементів CSS](/uk/docs/Web/CSS/CSS_pseudo) (представляє сутності, не включені в HTML)
+- [Модуль псевдоелементів CSS](/uk/docs/Web/CSS/CSS_pseudo-elements) (представляє сутності, не включені в HTML)
 
   - {{CSSXref("::after")}}
   - {{CSSXref("::before")}}
@@ -195,6 +195,6 @@ spec-urls: https://drafts.csswg.org/selectors/
 
 ## Дивіться також
 
-- [Модуль псевдоелементів CSS](/uk/docs/Web/CSS/CSS_pseudo)
+- [Модуль псевдоелементів CSS](/uk/docs/Web/CSS/CSS_pseudo-elements)
 - [Модуль каскаду та успадкування CSS](/uk/docs/Web/CSS/CSS_cascade)
 - [Застосування тіньового DOM](/uk/docs/Web/API/Web_components/Using_shadow_DOM)


### PR DESCRIPTION
Оригінальний вміст: [Селектори CSS@MDN](https://developer.mozilla.org/en-us/docs/Web/CSS/CSS_selectors), [сирці Селектори CSS@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/css/css_selectors/index.md)

Нові зміни:
- [mdn/content@c4b0f1c](https://github.com/mdn/content/commit/c4b0f1c1c9ed8beb4c23f2b7844f04b3d572b679)
- [mdn/content@cebbd90](https://github.com/mdn/content/commit/cebbd9095ac12557c55157355181672027fffc14)