### PR TITLE
update(JS): web/javascript/reference/operators/delete

### DIFF
--- a/files/uk/web/javascript/reference/operators/delete/index.md
+++ b/files/uk/web/javascript/reference/operators/delete/index.md
@@ -40,9 +40,9 @@ delete object[property]
 
 ## Опис
 
-Оператор `delete` має такий само [пріоритет](/uk/docs/Web/JavaScript/Reference/Operators/Operator_Precedence), як інші унарні оператори, як то [`typeof`](/uk/docs/Web/JavaScript/Reference/Operators/typeof). Таким чином, він приймає будь-які вирази, сформовані операторами вищого пріоритету. Проте форми, показані нижче, в [суворому режимі](/uk/docs/Web/JavaScript/Reference/Strict_mode) зразу призведуть до синтаксичних помилок:
+Оператор `delete` має такий само [пріоритет](/uk/docs/Web/JavaScript/Reference/Operators/Operator_precedence), як інші унарні оператори, як то [`typeof`](/uk/docs/Web/JavaScript/Reference/Operators/typeof). Таким чином, він приймає будь-які вирази, сформовані операторами вищого пріоритету. Проте форми, показані нижче, в [суворому режимі](/uk/docs/Web/JavaScript/Reference/Strict_mode) зразу призведуть до синтаксичних помилок:
 
-```js example-bad
+```js-nolint example-bad
 delete identifier;
 delete object.#privateProperty;
 ```
@@ -56,7 +56,7 @@ delete console.log(1);
 // Виводить 1, повертає true, але нічого не видалено
 ```
 
-Оператор `delete` прибирає з об'єкта задану властивість. У випадку успішного видалення – повертає `true`, інакше – `false`. Всупереч поширеному уявленню (мабуть, пов'язаному з іншими мовами програмування, як то [delete у C++](https://docs.microsoft.com/cpp/cpp/delete-operator-cpp?view=msvc-170)), оператор `delete` **не має** стосунку до безпосереднього звільнення пам'яті. Керування пам'яттю виконується в непрямий спосіб, шляхом розриву посилань. Дивіться подробиці на сторінці [керування пам'яттю](/uk/docs/Web/JavaScript/Memory_Management).
+Оператор `delete` прибирає з об'єкта задану властивість. У випадку успішного видалення – повертає `true`, інакше – `false`. Всупереч поширеному уявленню (мабуть, пов'язаному з іншими мовами програмування, як то [delete у C++](https://docs.microsoft.com/cpp/cpp/delete-operator-cpp?view=msvc-170)), оператор `delete` **не має** стосунку до безпосереднього звільнення пам'яті. Керування пам'яттю виконується в непрямий спосіб, шляхом розриву посилань. Дивіться подробиці на сторінці [керування пам'яттю](/uk/docs/Web/JavaScript/Memory_management).
 
 Важливо враховувати наступні варіанти:
 
@@ -78,7 +78,7 @@ delete console.log(1);
 // Оскільки використовується var, вона буде позначена як неналаштовна.
 var empCount = 43;
 
-// Створення в глобальній видимості властивості adminName.
+// Створення в глобальній видимості властивості EmployeeDetails.
 // Оскільки var не використовується, вона буде позначена як налаштовна.
 EmployeeDetails = {
   name: "xyz",


### PR DESCRIPTION
Оригінальний вміст: [Оператор delete@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Operators/delete), [сирці Оператор delete@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/operators/delete/index.md)

Нові зміни:
- [mdn/content@4c26e8a](https://github.com/mdn/content/commit/4c26e8a3fb50d06963b06017f51ce19364350564)
- [mdn/content@6359443](https://github.com/mdn/content/commit/6359443eda71039d50f10b94b5b23b80cdfd77bc)
- [mdn/content@d85a7ba](https://github.com/mdn/content/commit/d85a7ba8cca98c2f6cf67a0c44f0ffd467532f20)