### PR TITLE
update(JS): web/javascript/reference/global_objects/string/bold

### DIFF
--- a/files/uk/web/javascript/reference/global_objects/string/bold/index.md
+++ b/files/uk/web/javascript/reference/global_objects/string/bold/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.String.bold
 
 {{JSRef}} {{deprecated_header}}
 
-Метод **`bold()`** створює рядок, що вбудовує вихідний рядок в елемент {{HTMLElement("b")}} (`<b>рядок</b>`), що призводить до виведення цього рядка грубим шрифтом.
+Метод **`bold()`** (грубий) значень {{jsxref("String")}} створює рядок, що вбудовує рядок цього методу в елемент {{HTMLElement("b")}} (`<b>рядок</b>`), що призводить до виведення цього рядка грубим шрифтом.
 
 > **Примітка:** Всі [методи для обгортання в HTML](/uk/docs/Web/JavaScript/Reference/Global_Objects/String#metody-dlia-obhortannia-v-html) є нерекомендованими, вони стандартизовані суто для потреб сумісності. Замість них слід використовувати [API DOM](/uk/docs/Web/API/Document_Object_Model), як то [`document.createElement()`](/uk/docs/Web/API/Document/createElement).
 
@@ -18,6 +18,10 @@ browser-compat: javascript.builtins.String.bold
 ```js-nolint
 bold()
 ```
+
+### Параметри
+
+Жодних.
 
 ### Повернене значення
 


### PR DESCRIPTION
Оригінальний вміст: [String.prototype.bold()@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Global_Objects/String/bold), [сирці String.prototype.bold()@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/global_objects/string/bold/index.md)

Нові зміни:
- [mdn/content@2718087](https://github.com/mdn/content/commit/27180875516cc311342e74b596bfb589b7211e0c)
- [mdn/content@b7ca46c](https://github.com/mdn/content/commit/b7ca46c94631967ecd9ce0fe36579be334a01275)