### PR TITLE
update(JS): web/javascript/reference/global_objects/date/now

### DIFF
--- a/files/uk/web/javascript/reference/global_objects/date/now/index.md
+++ b/files/uk/web/javascript/reference/global_objects/date/now/index.md
@@ -17,6 +17,10 @@ browser-compat: javascript.builtins.Date.now
 Date.now()
 ```
 
+### Параметри
+
+Жодних.
+
 ### Повернене значення
 
 Число, котре представляє [мітку часу](/uk/docs/Web/JavaScript/Reference/Global_Objects/Date#epokha-mitky-chasu-ta-nediisna-data) поточної миті в мілісекундах.


### PR DESCRIPTION
Оригінальний вміст: [Date.now()@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Global_Objects/Date/now), [сирці Date.now()@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/global_objects/date/now/index.md)

Нові зміни:
- [mdn/content@2718087](https://github.com/mdn/content/commit/27180875516cc311342e74b596bfb589b7211e0c)