### PR TITLE
update(JS): web/javascript/reference/functions/arrow_functions

### DIFF
--- a/files/uk/web/javascript/reference/functions/arrow_functions/index.md
+++ b/files/uk/web/javascript/reference/functions/arrow_functions/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.functions.arrow_functions
 
 **Вираз стрілкової функції** — це компактна альтернатива традиційному [виразові функції](/uk/docs/Web/JavaScript/Reference/Operators/function), що має певні семантичні відмінності й свідомі обмеження у використанні:
 
-- Стрілкові функції не мають власних {{glossary("binding", "зв'язувань")}} [`this`](/uk/docs/Web/JavaScript/Reference/Operators/this), [`arguments`](/uk/docs/Web/JavaScript/Reference/Functions/arguments) та [`super`](/uk/docs/Web/JavaScript/Reference/Operators/super), і їх не слід використовувати як [методи](/uk/docs/Glossary/Method).
+- Стрілкові функції не мають власних {{Glossary("binding", "зв'язувань")}} [`this`](/uk/docs/Web/JavaScript/Reference/Operators/this), [`arguments`](/uk/docs/Web/JavaScript/Reference/Functions/arguments) та [`super`](/uk/docs/Web/JavaScript/Reference/Operators/super), і їх не слід використовувати як [методи](/uk/docs/Glossary/Method).
 - Стрілкові функції не можуть використовуватися як [конструктори](/uk/docs/Glossary/Constructor). Виклик їх з [`new`](/uk/docs/Web/JavaScript/Reference/Operators/new) викидає {{jsxref("TypeError")}}. Крім цього, вони не мають доступу до ключового слова [`new.target`](/uk/docs/Web/JavaScript/Reference/Operators/new.target)
 - Стрілкові функції не можуть використовувати у своєму тілі [`yield`](/uk/docs/Web/JavaScript/Reference/Operators/yield) і не можуть створюватися як генераторні функції.
 
@@ -457,7 +457,7 @@ obj.doSomethingLater(); // виводить 11
 
 ## Дивіться також
 
-- [Посібник з функцій](/uk/docs/Web/JavaScript/Guide/Functions)
+- Посібник [Функції](/uk/docs/Web/JavaScript/Guide/Functions)
 - [Функції](/uk/docs/Web/JavaScript/Reference/Functions)
 - {{jsxref("Statements/function", "function")}}
 - [Вираз `function`](/uk/docs/Web/JavaScript/Reference/Operators/function)


### PR DESCRIPTION
Оригінальний вміст: [Вирази стрілкових функцій@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Functions/Arrow_functions), [сирці Вирази стрілкових функцій@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/functions/arrow_functions/index.md)

Нові зміни:
- [mdn/content@4f86aad](https://github.com/mdn/content/commit/4f86aad2b0b66c0d2041354ec81400c574ab56ca)
- [mdn/content@c6f0f10](https://github.com/mdn/content/commit/c6f0f106b9083984dbf597678def6561729bb459)