### PR TITLE
update(JS): web/javascript/reference/lexical_grammar

### DIFF
--- a/files/uk/web/javascript/reference/lexical_grammar/index.md
+++ b/files/uk/web/javascript/reference/lexical_grammar/index.md
@@ -557,7 +557,7 @@ tag`string text ${expression} string text`
 - [`do...while`](/uk/docs/Web/JavaScript/Reference/Statements/do...while)
 - [`continue`](/uk/docs/Web/JavaScript/Reference/Statements/continue), [`break`](/uk/docs/Web/JavaScript/Reference/Statements/break), [`return`](/uk/docs/Web/JavaScript/Reference/Statements/return), [`throw`](/uk/docs/Web/JavaScript/Reference/Statements/throw)
 - [`debugger`](/uk/docs/Web/JavaScript/Reference/Statements/debugger)
-- Оголошення полів класів ([публічних](/uk/docs/Web/JavaScript/Reference/Classes/Public_class_fields) та [приватних](/uk/docs/Web/JavaScript/Reference/Classes/Private_class_fields))
+- Оголошення полів класів ([публічних](/uk/docs/Web/JavaScript/Reference/Classes/Public_class_fields) та [приватних](/uk/docs/Web/JavaScript/Reference/Classes/Private_properties))
 - [`import`](/uk/docs/Web/JavaScript/Reference/Statements/import), [`export`](/uk/docs/Web/JavaScript/Reference/Statements/export)
 
 Проте для того, щоб мова JavaScript була доступнішою та зрозумілішою, JavaScript автоматично вставляє крапки з комою, коли захоплює потік лексем, тож частина недійсних послідовностей лексем може бути "виправлена" до дійсного синтаксису. Цей крок відбувається після того, як текст програми розбирається на лексеми згідно з лексичною граматикою. Є три випадки, за яких автоматично вставляються крапки з комою:


### PR DESCRIPTION
Оригінальний вміст: [Лексична граматика@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Lexical_grammar), [сирці Лексична граматика@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/lexical_grammar/index.md)

Нові зміни:
- [mdn/content@41cddfd](https://github.com/mdn/content/commit/41cddfdaeed4a73fb8234c332150df8e54df31e9)