### PR TITLE
update(JS): web/javascript/reference/global_objects/array/length

### DIFF
--- a/files/uk/web/javascript/reference/global_objects/array/length/index.md
+++ b/files/uk/web/javascript/reference/global_objects/array/length/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.Array.length
 
 Властивість даних **`length`** (довжина) примірника {{jsxref("Array")}}, що представляє число елементів у такому масиві. Значення є беззнаковим 32-бітовим цілим числом, котре завжди більше за найбільший індекс елемента масиву.
 
-{{EmbedInteractiveExample("pages/js/array-length.html","shorter")}}
+{{EmbedInteractiveExample("pages/js/array-length.html", "shorter")}}
 
 ## Значення
 
@@ -127,6 +127,6 @@ numbers.push(5); // // TypeError: Cannot assign to read only property 'length' o
 
 - [Колекції з індексами](/uk/docs/Web/JavaScript/Guide/Indexed_collections)
 - {{jsxref("Array")}}
-- [`TypedArray`: `length`](/uk/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/length)
+- [`TypedArray.prototype.length`](/uk/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/length)
 - [`String`: `length`](/uk/docs/Web/JavaScript/Reference/Global_Objects/String/length)
 - [RangeError: invalid array length](/uk/docs/Web/JavaScript/Reference/Errors/Invalid_array_length)


### PR DESCRIPTION
Оригінальний вміст: [Array: length@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Global_Objects/Array/length), [сирці Array: length@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/global_objects/array/length/index.md)

Нові зміни:
- [mdn/content@5c3c25f](https://github.com/mdn/content/commit/5c3c25fd4f2fbd7a5f01727a65c2f70d73f1880a)
- [mdn/content@e01fd62](https://github.com/mdn/content/commit/e01fd6206ce2fad2fe09a485bb2d3ceda53a62de)