### PR TITLE
update(JS): web/javascript/reference/iteration_protocols

### DIFF
--- a/files/uk/web/javascript/reference/iteration_protocols/index.md
+++ b/files/uk/web/javascript/reference/iteration_protocols/index.md
@@ -123,8 +123,7 @@ console.log(aGeneratorObject[Symbol.iterator]() === aGeneratorObject);
 ### Вбудовані ітеровані об'єкти
 
 {{jsxref("String")}}, {{jsxref("Array")}}, {{jsxref("TypedArray")}}, {{jsxref("Map")}}, {{jsxref("Set")}} і [`Segments`](/uk/docs/Web/JavaScript/Reference/Global_Objects/Intl/Segmenter/segment/Segments) (повернений з [`Intl.Segmenter.prototype.segment()`](/uk/docs/Web/JavaScript/Reference/Global_Objects/Intl/Segmenter/segment)) є вбудованими ітерованими об'єктами, адже кожний з їхніх об'єктів `prototype` має реалізацію метода `@@iterator`. На додачу, об'єкт [`arguments`](/uk/docs/Web/JavaScript/Reference/Functions/arguments) і частина типів колекцій DOM, як то {{domxref("NodeList")}}, так само є ітерованими об'єктами.
-
-[`ReadableStream`](/uk/docs/Web/API/ReadableStream) – єдиний вбудований асинхронно ітерований об'єкт на час написання цих слів.
+У ядрі мови JavaScript немає жодного об'єкта, що був би асинхронним ітерованим. Деякі API Вебу, як то {{domxref("ReadableStream")}}, усталено мають метод `Symbol.asyncIterator`.
 
 [Генераторні функції](/uk/docs/Web/JavaScript/Reference/Statements/function*) повертають [генераторні об'єкти](/uk/docs/Web/JavaScript/Reference/Global_Objects/Generator), котрі є ітерованими ітераторами. [Асинхронні генераторні функції](/uk/docs/Web/JavaScript/Reference/Statements/async_function*) повертають [асинхронні генераторні об'єкти](/uk/docs/Web/JavaScript/Reference/Global_Objects/AsyncGenerator), котрі є асинхронними ітерованими ітераторами.
 


### PR DESCRIPTION
Оригінальний вміст: [Протоколи ітерування@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Iteration_protocols), [сирці Протоколи ітерування@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/iteration_protocols/index.md)

Нові зміни:
- [update list for async iterable objects (#31320)](https://github.com/mdn/content/commit/8d837c2d6de12aa24a45b6344603c210a44f8e90)