### PR TITLE
update(JS): web/javascript/reference/global_objects/parseint

### DIFF
--- a/files/uk/web/javascript/reference/global_objects/parseint/index.md
+++ b/files/uk/web/javascript/reference/global_objects/parseint/index.md
@@ -176,11 +176,11 @@ parseInt(1e21, 10); // 1
 
 ## Дивіться також
 
-- {{jsxref("Global_Objects/parseFloat", "parseFloat()")}}
+- {{jsxref("parseFloat()")}}
 - [Конструктор `Number()`](/uk/docs/Web/JavaScript/Reference/Global_Objects/Number/Number)
 - {{jsxref("Number.parseFloat()")}}
 - {{jsxref("Number.parseInt()")}}
-- {{jsxref("Global_Objects/isNaN", "isNaN()")}}
+- {{jsxref("isNaN()")}}
 - {{jsxref("Number.prototype.toString()")}}
 - {{jsxref("Object.prototype.valueOf()")}}
 - [Конструктор `BigInt()`](/uk/docs/Web/JavaScript/Reference/Global_Objects/BigInt/BigInt)


### PR DESCRIPTION
Оригінальний вміст: [parseInt()@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Global_Objects/parseInt), [сирці parseInt()@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/global_objects/parseint/index.md)

Нові зміни:
- [mdn/content@fb85334](https://github.com/mdn/content/commit/fb85334ffa4a2c88d209b1074909bee0e0abd57a)