### PR TITLE
update(JS): web/javascript/reference/operators/typeof

### DIFF
--- a/files/uk/web/javascript/reference/operators/typeof/index.md
+++ b/files/uk/web/javascript/reference/operators/typeof/index.md
@@ -5,7 +5,7 @@ page-type: javascript-operator
 browser-compat: javascript.operators.typeof
 ---
 
-{{JSSidebar("Operators")}}
+{{jsSidebar("Operators")}}
 
 Оператор **`typeof`** ("тип ...") повертає рядок, який вказує на тип значення операнда.
 
@@ -150,7 +150,7 @@ typeof (someData + " Wisen"); // 'string'
 typeof undeclaredVariable; // "undefined"
 ```
 
-Проте застосування `typeof` на лексичних оголошеннях ({{JSxRef("Statements/let", "let")}} {{JSxRef("Statements/const", "const")}} і [`class`](/uk/docs/Web/JavaScript/Reference/Statements/class)), в тому ж блоці перед місцем оголошення, викине {{JSxRef("ReferenceError")}}. Змінні блокової видимості перебувають у _[темпоральній мертвій зоні](/uk/docs/Web/JavaScript/Reference/Statements/let#temporalna-mertva-zona-tdz)_ від початку блока до обробки ініціалізації, протягом чого така змінна викине помилку, якщо спробувати до неї звернутися.
+Проте застосування `typeof` на лексичних оголошеннях ({{jsxref("Statements/let", "let")}} {{jsxref("Statements/const", "const")}} і [`class`](/uk/docs/Web/JavaScript/Reference/Statements/class)), в тому ж блоці перед місцем оголошення, викине {{jsxref("ReferenceError")}}. Змінні блокової видимості перебувають у _[темпоральній мертвій зоні](/uk/docs/Web/JavaScript/Reference/Statements/let#temporalna-mertva-zona-tdz)_ від початку блока до обробки ініціалізації, протягом чого така змінна викине помилку, якщо спробувати до неї звернутися.
 
 ```js example-bad
 typeof newLetVariable; // ReferenceError
@@ -214,7 +214,7 @@ function type(value) {
 }
 ```
 
-Для перевірки недійсних змінних, які в іншому випадку викинули б {{JSxRef("ReferenceError")}}, слід застосовувати `typeof nonExistentVar === 'undefined'`, адже таку поведінку неможливо імітувати за допомогою самописного коду.
+Для перевірки недійсних змінних, які в іншому випадку викинули б {{jsxref("ReferenceError")}}, слід застосовувати `typeof nonExistentVar === 'undefined'`, адже таку поведінку неможливо імітувати за допомогою самописного коду.
 
 ## Специфікації
 
@@ -226,5 +226,5 @@ function type(value) {
 
 ## Дивіться також
 
-- {{JSxRef("Operators/instanceof", "instanceof")}}
+- {{jsxref("Operators/instanceof", "instanceof")}}
 - [`document.all` — навмисне порушення стандарту (англ.)](https://github.com/tc39/ecma262/issues/668)


### PR DESCRIPTION
Оригінальний вміст: [typeof@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Operators/typeof), [сирці typeof@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/operators/typeof/index.md)

Нові зміни:
- [mdn/content@4f86aad](https://github.com/mdn/content/commit/4f86aad2b0b66c0d2041354ec81400c574ab56ca)