### PR TITLE
update(JS): web/javascript/reference/global_objects/string/replace

### DIFF
--- a/files/uk/web/javascript/reference/global_objects/string/replace/index.md
+++ b/files/uk/web/javascript/reference/global_objects/string/replace/index.md
@@ -173,7 +173,7 @@ function styleHyphenFormat(propertyName) {
 
 Для `styleHyphenFormat('borderTop')` це поверне `'border-top'`.
 
-Оскільки в цьому випадку потрібно додатково змінити _знайдений збіг_ перед остаточною заміною, то слід вжити функцію. Це змушує програму спершу знайти збіг, тобто до виконання методу {{jsxref("String.prototype.toLowerCase()", "toLowerCase()")}}. Якщо спробувати зробити заміну без функції, то метод {{jsxref("String.prototype.toLowerCase()", "toLowerCase()")}} не матиме ефекту.
+Оскільки в цьому випадку потрібно додатково змінити _знайдений збіг_ перед остаточною заміною, то слід вжити функцію. Це змушує програму спершу знайти збіг, тобто до виконання методу {{jsxref("String/toLowerCase", "toLowerCase()")}}. Якщо спробувати зробити заміну без функції, то метод {{jsxref("String.prototype.toLowerCase()", "toLowerCase()")}} не матиме ефекту.
 
 ```js example-bad
 // так не працює
@@ -244,9 +244,9 @@ console.log("abcd".replace(/(?<group>bc)/, addOffset)); // "abc (1) d"
 ## Дивіться також
 
 - [Поліфіл `String.prototype.replace` у складі `core-js`, з виправленнями й реалізацією сучасної логіки, як то підтримки `Symbol.replace`](https://github.com/zloirock/core-js#ecmascript-string-and-regexp)
-- {{jsxref("String.prototype.replaceAll", "String.prototype.replaceAll()")}}
-- {{jsxref("String.prototype.match", "String.prototype.match()")}}
-- {{jsxref("RegExp.prototype.exec", "RegExp.prototype.exec()")}}
-- {{jsxref("RegExp.prototype.test", "RegExp.prototype.test()")}}
+- {{jsxref("String.prototype.replaceAll()")}}
+- {{jsxref("String.prototype.match()")}}
+- {{jsxref("RegExp.prototype.exec()")}}
+- {{jsxref("RegExp.prototype.test()")}}
 - [`Symbol.replace`](/uk/docs/Web/JavaScript/Reference/Global_Objects/Symbol/replace)
 - [`RegExp.prototype[@@replace]()`](/uk/docs/Web/JavaScript/Reference/Global_Objects/RegExp/@@replace)


### PR DESCRIPTION
Оригінальний вміст: [String.prototype.replace()@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Global_Objects/String/replace), [сирці String.prototype.replace()@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/global_objects/string/replace/index.md)

Нові зміни:
- [mdn/content@fb85334](https://github.com/mdn/content/commit/fb85334ffa4a2c88d209b1074909bee0e0abd57a)