### PR TITLE
update(JS): web/javascript/reference

### DIFF
--- a/files/uk/web/javascript/reference/index.md
+++ b/files/uk/web/javascript/reference/index.md
@@ -26,16 +26,16 @@ page-type: landing-page
 ### Властивості-функції
 
 - {{jsxref("Global_Objects/eval", "eval()")}}
-- {{jsxref("Global_Objects/isFinite", "isFinite()")}}
-- {{jsxref("Global_Objects/isNaN", "isNaN()")}}
-- {{jsxref("Global_Objects/parseFloat", "parseFloat()")}}
-- {{jsxref("Global_Objects/parseInt", "parseInt()")}}
-- {{jsxref("Global_Objects/decodeURI", "decodeURI()")}}
-- {{jsxref("Global_Objects/decodeURIComponent", "decodeURIComponent()")}}
-- {{jsxref("Global_Objects/encodeURI", "encodeURI()")}}
-- {{jsxref("Global_Objects/encodeURIComponent", "encodeURIComponent()")}}
-- {{jsxref("Global_Objects/escape", "escape()")}} {{deprecated_inline}}
-- {{jsxref("Global_Objects/unescape", "unescape()")}} {{deprecated_inline}}
+- {{jsxref("isFinite()")}}
+- {{jsxref("isNaN()")}}
+- {{jsxref("parseFloat()")}}
+- {{jsxref("parseInt()")}}
+- {{jsxref("decodeURI()")}}
+- {{jsxref("decodeURIComponent()")}}
+- {{jsxref("encodeURI()")}}
+- {{jsxref("encodeURIComponent()")}}
+- {{jsxref("escape()")}} {{deprecated_inline}}
+- {{jsxref("unescape()")}} {{deprecated_inline}}
 
 ### Корінні об'єкти
 
@@ -192,15 +192,15 @@ page-type: landing-page
 ### Основні вирази
 
 - {{jsxref("Operators/this", "this")}}
-- [Literals](/uk/docs/Web/JavaScript/Reference/Lexical_grammar#literaly)
-- {{jsxref("Global_Objects/Array", "[]")}}
+- [Літерали](/uk/docs/Web/JavaScript/Reference/Lexical_grammar#literaly)
+- {{jsxref("Array", "[]")}}
 - {{jsxref("Operators/Object_initializer", "{}")}}
 - {{jsxref("Operators/function", "function")}}
 - {{jsxref("Operators/class", "class")}}
 - {{jsxref("Operators/function*", "function*")}}
 - {{jsxref("Operators/async_function", "async function")}}
 - {{jsxref("Operators/async_function*", "async function*")}}
-- {{jsxref("Global_Objects/RegExp", "/ab+c/i")}}
+- {{jsxref("RegExp", "/ab+c/i")}}
 - {{jsxref("Template_literals", "`string`")}}
 - {{jsxref("Operators/Grouping", "( )")}}
 


### PR DESCRIPTION
Оригінальний вміст: [Довідник з JavaScript@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference), [сирці Довідник з JavaScript@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/index.md)

Нові зміни:
- [mdn/content@fb85334](https://github.com/mdn/content/commit/fb85334ffa4a2c88d209b1074909bee0e0abd57a)