### PR TITLE
update(JS): web/javascript/reference/global_objects/string/substr

### DIFF
--- a/files/uk/web/javascript/reference/global_objects/string/substr/index.md
+++ b/files/uk/web/javascript/reference/global_objects/string/substr/index.md
@@ -7,7 +7,7 @@ status:
 browser-compat: javascript.builtins.String.substr
 ---
 
-{{JSRef}} {{deprecated_header}}
+{{JSRef}} {{Deprecated_Header}}
 
 Метод **`substr()`** (підрядок) значень {{jsxref("String")}} повертає порцію рядка, яка починається за вказаним індексом і продовжується протягом заданої кількості символів.
 


### PR DESCRIPTION
Оригінальний вміст: [String.prototype.substr()@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Global_Objects/String/substr), [сирці String.prototype.substr()@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/global_objects/string/substr/index.md)

Нові зміни:
- [mdn/content@c2445ce](https://github.com/mdn/content/commit/c2445ce1dc3a0170e2fbfdbee10e18a7455c2282)