### PR TITLE
update(JS): web/javascript/reference/global_objects/string/link

### DIFF
--- a/files/uk/web/javascript/reference/global_objects/string/link/index.md
+++ b/files/uk/web/javascript/reference/global_objects/string/link/index.md
@@ -7,7 +7,7 @@ status:
 browser-compat: javascript.builtins.String.link
 ---
 
-{{JSRef}} {{deprecated_header}}
+{{JSRef}} {{Deprecated_Header}}
 
 Метод **`link()`** (посилання) значень {{jsxref("String")}} створює рядок, що вбудовує рядок цього методу в елемент {{HTMLElement("a")}} (`<a href="...">str</a>`), аби використати його як гіпертекстове посилання на іншу URL-адресу.
 
@@ -32,14 +32,28 @@ link(url)
 
 ### Застосування link()
 
-Наступний приклад показує слово "WebDoky" як гіпертекстове посилання, яке повертає користувача до вебсайту WebDoky.
+Код нижче створює рядок HTML, а потім замінює ним тіло документа:
 
 ```js
-const hotText = "WebDoky";
-var const = "https://webdoky.org/";
+const contentString = "ВебДоки";
 
-console.log(`Клацніть, щоб повернутися до ${hotText.link(url)}`);
-// Клацніть, щоб повернутися до <a href="https://webdoky.org/">WebDoky</a>
+document.body.innerHTML = contentString.link("https://webdoky.org/");
+```
+
+Це створить наступний HTML:
+
+```html
+<a href="https://webdoky.org/">ВебДоки</a>
+```
+
+Замість використання `link()` і безпосереднього створення тексту HTML слід використовувати API DOM, такі як [`document.createElement()`](/uk/docs/Web/API/Document/createElement). Наприклад:
+
+```js
+const contentString = "ВебДоки";
+const elem = document.createElement("a");
+elem.href = "https://webdoky.org/";
+elem.innerText = contentString;
+document.body.appendChild(elem);
 ```
 
 ## Специфікації
@@ -53,5 +67,5 @@ console.log(`Клацніть, щоб повернутися до ${hotText.link
 ## Дивіться також
 
 - [Поліфіл `String.prototype.link` у складі `core-js`](https://github.com/zloirock/core-js#ecmascript-string-and-regexp)
-- {{jsxref("String.prototype.anchor()")}}
-- {{domxref("document.links")}}
+- [Методи для обгортання в HTML](/uk/docs/Web/JavaScript/Reference/Global_Objects/String#metody-dlia-obhortannia-v-html)
+- {{HTMLElement("a")}}


### PR DESCRIPTION
Оригінальний вміст: [String.prototype.link()@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Global_Objects/String/link), [сирці String.prototype.link()@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/global_objects/string/link/index.md)

Нові зміни:
- [mdn/content@5a2cea7](https://github.com/mdn/content/commit/5a2cea779777daaff451f21ca3b7f4c28a68de9e)
- [mdn/content@c2445ce](https://github.com/mdn/content/commit/c2445ce1dc3a0170e2fbfdbee10e18a7455c2282)