### PR TITLE
update(JS): web/javascript/reference/global_objects/date/now

### DIFF
--- a/files/uk/web/javascript/reference/global_objects/date/now/index.md
+++ b/files/uk/web/javascript/reference/global_objects/date/now/index.md
@@ -73,5 +73,5 @@ console.log(`Time elapsed: ${Date.now() - start} ms`);
 
 - [Поліфіл `Date.now` у складі `core-js`](https://github.com/zloirock/core-js#ecmascript-date)
 - {{domxref("Performance.now()")}}
-- {{domxref("console.time()")}}
-- {{domxref("console.timeEnd()")}}
+- {{domxref("console/time_static", "console.time()")}}
+- {{domxref("console/timeEnd_static", "console.timeEnd()")}}


### PR DESCRIPTION
Оригінальний вміст: [Date.now()@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Global_Objects/Date/now), [сирці Date.now()@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/global_objects/date/now/index.md)

Нові зміни:
- [Fix links to static console methods (#30528)](https://github.com/mdn/content/commit/dae250f0451c1072def7db7eaa392bfb00598d62)