### PR TITLE
update(JS): web/javascript/reference/global_objects/array/concat

### DIFF
--- a/files/uk/web/javascript/reference/global_objects/array/concat/index.md
+++ b/files/uk/web/javascript/reference/global_objects/array/concat/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.Array.concat
 
 Метод **`concat()`** (зчепити) використовується для злиття двох і більше масивів. Він не змінює наявні масиви, а повертає новий.
 
-{{EmbedInteractiveExample("pages/js/array-concat.html","shorter")}}
+{{EmbedInteractiveExample("pages/js/array-concat.html", "shorter")}}
 
 ## Синтаксис
 

--- a/files/uk/web/javascript/reference/global_objects/array/concat/index.md
+++ b/files/uk/web/javascript/reference/global_objects/array/concat/index.md
@@ -150,7 +150,7 @@ console.log(Array.prototype.concat.call(arrayLike, 3, 4)); // [1, 2, 3, 4]
 ## Дивіться також
 
 - [Поліфіл для `Array.prototype.concat` доступний в складі `core-js`, разом з виправленнями й реалізацією сучасної логіки типу підтримки `Symbol.isConcatSpreadable`](https://github.com/zloirock/core-js#ecmascript-array)
-- [Колекції з індексами](/uk/docs/Web/JavaScript/Guide/Indexed_collections)
+- Посібник [Колекції з індексами](/uk/docs/Web/JavaScript/Guide/Indexed_collections)
 - {{jsxref("Array")}}
 - {{jsxref("Array.prototype.push()")}}
 - {{jsxref("Array.prototype.unshift()")}}


### PR DESCRIPTION
Оригінальний вміст: [Array.prototype.concat()@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Global_Objects/Array/concat), [сирці Array.prototype.concat()@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/global_objects/array/concat/index.md)

Нові зміни:
- [mdn/content@5c3c25f](https://github.com/mdn/content/commit/5c3c25fd4f2fbd7a5f01727a65c2f70d73f1880a)
- [mdn/content@e01fd62](https://github.com/mdn/content/commit/e01fd6206ce2fad2fe09a485bb2d3ceda53a62de)