### PR TITLE
update(CSS): web/css/css_grid_layout

### DIFF
--- a/files/uk/web/css/css_grid_layout/index.md
+++ b/files/uk/web/css/css_grid_layout/index.md
@@ -151,6 +151,8 @@ spec-urls: https://drafts.csswg.org/css-grid/
   - [Вісь сітки](/uk/docs/Glossary/Grid_Axis)
   - [Ряд сітки](/uk/docs/Glossary/Grid_Row)
   - [Колонка сітки](/uk/docs/Glossary/Grid_Column)
+- Модуль [Компонування гнучкої рамки CSS](/uk/docs/Web/CSS/CSS_flexible_box_layout)
+- Модуль [Відображення CSS](/uk/docs/Web/CSS/CSS_display)
 - [Сітка за прикладом](https://gridbyexample.com/) - Колекція прикладів застосування та відеоуроків
 - [Довідка сітки CSS - Codrops (англ.)](https://tympanus.net/codrops/css_reference/grid/)
 - [Інспектор сітки CSS - Firefox DevTools (англ.)](https://firefox-source-docs.mozilla.org/devtools-user/page_inspector/how_to/examine_grid_layouts/index.html)


### PR DESCRIPTION
Оригінальний вміст: [Сіткове компонування CSS@MDN](https://developer.mozilla.org/en-us/docs/Web/CSS/CSS_grid_layout), [сирці Сіткове компонування CSS@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/css/css_grid_layout/index.md)

Нові зміни:
- [docs(CSS): Allow more usage of multi-keyword `display` values  (#30831)](https://github.com/mdn/content/commit/b9db4e51b6f1cddba3af708643fc9804849d61c2)
- [fix(css): Titles in module landing pages should follow sentence casing (#27280)](https://github.com/mdn/content/commit/6e1e7200ae79f8f292a18ba2af2ee190d88cb7e8)