### PR TITLE
update(CSS): web/css/css_selectors

### DIFF
--- a/files/uk/web/css/css_selectors/index.md
+++ b/files/uk/web/css/css_selectors/index.md
@@ -66,7 +66,6 @@ spec-urls: https://drafts.csswg.org/selectors/
 - {{CSSXref(":nth-of-type", ":nth-of-type()")}}
 - {{CSSXref(":nth-last-child", ":nth-last-child()")}}
 - {{CSSXref(":nth-last-of-type", ":nth-last-of-type()")}}
-- {{CSSXref(":nth-of-type", ":nth-of-type()")}}
 - {{CSSXref(":only-child")}}
 - {{CSSXref(":only-of-type")}}
 - {{CSSXref(":optional")}}


### PR DESCRIPTION
Оригінальний вміст: [Селектори CSS@MDN](https://developer.mozilla.org/en-us/docs/Web/CSS/CSS_selectors), [сирці Селектори CSS@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/css/css_selectors/index.md)

Нові зміни:
- [fix: remove duplicate nth-of-type entry (#30540)](https://github.com/mdn/content/commit/620e8846e0c617e1b93b7aa92f8bb86ce7fb975b)