### PR TITLE
update(CSS): web/css/css_selectors

### DIFF
--- a/files/uk/web/css/css_selectors/index.md
+++ b/files/uk/web/css/css_selectors/index.md
@@ -17,10 +17,10 @@ spec-urls: https://drafts.csswg.org/selectors/
 
 ### Комбінатори та розділювачі
 
-- `+` ([Комбінатор суміжних чи наступних сестринських елементів](/uk/docs/Web/CSS/Adjacent_sibling_combinator))
+- `+` ([Комбінатор наступної сестри](/uk/docs/Web/CSS/Next-sibling_combinator))
 - `>` ([Дочірній комбінатор](/uk/docs/Web/CSS/Child_combinator))
 - `||` ([Колонковий комбінатор](/uk/docs/Web/CSS/Column_combinator)) {{Experimental_Inline}}
-- `~` ([Комбінатор загальних чи подальших сестринських елементів](/uk/docs/Web/CSS/General_sibling_combinator))
+- `~` ([Комбінатор подальших сестер](/uk/docs/Web/CSS/Subsequent-sibling_combinator))
 - " " ([Комбінатор нащадків](/uk/docs/Web/CSS/Descendant_combinator))
 - `|` ([Розділювач областей імен](/uk/docs/Web/CSS/Namespace_separator))
 
@@ -63,9 +63,8 @@ spec-urls: https://drafts.csswg.org/selectors/
 - {{CSSXref(":muted")}}
 - {{CSSXref(":not", ":not()")}}
 - {{CSSXref(":nth-child", ":nth-child()")}}
-- {{CSSXref(":nth-col", ":nth-col()")}}
+- {{CSSXref(":nth-of-type", ":nth-of-type()")}}
 - {{CSSXref(":nth-last-child", ":nth-last-child()")}}
-- {{CSSXref(":nth-last-col", ":nth-last-col()")}}
 - {{CSSXref(":nth-last-of-type", ":nth-last-of-type()")}}
 - {{CSSXref(":nth-of-type", ":nth-of-type()")}}
 - {{CSSXref(":only-child")}}


### PR DESCRIPTION
Оригінальний вміст: [Селектори CSS@MDN](https://developer.mozilla.org/en-us/docs/Web/CSS/CSS_selectors), [сирці Селектори CSS@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/css/css_selectors/index.md)

Нові зміни:
- [mdn/content@bb652aa](https://github.com/mdn/content/commit/bb652aaf3e38f3c7fef970a62f813047dffac879)
- [mdn/content@30c8486](https://github.com/mdn/content/commit/30c8486641d7aba05079003bff5d8807a44cb395)