### PR TITLE
update(JS): web/javascript/reference/global_objects/math/log10e

### DIFF
--- a/files/uk/web/javascript/reference/global_objects/math/log10e/index.md
+++ b/files/uk/web/javascript/reference/global_objects/math/log10e/index.md
@@ -1,20 +1,21 @@
 ---
 title: Math.LOG10E
 slug: Web/JavaScript/Reference/Global_Objects/Math/LOG10E
-tags:
-  - JavaScript
-  - Math
-  - Property
-  - Reference
+page-type: javascript-static-data-property
 browser-compat: javascript.builtins.Math.LOG10E
 ---
+
 {{JSRef}}
 
-Властивість **`Math.LOG10E`** відображає логарифм `e` за основою 10, що наближено дорівнює 0.434:
+Статична властивість даних **`Math.LOG10E`** відображає логарифм [e](/uk/docs/Web/JavaScript/Reference/Global_Objects/Math/E) за основою 10, що наближено дорівнює 0.434.
 
-<math display="block"><semantics><mrow><mstyle mathvariant="monospace"><mi>Math.LOG10E</mi></mstyle><mo>=</mo><msub><mo lspace="0em" rspace="0em">log</mo><mn>10</mn></msub><mo stretchy="false">(</mo><mi>e</mi><mo stretchy="false">)</mo><mo>≈</mo><mn>0.434</mn></mrow><annotation encoding="TeX">\mathtt{\mi{Math.LOG10E}} = \log_{10}(e) \approx 0.434</annotation></semantics></math>
+{{EmbedInteractiveExample("pages/js/math-log10e.html", "shorter")}}
 
-{{EmbedInteractiveExample("pages/js/math-log10e.html", "shorter")}}{{js_property_attributes(0, 0, 0)}}
+## Значення
+
+<math display="block"><semantics><mrow><mi>𝙼𝚊𝚝𝚑.𝙻𝙾𝙶𝟷𝟶𝙴</mi><mo>=</mo><msub><mo lspace="0em" rspace="0em">log</mo><mn>10</mn></msub><mo stretchy="false">(</mo><mi mathvariant="normal">e</mi><mo stretchy="false">)</mo><mo>≈</mo><mn>0.434</mn></mrow><annotation encoding="TeX">\mathtt{\mi{Math.LOG10E}} = \log\_{10}(\mathrm{e}) \approx 0.434</annotation></semantics></math>
+
+{{js_property_attributes(0, 0, 0)}}
 
 ## Опис
 


### PR DESCRIPTION
Оригінальний вміст: [Math.LOG10E@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Global_Objects/Math/LOG10E), [сирці Math.LOG10E@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/global_objects/math/log10e/index.md)

Нові зміни:
- [mdn/content@fcd80ee](https://github.com/mdn/content/commit/fcd80ee4c8477b6f73553bfada841781cf74cf46)
- [mdn/content@8183cfa](https://github.com/mdn/content/commit/8183cfa3a25c440ca4ff0f39fe941871ed495a7b)
- [mdn/content@0f248ad](https://github.com/mdn/content/commit/0f248adcab759bdad247a5dbfb7da12dc32bce59)
- [mdn/content@6e5536c](https://github.com/mdn/content/commit/6e5536c6a4d79157d1f4e69c427d07d8a6b92326)
- [mdn/content@801125c](https://github.com/mdn/content/commit/801125c424cfb38d036ecd8091decc66c3ee5849)