### PR TITLE
update(JS): web/javascript/reference/global_objects/string/trimend

### DIFF
--- a/files/uk/web/javascript/reference/global_objects/string/trimend/index.md
+++ b/files/uk/web/javascript/reference/global_objects/string/trimend/index.md
@@ -19,6 +19,10 @@ trimEnd()
 trimRight()
 ```
 
+### Параметри
+
+Жодних.
+
 ### Повернене значення
 
 Новий рядок, що містить значення початкового рядка `str`, у якого пробільні символи в кінці (з правого боку) — обрізані. Пробільні символи визначені як символи-[пробіли](/uk/docs/Web/JavaScript/Reference/Lexical_grammar#probily) плюс [символи кінця рядка](/uk/docs/Web/JavaScript/Reference/Lexical_grammar#symvoly-kintsia-riadka).


### PR DESCRIPTION
Оригінальний вміст: [String.prototype.trimEnd()@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Global_Objects/String/trimEnd), [сирці String.prototype.trimEnd()@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/global_objects/string/trimend/index.md)

Нові зміни:
- [mdn/content@2718087](https://github.com/mdn/content/commit/27180875516cc311342e74b596bfb589b7211e0c)