### PR TITLE
update(JS): web/javascript/reference/global_objects/json/stringify

### DIFF
--- a/files/uk/web/javascript/reference/global_objects/json/stringify/index.md
+++ b/files/uk/web/javascript/reference/global_objects/json/stringify/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.JSON.stringify
 
 Статичний метод **`JSON.stringify()`** (перетворити на рядок) перетворює значення JavaScript на рядок JSON, додатково замінюючи значення, якщо була вказана необов'язкова функція-замінювач, або ж додатково вибираючи лише вказані властивості, якщо було передано замінювач-масив.
 
-{{EmbedInteractiveExample("pages/js/json-stringify.html")}}
+{{EmbedInteractiveExample("pages/js/json-stringify.html", "taller")}}
 
 ## Синтаксис
 


### PR DESCRIPTION
Оригінальний вміст: [JSON.stringify()@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify), [сирці JSON.stringify()@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/global_objects/json/stringify/index.md)

Нові зміни:
- [mdn/content@c607c48](https://github.com/mdn/content/commit/c607c483fe079c61de5e32fba1a6cce61896e97d)