### PR TITLE
update(JS): web/javascript/reference/operators

### DIFF
--- a/files/uk/web/javascript/reference/operators/index.md
+++ b/files/uk/web/javascript/reference/operators/index.md
@@ -21,7 +21,7 @@ browser-compat: javascript.operators
   - : Ключове слово `this` посилається на спеціальну властивість контексту виконання.
 - [Літерали](/uk/docs/Web/JavaScript/Reference/Lexical_grammar#literaly)
   - : Базові літерали `null`, булевих значень, чисел та рядків.
-- {{jsxref("Global_Objects/Array", "[]")}}
+- {{jsxref("Array", "[]")}}
   - : Синтаксис ініціалізаторів, чи літералів, масивів.
 - {{jsxref("Operators/Object_initializer", "{}")}}
   - : Синтаксис об'єктних ініціалізаторів – літералів.
@@ -35,7 +35,7 @@ browser-compat: javascript.operators
   - : `async function` оголошує вираз асинхронної функції.
 - {{jsxref("Operators/async_function*", "async function*")}}
   - : Ключові слова `async function*` оголошують вираз асинхронної функції-генератора.
-- {{jsxref("Global_Objects/RegExp", "/ab+c/i")}}
+- {{jsxref("RegExp", "/ab+c/i")}}
   - : Літеральний синтаксис регулярного виразу.
 - {{jsxref("Template_literals", "`string`")}}
   - : Синтаксис шаблонних літералів.


### PR DESCRIPTION
Оригінальний вміст: [Вирази та оператори@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Operators), [сирці Вирази та оператори@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/operators/index.md)

Нові зміни:
- [mdn/content@fb85334](https://github.com/mdn/content/commit/fb85334ffa4a2c88d209b1074909bee0e0abd57a)