### PR TITLE
update(JS): web/javascript/reference/global_objects/string/raw

### DIFF
--- a/files/uk/web/javascript/reference/global_objects/string/raw/index.md
+++ b/files/uk/web/javascript/reference/global_objects/string/raw/index.md
@@ -15,9 +15,9 @@ browser-compat: javascript.builtins.String.raw
 
 ```js-nolint
 String.raw(strings)
-String.raw(strings, substitution1)
-String.raw(strings, substitution1, substitution2)
-String.raw(strings, substitution1, substitution2, /* …, */ substitutionN)
+String.raw(strings, sub1)
+String.raw(strings, sub1, sub2)
+String.raw(strings, sub1, sub2, /* …, */ subN)
 
 String.raw`templateString`
 ```
@@ -26,7 +26,7 @@ String.raw`templateString`
 
 - `strings`
   - : Як слід сформований масивний об'єкт шаблонного літерала, подібний до `{ raw: ['foo', 'bar', 'baz'] }`. Повинен бути об'єктом зі властивістю `raw`, чиє значення – масивоподібний об'єкт з рядками.
-- `...substitutions`
+- `sub1`, …, `subN`
   - : Містить значення для підставлення.
 - `templateString`
   - : [Шаблонний літерал](/uk/docs/Web/JavaScript/Reference/Template_literals); може містити (необов'язково) вирази підставлення (`${...}`).


### PR DESCRIPTION
Оригінальний вміст: [String.raw()@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Global_Objects/String/raw), [сирці String.raw()@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/global_objects/string/raw/index.md)

Нові зміни:
- [mdn/content@88d71e5](https://github.com/mdn/content/commit/88d71e500938fa8ca969fe4fe3c80a5abe23d767)