### PR TITLE
update(JS): web/javascript/reference/global_objects/string/valueof

### DIFF
--- a/files/uk/web/javascript/reference/global_objects/string/valueof/index.md
+++ b/files/uk/web/javascript/reference/global_objects/string/valueof/index.md
@@ -7,7 +7,7 @@ browser-compat: javascript.builtins.String.valueOf
 
 {{JSRef}}
 
-Метод **`valueOf()`** повертає примітивне значення об'єкта {{jsxref("String")}}.
+Метод **`valueOf()`** (значення) значень {{jsxref("String")}} повертає рядкове значення, з якого був викликаний.
 
 {{EmbedInteractiveExample("pages/js/string-valueof.html")}}
 
@@ -16,6 +16,10 @@ browser-compat: javascript.builtins.String.valueOf
 ```js-nolint
 valueOf()
 ```
+
+### Параметри
+
+Жодних.
 
 ### Повернене значення
 


### PR DESCRIPTION
Оригінальний вміст: [String.prototype.valueOf()@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Global_Objects/String/valueOf), [сирці String.prototype.valueOf()@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/global_objects/string/valueof/index.md)

Нові зміни:
- [mdn/content@2718087](https://github.com/mdn/content/commit/27180875516cc311342e74b596bfb589b7211e0c)
- [mdn/content@b7ca46c](https://github.com/mdn/content/commit/b7ca46c94631967ecd9ce0fe36579be334a01275)