### PR TITLE
update(JS): web/javascript/reference/global_objects/array/every

### DIFF
--- a/files/uk/web/javascript/reference/global_objects/array/every/index.md
+++ b/files/uk/web/javascript/reference/global_objects/array/every/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.Array.every
 
 Метод **`every()`** (кожний) примірників {{jsxref("Array")}} перевіряє, чи всі елементи масиву проходять перевірку, реалізовану наданою функцією. Повертає булеве значення.
 
-{{EmbedInteractiveExample("pages/js/array-every.html","shorter")}}
+{{EmbedInteractiveExample("pages/js/array-every.html", "shorter")}}
 
 ## Синтаксис
 
@@ -33,7 +33,7 @@ every(callbackFn, thisArg)
 
 ### Повернене значення
 
-`true`, якщо `callbackFn` повертає значення {{Glossary("truthy", "істинності")}} для кожного елемента масиву. Інакше – `false`.
+`true`, якщо `callbackFn` не повертає {{Glossary("falsy", "хибне")}} значення для одного з елементів масиву, – в цьому випадку негайно повертається `false`
 
 ## Опис
 
@@ -171,7 +171,7 @@ console.log(
 ## Дивіться також
 
 - [Поліфіл `Array.prototype.every` у складі `core-js`](https://github.com/zloirock/core-js#ecmascript-array)
-- [Колекції з індексами](/uk/docs/Web/JavaScript/Guide/Indexed_collections)
+- Посібник [Колекції з індексами](/uk/docs/Web/JavaScript/Guide/Indexed_collections)
 - {{jsxref("Array")}}
 - {{jsxref("Array.prototype.forEach()")}}
 - {{jsxref("Array.prototype.some()")}}


### PR DESCRIPTION
Оригінальний вміст: [Array.prototype.every()@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Global_Objects/Array/every), [сирці Array.prototype.every()@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/global_objects/array/every/index.md)

Нові зміни:
- [mdn/content@5c3c25f](https://github.com/mdn/content/commit/5c3c25fd4f2fbd7a5f01727a65c2f70d73f1880a)
- [mdn/content@2823298](https://github.com/mdn/content/commit/28232983aa91026e50ec4300ddcb1b1d894a93b9)
- [mdn/content@e01fd62](https://github.com/mdn/content/commit/e01fd6206ce2fad2fe09a485bb2d3ceda53a62de)