### PR TITLE
update(JS): web/javascript/reference/global_objects/math/hypot

### DIFF
--- a/files/uk/web/javascript/reference/global_objects/math/hypot/index.md
+++ b/files/uk/web/javascript/reference/global_objects/math/hypot/index.md
@@ -17,9 +17,9 @@ browser-compat: javascript.builtins.Math.hypot
 
 ```js-nolint
 Math.hypot()
-Math.hypot(value0)
-Math.hypot(value0, value1)
-Math.hypot(value0, value1, /* …, */ valueN)
+Math.hypot(value1)
+Math.hypot(value1, value2)
+Math.hypot(value1, value2, /* …, */ valueN)
 ```
 
 ### Параметри


### PR DESCRIPTION
Оригінальний вміст: [Math.hypot()@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Global_Objects/Math/hypot), [сирці Math.hypot()@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/global_objects/math/hypot/index.md)

Нові зміни:
- [mdn/content@88d71e5](https://github.com/mdn/content/commit/88d71e500938fa8ca969fe4fe3c80a5abe23d767)