### PR TITLE
update(CSS): web/css/text-align

### DIFF
--- a/files/uk/web/css/text-align/index.md
+++ b/files/uk/web/css/text-align/index.md
@@ -24,10 +24,6 @@ text-align: justify;
 text-align: justify-all;
 text-align: match-parent;
 
-/* Посимвольне шикування в колонці таблиці */
-text-align: ".";
-text-align: "." center;
-
 /* Значення блокового шикування (нестандартний синтаксис) */
 text-align: -moz-center;
 text-align: -webkit-center;
@@ -64,8 +60,6 @@ text-align: unset;
   - : Те саме, що `justify`, але, крім того, рівномірно розподіляє останній рядок.
 - `match-parent`
   - : Подібне до `inherit`, але значення `start` і `end` обчислюються згідно з {{cssxref("direction")}} батьківського елемента і замінюються відповідним значенням – `left` чи `right`.
-- {{cssxref("&lt;string&gt;")}} {{experimental_inline}}
-  - : Бувши застосованим до комірки таблиці, таке значення задає символ шикування, навколо якого шикуватиметься вміст комірки.
 
 ## Занепокоєння щодо доступності
 


### PR DESCRIPTION
Оригінальний вміст: [text-align@MDN](https://developer.mozilla.org/en-us/docs/Web/CSS/text-align), [сирці text-align@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/css/text-align/index.md)

Нові зміни:
- [fix(css): remove un-implemented value from text-align page (#31119)](https://github.com/mdn/content/commit/64fe101e82b2c40038d1b876d25100e34286a690)