### PR TITLE
update(JS): web/javascript/reference/global_objects/regexp/exec

### DIFF
--- a/files/uk/web/javascript/reference/global_objects/regexp/exec/index.md
+++ b/files/uk/web/javascript/reference/global_objects/regexp/exec/index.md
@@ -82,7 +82,7 @@ const result = re.exec("The Quick Brown Fox Jumps Over The Lazy Dog");
 
 ### Пошук послідовних збігів
 
-Коли регулярний вираз застосовує позначку [`g`](/uk/docs/Web/JavaScript/Guide/Regular_expressions#pohlyblenyi-poshuk-z-poznachkamy), можна використовувати метод `exec()` багато разів для отримання послідовних збігів у тому самому рядку. У такому випадку пошук починається від підрядка `str`, заданого властивістю регулярного виразу {{jsxref("RegExp/lastIndex", "lastIndex")}} ({{jsxref("RegExp.prototype.test()", "test()")}} також посуває властивість {{jsxref("RegExp/lastIndex", "lastIndex")}}). Зверніть увагу, що властивість {{jsxref("RegExp/lastIndex", "lastIndex")}} не скидається при пошуку в іншому рядку, а почне пошук згідно з наявним значенням {{jsxref("RegExp/lastIndex", "lastIndex")}}.
+Коли регулярний вираз застосовує позначку [`g`](/uk/docs/Web/JavaScript/Guide/Regular_expressions#pohlyblenyi-poshuk-z-poznachkamy), можна використовувати метод `exec()` багато разів для отримання послідовних збігів у тому самому рядку. У такому випадку пошук починається від підрядка `str`, заданого властивістю регулярного виразу {{jsxref("RegExp/lastIndex", "lastIndex")}} ({{jsxref("RegExp/test", "test()")}} також посуває властивість {{jsxref("RegExp/lastIndex", "lastIndex")}}). Зверніть увагу, що властивість {{jsxref("RegExp/lastIndex", "lastIndex")}} не скидається при пошуку в іншому рядку, а почне пошук згідно з наявним значенням {{jsxref("RegExp/lastIndex", "lastIndex")}}.
 
 Наприклад, припустімо, є такий сценарій:
 


### PR DESCRIPTION
Оригінальний вміст: [RegExp.prototype.exec()@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Global_Objects/RegExp/exec), [сирці RegExp.prototype.exec()@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/global_objects/regexp/exec/index.md)

Нові зміни:
- [mdn/content@fb85334](https://github.com/mdn/content/commit/fb85334ffa4a2c88d209b1074909bee0e0abd57a)