### PR TITLE
update(JS): web/javascript/reference/statements/switch

### DIFF
--- a/files/uk/web/javascript/reference/statements/switch/index.md
+++ b/files/uk/web/javascript/reference/statements/switch/index.md
@@ -84,7 +84,7 @@ switch (foo) {
 
 Пункти `case` і `default` подібні до [міток](/uk/docs/Web/JavaScript/Reference/Statements/label): вони вказують місця, куди контроль плину виконання може перестрибнути. Проте вони не створюють самі по собі лексичних [областей видимості](/uk/docs/Glossary/Scope) (так само як не виконують автоматично виходу – як показано вище). Наприклад:
 
-```js example-bad
+```js-nolint example-bad
 const action = "say_hello";
 switch (action) {
   case "say_hello":


### PR DESCRIPTION
Оригінальний вміст: [switch@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Statements/switch), [сирці switch@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/statements/switch/index.md)

Нові зміни:
- [mdn/content@4c26e8a](https://github.com/mdn/content/commit/4c26e8a3fb50d06963b06017f51ce19364350564)