### PR TITLE
update(JS): web/javascript/reference

### DIFF
--- a/files/uk/web/javascript/reference/index.md
+++ b/files/uk/web/javascript/reference/index.md
@@ -330,7 +330,7 @@ page-type: landing-page
 
 - {{jsxref("Classes/Constructor", "constructor")}}
 - {{jsxref("Classes/extends", "extends")}}
-- [Приватні властивості класів](/uk/docs/Web/JavaScript/Reference/Classes/Private_class_fields)
+- [Приватні властивості](/uk/docs/Web/JavaScript/Reference/Classes/Private_properties)
 - [Публічні поля класів](/uk/docs/Web/JavaScript/Reference/Classes/Public_class_fields)
 - {{jsxref("Classes/static", "static")}}
 - [Блоки статичної ініціалізації](/uk/docs/Web/JavaScript/Reference/Classes/Static_initialization_blocks)


### PR DESCRIPTION
Оригінальний вміст: [Довідник з JavaScript@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference), [сирці Довідник з JavaScript@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/index.md)

Нові зміни:
- [mdn/content@41cddfd](https://github.com/mdn/content/commit/41cddfdaeed4a73fb8234c332150df8e54df31e9)