### PR TITLE
update(JS): web/javascript/reference/operators/property_accessors

### DIFF
--- a/files/uk/web/javascript/reference/operators/property_accessors/index.md
+++ b/files/uk/web/javascript/reference/operators/property_accessors/index.md
@@ -26,7 +26,7 @@ object[expression]
 
 ### Крапкова нотація
 
-`propertyName` у синтаксисі `object.propertyName` має бути дійсним [ідентифікатором](/uk/docs/Web/JavaScript/Reference/Lexical_grammar#identyfikatory) JavaScript, який також може бути [зарезервованим словом](/uk/docs/Web/JavaScript/Reference/Lexical_grammar#klichovi-slova). Наприклад, `object.$1` – дійсне звертання, тоді як `object.1` – ні.
+`propertyName` у синтаксисі `object.propertyName` має бути дійсним [ідентифікатором](/uk/docs/Web/JavaScript/Reference/Lexical_grammar#identyfikatory) JavaScript, який також може бути [зарезервованим словом](/uk/docs/Web/JavaScript/Reference/Lexical_grammar#kliuchovi-slova). Наприклад, `object.$1` – дійсне звертання, тоді як `object.1` – ні.
 
 ```js
 const variable = object.propertyName;
@@ -39,7 +39,7 @@ object.$1 = "foo";
 console.log(object.$1); // 'foo'
 ```
 
-```js example-bad
+```js-nolint example-bad
 const object = {};
 object.1 = 'bar'; // SyntaxError
 console.log(object.1); // SyntaxError
@@ -158,4 +158,4 @@ const x = document.forms.form_name.elements[strFormControl].value;
 
 - {{jsxref("Object")}}
 - {{jsxref("Object.defineProperty()")}}
-- [Необов'язковий ланцюжок](/uk/docs/Web/JavaScript/Reference/Operators/Optional_chaining)
+- [Необов'язковий ланцюжок (`?.`)](/uk/docs/Web/JavaScript/Reference/Operators/Optional_chaining)


### PR DESCRIPTION
Оригінальний вміст: [Аксесори властивостей@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Operators/Property_accessors), [сирці Аксесори властивостей@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/operators/property_accessors/index.md)

Нові зміни:
- [mdn/content@c6f0f10](https://github.com/mdn/content/commit/c6f0f106b9083984dbf597678def6561729bb459)
- [mdn/content@4c26e8a](https://github.com/mdn/content/commit/4c26e8a3fb50d06963b06017f51ce19364350564)