### PR TITLE
update(JS): web/javascript/reference/global_objects/math/min

### DIFF
--- a/files/uk/web/javascript/reference/global_objects/math/min/index.md
+++ b/files/uk/web/javascript/reference/global_objects/math/min/index.md
@@ -15,9 +15,9 @@ browser-compat: javascript.builtins.Math.min
 
 ```js-nolint
 Math.min()
-Math.min(value0)
-Math.min(value0, value1)
-Math.min(value0, value1, /* …, */ valueN)
+Math.min(value1)
+Math.min(value1, value2)
+Math.min(value1, value2, /* …, */ valueN)
 ```
 
 ### Параметри


### PR DESCRIPTION
Оригінальний вміст: [Math.min()@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Global_Objects/Math/min), [сирці Math.min()@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/global_objects/math/min/index.md)

Нові зміни:
- [mdn/content@88d71e5](https://github.com/mdn/content/commit/88d71e500938fa8ca969fe4fe3c80a5abe23d767)