### PR TITLE
update(JS): web/javascript/reference/global_objects/date/tolocalestring

### DIFF
--- a/files/uk/web/javascript/reference/global_objects/date/tolocalestring/index.md
+++ b/files/uk/web/javascript/reference/global_objects/date/tolocalestring/index.md
@@ -151,7 +151,7 @@ console.log(date.toLocaleString("en-US", { hour12: false }));
 
 ## Дивіться також
 
-- {{jsxref("Global_Objects/Intl/DateTimeFormat", "Intl.DateTimeFormat")}}
+- {{jsxref("Intl.DateTimeFormat")}}
 - {{jsxref("Date.prototype.toLocaleDateString()")}}
 - {{jsxref("Date.prototype.toLocaleTimeString()")}}
 - {{jsxref("Date.prototype.toString()")}}


### PR DESCRIPTION
Оригінальний вміст: [Date.prototype.toLocaleString()@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleString), [сирці Date.prototype.toLocaleString()@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/global_objects/date/tolocalestring/index.md)

Нові зміни:
- [mdn/content@fb85334](https://github.com/mdn/content/commit/fb85334ffa4a2c88d209b1074909bee0e0abd57a)