### PR TITLE
update(JS): web/javascript/reference/global_objects/error

### DIFF
--- a/files/uk/web/javascript/reference/global_objects/error/index.md
+++ b/files/uk/web/javascript/reference/global_objects/error/index.md
@@ -216,7 +216,7 @@ try {
 
 ## Дивіться також
 
-- [Поліфіл `Error`](https://github.com/zloirock/core-js#ecmascript-error) з сучасною логікою штибу підтримки `cause` – доступний у складі [`core-js`](https://github.com/zloirock/core-js)
+- [Поліфіл `Error` з підтримкою `cause` у складі `core-js`](https://github.com/zloirock/core-js#ecmascript-error)
 - {{JSxRef("Statements/throw", "throw")}}
 - {{JSxRef("Statements/try...catch", "try...catch")}}
-- [Документація V8](https://v8.dev/docs/stack-trace-api) для `Error.captureStackTrace()`, `Error.stackTraceLimit` і `Error.prepareStackTrace()`.
+- [API трасування стека](https://v8.dev/docs/stack-trace-api) в документації V8


### PR DESCRIPTION
Оригінальний вміст: [Error@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Global_Objects/Error), [сирці Error@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/global_objects/error/index.md)

Нові зміни:
- [mdn/content@70f0967](https://github.com/mdn/content/commit/70f09675ddcfc75a3bb66d2dce4cf82738948a37)