### PR TITLE
update(JS): web/javascript/reference/global_objects/array/from

### DIFF
--- a/files/uk/web/javascript/reference/global_objects/array/from/index.md
+++ b/files/uk/web/javascript/reference/global_objects/array/from/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.Array.from
 
 Статичний метод **`Array.from()`** (із) створює новий, поверхнево скопійований примірник `Array` на основі [ітерованого](/uk/docs/Web/JavaScript/Reference/Iteration_protocols#protokol-iterovanoho-obiekta) або [масивоподібного](/uk/docs/Web/JavaScript/Guide/Indexed_collections#robota-z-masyvopodibnymy-obiektamy) об'єкта.
 
-{{EmbedInteractiveExample("pages/js/array-from.html","shorter")}}
+{{EmbedInteractiveExample("pages/js/array-from.html", "shorter")}}
 
 ## Синтаксис
 
@@ -145,7 +145,7 @@ range(1, 10, 2);
 
 // Згенерувати за допомогою Array.from алфавіт, користуючись тим, що він має послідовний порядок
 range("A".charCodeAt(0), "Z".charCodeAt(0), 1).map((x) =>
-  String.fromCharCode(x)
+  String.fromCharCode(x),
 );
 // ["A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "O", "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z"]
 ```
@@ -185,7 +185,7 @@ console.log(Array.from.call({}, { length: 1, 0: "foo" })); // [ 'foo' ]
 ## Дивіться також
 
 - [Поліфіл `Array.from` у складі `core-js`](https://github.com/zloirock/core-js#ecmascript-array)
-- [Колекції з індексами](/uk/docs/Web/JavaScript/Guide/Indexed_collections)
+- Посібник [Колекції з індексами](/uk/docs/Web/JavaScript/Guide/Indexed_collections)
 - {{jsxref("Array")}}
 - {{jsxref("Array/Array", "Array()")}}
 - {{jsxref("Array.of()")}}


### PR DESCRIPTION
Оригінальний вміст: [Array.from()@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Global_Objects/Array/from), [сирці Array.from()@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/global_objects/array/from/index.md)

Нові зміни:
- [mdn/content@5c3c25f](https://github.com/mdn/content/commit/5c3c25fd4f2fbd7a5f01727a65c2f70d73f1880a)
- [mdn/content@e01fd62](https://github.com/mdn/content/commit/e01fd6206ce2fad2fe09a485bb2d3ceda53a62de)