### PR TITLE
update(JS): web/javascript/reference/global_objects/array/concat

### DIFF
--- a/files/uk/web/javascript/reference/global_objects/array/concat/index.md
+++ b/files/uk/web/javascript/reference/global_objects/array/concat/index.md
@@ -15,14 +15,14 @@ browser-compat: javascript.builtins.Array.concat
 
 ```js-nolint
 concat()
-concat(value0)
-concat(value0, value1)
-concat(value0, value1, /* …, */ valueN)
+concat(value1)
+concat(value1, value2)
+concat(value1, value2, /* …, */ valueN)
 ```
 
 ### Параметри
 
-- `valueN` (значення № N) {{optional_inline}}
+- `value1`, …, `valueN` {{optional_inline}}
   - : Масиви та (або) значення, котрі слід злити в новий масив. Якщо всі параметри опущені, то `valueN`, `concat` повертає [поверхневу копію](/uk/docs/Glossary/Shallow_copy) наявного масиву, на котрому його викликали.
 
 ### Повернене значення


### PR DESCRIPTION
Оригінальний вміст: [Array.prototype.concat()@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Global_Objects/Array/concat), [сирці Array.prototype.concat()@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/global_objects/array/concat/index.md)

Нові зміни:
- [mdn/content@88d71e5](https://github.com/mdn/content/commit/88d71e500938fa8ca969fe4fe3c80a5abe23d767)