### PR TITLE
update(HTML): web/html/element/meter

### DIFF
--- a/files/uk/web/html/element/meter/index.md
+++ b/files/uk/web/html/element/meter/index.md
@@ -142,3 +142,4 @@ browser-compat: html.elements.meter
 ## Дивіться також
 
 - {{HTMLElement("progress")}}
+- {{cssxref("::-webkit-meter-bar")}}, {{cssxref("::-webkit-meter-inner-element")}}, {{cssxref("::-webkit-meter-even-less-good-value")}}, {{cssxref("::-webkit-meter-optimum-value")}}, {{cssxref("::-webkit-meter-suboptimum-value")}} – нестандартні псевдоелементи


### PR DESCRIPTION
Оригінальний вміст: ["&lt;meter&gt;: Елемент лічильника HTML"@MDN](https://developer.mozilla.org/en-us/docs/Web/HTML/Element/meter), [сирці "&lt;meter&gt;: Елемент лічильника HTML"@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/html/element/meter/index.md)

Нові зміни:
- [(HTML) Add `-webkit` prefixed props to `<meter>` page (#30702)](https://github.com/mdn/content/commit/fb28dcb8d47c4239bbc56588a51a40c24044c57f)