### PR TITLE
update(JS): web/javascript/reference/global_objects/string/trim

### DIFF
--- a/files/uk/web/javascript/reference/global_objects/string/trim/index.md
+++ b/files/uk/web/javascript/reference/global_objects/string/trim/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.String.trim
 
 Метод **`trim()`** (підрізати, привести до ладу) значень {{jsxref("String")}} видаляє пробільні символи з обох кінців свого рядка і повертає результат як новий рядок, без внесення змін в початковий.
 
-Аби отримати новий рядок, в якому пробільні символи обрізані лише з одного кінця, слід використати методи {{jsxref("String.prototype.trimStart()", "trimStart()")}} чи {{jsxref("String.prototype.trimEnd()", "trimEnd()")}}.
+Аби отримати новий рядок, в якому пробільні символи обрізані лише з одного кінця, слід використати методи {{jsxref("String/trimStart", "trimStart()")}} чи {{jsxref("String/trimEnd", "trimEnd()")}}.
 
 {{EmbedInteractiveExample("pages/js/string-trim.html")}}
 


### PR DESCRIPTION
Оригінальний вміст: [String.prototype.trim()@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Global_Objects/String/trim), [сирці String.prototype.trim()@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/global_objects/string/trim/index.md)

Нові зміни:
- [mdn/content@fb85334](https://github.com/mdn/content/commit/fb85334ffa4a2c88d209b1074909bee0e0abd57a)