### PR TITLE
update(JS): web/javascript/reference/operators/typeof

### DIFF
--- a/files/uk/web/javascript/reference/operators/typeof/index.md
+++ b/files/uk/web/javascript/reference/operators/typeof/index.md
@@ -150,7 +150,7 @@ typeof (someData + " Wisen"); // 'string'
 typeof undeclaredVariable; // "undefined"
 ```
 
-Проте застосування `typeof` на лексичних оголошеннях ({{JSxRef("Statements/let", "let")}} {{JSxRef("Statements/const", "const")}} і [`class`](/uk/docs/Web/JavaScript/Reference/Statements/class)), в одному блоці перед рядком оголошення, викине {{JSxRef("ReferenceError")}}. Змінні блокової видимості перебувають у _[темпоральній мертвій зоні](/uk/docs/Web/JavaScript/Reference/Statements/let#temporalna-mertva-zona-tdz)_ від початку блока до обробки ініціалізації, протягом чого така змінна викине помилку, якщо спробувати до неї звернутися.
+Проте застосування `typeof` на лексичних оголошеннях ({{JSxRef("Statements/let", "let")}} {{JSxRef("Statements/const", "const")}} і [`class`](/uk/docs/Web/JavaScript/Reference/Statements/class)), в тому ж блоці перед місцем оголошення, викине {{JSxRef("ReferenceError")}}. Змінні блокової видимості перебувають у _[темпоральній мертвій зоні](/uk/docs/Web/JavaScript/Reference/Statements/let#temporalna-mertva-zona-tdz)_ від початку блока до обробки ініціалізації, протягом чого така змінна викине помилку, якщо спробувати до неї звернутися.
 
 ```js example-bad
 typeof newLetVariable; // ReferenceError


### PR DESCRIPTION
Оригінальний вміст: [typeof@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Operators/typeof), [сирці typeof@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/operators/typeof/index.md)

Нові зміни:
- [mdn/content@ee1599c](https://github.com/mdn/content/commit/ee1599cba00284fd6af713e61e96dae61bb10287)