### PR TITLE
update(JS): web/javascript/reference/global_objects/math/max

### DIFF
--- a/files/uk/web/javascript/reference/global_objects/math/max/index.md
+++ b/files/uk/web/javascript/reference/global_objects/math/max/index.md
@@ -15,14 +15,14 @@ browser-compat: javascript.builtins.Math.max
 
 ```js-nolint
 Math.max()
-Math.max(value0)
-Math.max(value0, value1)
-Math.max(value0, value1, /* …, */ valueN)
+Math.max(value1)
+Math.max(value1, value2)
+Math.max(value1, value2, /* …, */ valueN)
 ```
 
 ### Параметри
 
-- `value1`, `value2`, … , `valueN`
+- `value1`, …, `valueN`
   - : Нуль чи більше чисел, найбільше з яких буде знайдено і повернено.
 
 ### Повернене значення


### PR DESCRIPTION
Оригінальний вміст: [Math.max()@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Global_Objects/Math/max), [сирці Math.max()@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/global_objects/math/max/index.md)

Нові зміни:
- [mdn/content@88d71e5](https://github.com/mdn/content/commit/88d71e500938fa8ca969fe4fe3c80a5abe23d767)