### PR TITLE
update(CSS): web/css/@font-face

### DIFF
--- a/files/uk/web/css/@font-face/index.md
+++ b/files/uk/web/css/@font-face/index.md
@@ -14,9 +14,11 @@ browser-compat: css.at-rules.font-face
 ```css
 @font-face {
   font-family: "Trickster";
-  src: local("Trickster"),
-    url("trickster-COLRv1.otf") format("opentype") tech(color-COLRv1), url("trickster-outline.otf")
-      format("opentype"), url("trickster-outline.woff") format("woff");
+  src:
+    local("Trickster"),
+    url("trickster-COLRv1.otf") format("opentype") tech(color-COLRv1),
+    url("trickster-outline.otf") format("opentype"),
+    url("trickster-outline.woff") format("woff");
 }
 ```
 
@@ -104,7 +106,7 @@ browser-compat: css.at-rules.font-face
 Цей приклад задає використання віддаленого шрифту, застосовуючи його до всього тіла документа:
 
 ```html
-<!DOCTYPE html>
+<!doctype html>
 <html lang="uk">
   <head>
     <meta charset="utf-8" />
@@ -154,7 +156,7 @@ browser-compat: css.at-rules.font-face
 
 ## Дивіться також
 
-- [Про WOFF](/uk/docs/Web/Guide/WOFF)
+- [Про WOFF](/uk/docs/Web/CSS/CSS_fonts/WOFF)
 - [Генератор @font-face – FontSquirrel](https://www.fontsquirrel.com/tools/webfont-generator)
 - [Прекрасні шрифти з допомогою @font-face](https://hacks.mozilla.org/2009/06/beautiful-fonts-with-font-face/)
 - [Бібліотека шрифтів](https://fontlibrary.org/)


### PR DESCRIPTION
Оригінальний вміст: ["@font-face"@MDN](https://developer.mozilla.org/en-us/docs/Web/CSS/@font-face), [сирці "@font-face"@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/css/@font-face/index.md)

Нові зміни:
- [Move WOFF from guides to fonts (#30643)](https://github.com/mdn/content/commit/2c93a52b1c3bf901943c16ea739ca6ee45b51845)
- [Bump prettier from 2.8.8 to 3.0.0 (#27777)](https://github.com/mdn/content/commit/acfe8c9f1f4145f77653a2bc64a9744b001358dc)