### PR TITLE
update(JS): web/javascript/reference/global_objects/string/fromcharcode

### DIFF
--- a/files/uk/web/javascript/reference/global_objects/string/fromcharcode/index.md
+++ b/files/uk/web/javascript/reference/global_objects/string/fromcharcode/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.String.fromCharCode
 
 Статичний метод **`String.fromCharCode()`** (із коду символу) повертає рядок, сформований з вказаної послідовності кодових одиниць UTF-16.
 
-{{EmbedInteractiveExample("pages/js/string-fromcharcode.html","shorter")}}
+{{EmbedInteractiveExample("pages/js/string-fromcharcode.html", "shorter")}}
 
 ## Синтаксис
 
@@ -22,7 +22,7 @@ String.fromCharCode(num1, num2, /* …, */ numN)
 
 ### Параметри
 
-- `numN`
+- `num1`, …, `numN`
   - : Число між `0` і `65535` (`0xFFFF`), що відповідає кодовій одиниці UTF-16. Числа, більші за `0xFFFF`, обрізаються до останніх 16 бітів. Перевірка на коректність не виконується.
 
 ### Повернене значення


### PR DESCRIPTION
Оригінальний вміст: [String.fromCharCode()@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Global_Objects/String/fromCharCode), [сирці String.fromCharCode()@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/global_objects/string/fromcharcode/index.md)

Нові зміни:
- [mdn/content@c2445ce](https://github.com/mdn/content/commit/c2445ce1dc3a0170e2fbfdbee10e18a7455c2282)
- [mdn/content@88d71e5](https://github.com/mdn/content/commit/88d71e500938fa8ca969fe4fe3c80a5abe23d767)