### PR TITLE
update(CSS): web/css/-moz-force-broken-image-icon

### DIFF
--- a/files/uk/web/css/-moz-force-broken-image-icon/index.md
+++ b/files/uk/web/css/-moz-force-broken-image-icon/index.md
@@ -68,4 +68,4 @@ img {
 
 ## Дивіться також
 
-- [Вада Webkit 58646](https://bugzil.la/58646)
+- [Вада Firefox 58646](https://bugzil.la/58646)


### PR DESCRIPTION
Оригінальний вміст: [-moz-force-broken-image-icon@MDN](https://developer.mozilla.org/en-us/docs/Web/CSS/-moz-force-broken-image-icon), [сирці -moz-force-broken-image-icon@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/css/-moz-force-broken-image-icon/index.md)

Нові зміни:
- [mdn/content@88241bf](https://github.com/mdn/content/commit/88241bf466f1025d3c2f4ce2752586dd85d1ae13)