### PR TITLE
update(CSS): web/css/gradient/linear-gradient

### DIFF
--- a/files/uk/web/css/gradient/linear-gradient/index.md
+++ b/files/uk/web/css/gradient/linear-gradient/index.md
@@ -16,27 +16,37 @@ browser-compat: css.types.image.gradient.linear-gradient
 ```css
 /* Градієнт під кутом 45 градусів,
   починається синім і закінчується червоним */
-linear-gradient(45deg, blue, red);
+linear-gradient(45deg, blue, red)
 
 /* Градієнт з нижнього правого кута у верхній лівий кут,
    починається синім і закінчується червоним */
-linear-gradient(to left top, blue, red);
+linear-gradient(to left top, blue, red)
+
+/* Інтерполяція в прямокутному кольоровому просторі */
+linear-gradient(in oklab, blue, red)
+
+/* Інтерполяція в полярному кольоровому просторі */
+linear-gradient(in hsl, blue, red)
+
+/* Інтерполяція в полярному кольоровому просторі
+   з довшим методом інтерполяції відтінку */
+linear-gradient(in hsl longer hue, blue, red)
 
 /* Зупинка кольору: градієнт йде знизу догори,
    починається синім, стає зеленим на 40% своєї довжини,
    і закінчується червоним */
-linear-gradient(0deg, blue, green 40%, red);
+linear-gradient(0deg, blue, green 40%, red)
 
 /* Підказка кольору: градієнт іде зліва направо,
    починається червоним, досягає середнього кольору
    на 10% своєї довжини,
    витрачаючи решту 90% своєї довжини на перехід до синього */
-linear-gradient(.25turn, red, 10%, blue);
+linear-gradient(.25turn, red, 10%, blue)
 
 /* Багатопозиційна зупинка кольору: градієнт під кутом 45 градусів,
    з червоною половиною знизу зліва і синьою половиною згори справа,
    з різкою лінією там, де градієнт переходить від червоного до синього */
-linear-gradient(45deg, red 0 50%, blue 50% 100%);
+linear-gradient(45deg, red 0 50%, blue 50% 100%)
 ```
 
 ### Значення
@@ -147,6 +157,54 @@ body {
 
 {{EmbedLiveSample("hradiient-shcho-pochynaietsia-na-60-svoiei-linii", 120, 120)}}
 
+### Інтерполяція в прямокутному кольоровому просторі
+
+```css hidden
+body {
+  width: 100vw;
+  height: 100vh;
+}
+```
+
+```css
+body {
+  background: linear-gradient(90deg in oklab, blue, red);
+}
+```
+
+{{EmbedLiveSample("interpoliatsiia-v-pryamokutnomu-kolorovomu-prostori", 120, 120)}}
+
+### Інтерполяція з відтінком
+
+```html hidden
+<div class="shorter">коротший відтінок</div>
+<div class="longer">довший відтінок</div>
+```
+
+```css hidden
+div {
+  height: 50vh;
+  color: white;
+  font-weight: bolder;
+}
+```
+
+У цьому прикладі інтерполяції використовується система кольорів [hsl](/uk/docs/Web/CSS/color_value/hsl), а інтерполюється [відтінок](/uk/docs/Web/CSS/hue).
+
+```css
+.shorter {
+  background: linear-gradient(90deg in hsl shorter hue, red, blue);
+}
+
+.longer {
+  background: linear-gradient(90deg in hsl longer hue, red, blue);
+}
+```
+
+Рамка згори використовує [коротшу інтерполяцію](/uk/docs/Web/CSS/hue-interpolation-method#korotshyi), що означає, що колір йде прямо від червоного до синього, використовуючи коротку дугу на [колірному колесі](/uk/docs/Glossary/Color_wheel). Рамка знизу використовує [довшу інтерполяцію](/uk/docs/Web/CSS/hue-interpolation-method#dovshyi), що означає, що колір йде від червоного до синього, використовуючи довшу дугу, проходячи через зелені, жовті та помаранчеві.
+
+{{EmbedLiveSample("interpoliatsiia-z-vidtinkom", 120, 120)}}
+
 ### Градієнт з колірними зупинками з багатьма положеннями
 
 Цей приклад демонструє колірні зупинки з багатьма положеннями, де сусідні кольори мають однакове значення колірної зупинки, утворюючи ефект смуг.
@@ -189,6 +247,8 @@ body {
 
 - [Використання градієнтів CSS](/uk/docs/Web/CSS/CSS_images/Using_CSS_gradients)
 - Інші функції градієнта: {{cssxref("gradient/repeating-linear-gradient", "repeating-linear-gradient()")}}, {{cssxref("gradient/radial-gradient", "radial-gradient()")}}, {{cssxref("gradient/repeating-radial-gradient", "repeating-radial-gradient()")}}, {{cssxref("gradient/conic-gradient", "conic-gradient()")}}, {{cssxref("gradient/repeating-conic-gradient", "repeating-conic-gradient()")}}
+- [`<hue-interpolation-method>`](/uk/docs/Web/CSS/hue-interpolation-method)
+- [`<color-interpolation-method>`](/uk/docs/Web/CSS/color-interpolation-method)
 - {{CSSxRef("&lt;image&gt;")}}
 - {{cssxref("element", "element()")}}
 - {{cssxref("image/image","image()")}}


### PR DESCRIPTION
Оригінальний вміст: [linear-gradient()@MDN](https://developer.mozilla.org/en-us/docs/Web/CSS/gradient/linear-gradient), [сирці linear-gradient()@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/css/gradient/linear-gradient/index.md)

Нові зміни:
- [fix(css): add color space info to gradient pages (#30047)](https://github.com/mdn/content/commit/989c46b1fef23773911b40f7dfd716fc73d942a6)
- [Run "yarn tool fix-flaws" on /web/css (part 3) (#27997)](https://github.com/mdn/content/commit/5e7d1f9ae2cce0cb3f7693dfb8dc6e8d375b2231)