### PR TITLE
update(JS): web/javascript/reference/global_objects/string/slice

### DIFF
--- a/files/uk/web/javascript/reference/global_objects/string/slice/index.md
+++ b/files/uk/web/javascript/reference/global_objects/string/slice/index.md
@@ -37,8 +37,8 @@ slice(indexStart, indexEnd)
 
 - Якщо `indexStart >= str.length`, то повертається порожній рядок.
 - Якщо `indexStart < 0`, то індекс рахується з кінця рядка. Більш формально висловлюючись, в цьому випадку підрядок починається від `max(indexStart + str.length, 0)`.
-- Якщо `indexStart` опущено, невизначений або не може бути перетворений на число (за допомогою {{jsxref('Number', 'Number(indexStart)')}}), то він вважається еквівалентним `0`.
-- Якщо `indexEnd` опущено, невизначений або не може бути перетворений на число (за допомогою {{jsxref('Number', 'Number(indexEnd)')}}), або якщо `indexEnd >= str.length`, то `slice()` вибирає символи до самого кінця рядка.
+- Якщо `indexStart` опущено, невизначений або не може бути [перетворений на число](/uk/docs/Web/JavaScript/Reference/Global_Objects/Number#zvedennia-do-chysla), то він вважається еквівалентним `0`.
+- Якщо `indexEnd` опущено, невизначений або не може бути [перетворений на число](/uk/docs/Web/JavaScript/Reference/Global_Objects/Number#zvedennia-do-chysla), або якщо `indexEnd >= str.length`, то `slice()` вибирає символи до самого кінця рядка.
 - Якщо `indexEnd < 0`, то індекс рахується від кінця рядка. Більш формально висловлюючись, в цьому випадку підрядок закінчується на `max(indexEnd + str.length, 0)`.
 - Якщо після нормалізації від'ємних значень `indexEnd <= indexStart` (наприклад, `indexEnd` вказує на символ, що стоїть перед `indexStart`), то повертається порожній рядок.
 


### PR DESCRIPTION
Оригінальний вміст: [String.prototype.slice()@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Global_Objects/String/slice), [сирці String.prototype.slice()@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/global_objects/string/slice/index.md)

Нові зміни:
- [mdn/content@c2445ce](https://github.com/mdn/content/commit/c2445ce1dc3a0170e2fbfdbee10e18a7455c2282)