### PR TITLE
update(CSS): web/css/css_flexible_box_layout

### DIFF
--- a/files/uk/web/css/css_flexible_box_layout/index.md
+++ b/files/uk/web/css/css_flexible_box_layout/index.md
@@ -65,6 +65,8 @@ spec-urls: https://drafts.csswg.org/css-flexbox/
 
 ## Дивіться також
 
+- Модуль [Відображення CSS](/uk/docs/Web/CSS/CSS_display)
+- [Використання синтаксису із кількома значеннями у Відображенні CSS](/uk/docs/Web/CSS/display/multi-keyword_syntax_of_display)
 - Терміни Глосарія:
   - {{Glossary("Flexbox", "Флексбокс")}}
   - {{Glossary("Flex Container", "Гнучкий контейнер")}}


### PR DESCRIPTION
Оригінальний вміст: [Компонування гнучкої рамки CSS@MDN](https://developer.mozilla.org/en-us/docs/Web/CSS/CSS_flexible_box_layout), [сирці Компонування гнучкої рамки CSS@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/css/css_flexible_box_layout/index.md)

Нові зміни:
- [docs(CSS): Allow more usage of multi-keyword `display` values  (#30831)](https://github.com/mdn/content/commit/b9db4e51b6f1cddba3af708643fc9804849d61c2)