### PR TITLE
update(JS): web/javascript/reference/global_objects/json/stringify

### DIFF
--- a/files/uk/web/javascript/reference/global_objects/json/stringify/index.md
+++ b/files/uk/web/javascript/reference/global_objects/json/stringify/index.md
@@ -42,7 +42,7 @@ JSON.stringify(value, replacer, space)
 ### Винятки
 
 - {{jsxref("TypeError")}}
-  - : Викидається, коли виконується одна з двох умов:
+  - : Викидається в одному з наступних випадків:
     - `value` містить циклічне посилання.
     - Зустрічається значення {{jsxref("BigInt")}}.
 
@@ -177,7 +177,7 @@ JSON.stringify(
   Object.create(null, {
     x: { value: "x", enumerable: false },
     y: { value: "y", enumerable: true },
-  })
+  }),
 );
 // '{"y":"y"}'
 


### PR DESCRIPTION
Оригінальний вміст: [JSON.stringify()@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify), [сирці JSON.stringify()@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/global_objects/json/stringify/index.md)

Нові зміни:
- [mdn/content@3bb625c](https://github.com/mdn/content/commit/3bb625c6e90ea87be9592a611fb03364905d067d)