### PR TITLE
update(JS): web/javascript/reference/global_objects/string/repeat

### DIFF
--- a/files/uk/web/javascript/reference/global_objects/string/repeat/index.md
+++ b/files/uk/web/javascript/reference/global_objects/string/repeat/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.String.repeat
 
 Метод **`repeat()`** (повторювати) значень {{jsxref("String")}} збирає і повертає новий рядок, який містить вказану кількість копій свого рядка, зчеплену докупи.
 
-{{EmbedInteractiveExample("pages/js/string-repeat.html","shorter")}}
+{{EmbedInteractiveExample("pages/js/string-repeat.html", "shorter")}}
 
 ## Синтаксис
 


### PR DESCRIPTION
Оригінальний вміст: [String.prototype.repeat()@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Global_Objects/String/repeat), [сирці String.prototype.repeat()@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/global_objects/string/repeat/index.md)

Нові зміни:
- [mdn/content@c2445ce](https://github.com/mdn/content/commit/c2445ce1dc3a0170e2fbfdbee10e18a7455c2282)