### PR TITLE
update(JS): web/javascript/reference/global_objects/regexp

### DIFF
--- a/files/uk/web/javascript/reference/global_objects/regexp/index.md
+++ b/files/uk/web/javascript/reference/global_objects/regexp/index.md
@@ -99,17 +99,17 @@ re.exec("bar"); // [ 'bar', index: 0, input: 'bar', groups: undefined ]
 
 ## Статичні властивості
 
-- {{jsxref("RegExp/n", "RegExp.$1, …, RegExp.$9")}} {{Deprecated_Inline}}
+- {{jsxref("RegExp/n", "RegExp.$1, …, RegExp.$9")}} {{deprecated_inline}}
   - : Статичні властивості лише для зчитування, що містять збіги підрядків у дужках.
-- {{jsxref("RegExp.input", "RegExp.input ($_)")}} {{Deprecated_Inline}}
+- {{jsxref("RegExp.input", "RegExp.input ($_)")}} {{deprecated_inline}}
   - : Статична властивість лише для зчитування, що містить останній рядок, щодо якого відбувся успішний збіг.
-- {{jsxref("RegExp.lastMatch", "RegExp.lastMatch ($&)")}} {{Deprecated_Inline}}
+- {{jsxref("RegExp.lastMatch", "RegExp.lastMatch ($&)")}} {{deprecated_inline}}
   - : Статична властивість лише для зчитування, що містить останній підрядок, з яким трапився збіг.
-- {{jsxref("RegExp.lastParen", "RegExp.lastParen ($+)")}} {{Deprecated_Inline}}
+- {{jsxref("RegExp.lastParen", "RegExp.lastParen ($+)")}} {{deprecated_inline}}
   - : Статична властивість лише для зчитування, що містить останній збіг підрядку в дужках.
-- {{jsxref("RegExp.leftContext", "RegExp.leftContext ($`)")}} {{Deprecated_Inline}}
+- {{jsxref("RegExp.leftContext", "RegExp.leftContext ($`)")}} {{deprecated_inline}}
   - : Статична властивість лише для зчитування, що містить підрядок, котрий передував останньому збігові.
-- {{jsxref("RegExp.rightContext", "RegExp.rightContext ($')")}} {{Deprecated_Inline}}
+- {{jsxref("RegExp.rightContext", "RegExp.rightContext ($')")}} {{deprecated_inline}}
   - : Статична властивість лише для зчитування, що містить підрядок, котрий стояв після останнього збігу.
 - {{jsxref("RegExp/@@species", "RegExp[@@species]")}}
   - : Функція-конструктор, що використовується для створення похідних об'єктів.
@@ -148,7 +148,7 @@ re.exec("bar"); // [ 'bar', index: 0, input: 'bar', groups: undefined ]
 
 ## Методи примірника
 
-- {{jsxref("RegExp.prototype.compile()")}} (компілювати) {{Deprecated_Inline}}
+- {{jsxref("RegExp.prototype.compile()")}} (компілювати) {{deprecated_inline}}
   - : (Повторно) компілює регулярний вираз під час виконання сценарію.
 - {{jsxref("RegExp.prototype.exec()")}} (виконати)
   - : Виконує пошук збігу у своєму рядковому параметрі.
@@ -317,8 +317,8 @@ order.match(new RegExp(`\\b(${breakfasts.join("|")})\\b`, "g"));
 ## Дивіться також
 
 - [Поліфіл багатьох сучасних можливостей `RegExp` (позначки `dotAll`, `sticky`, іменовані групи захоплення тощо) у складі `core-js`](https://github.com/zloirock/core-js#ecmascript-string-and-regexp)
-- [Посібник з регулярних виразів](/uk/docs/Web/JavaScript/Guide/Regular_Expressions)
-- [Довідка з регулярних виразів](/uk/docs/Web/JavaScript/Reference/Regular_expressions)
+- Посібник [Регулярні вирази](/uk/docs/Web/JavaScript/Guide/Regular_Expressions)
+- [Регулярні вирази](/uk/docs/Web/JavaScript/Reference/Regular_expressions)
 - {{jsxref("String.prototype.match()")}}
 - {{jsxref("String.prototype.replace()")}}
 - {{jsxref("String.prototype.split()")}}


### PR DESCRIPTION
Оригінальний вміст: [RegExp@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Global_Objects/RegExp), [сирці RegExp@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/global_objects/regexp/index.md)

Нові зміни:
- [mdn/content@c2445ce](https://github.com/mdn/content/commit/c2445ce1dc3a0170e2fbfdbee10e18a7455c2282)
- [mdn/content@e01fd62](https://github.com/mdn/content/commit/e01fd6206ce2fad2fe09a485bb2d3ceda53a62de)