### PR TITLE
update(CSS): web/css/backdrop-filter

### DIFF
--- a/files/uk/web/css/backdrop-filter/index.md
+++ b/files/uk/web/css/backdrop-filter/index.md
@@ -64,7 +64,7 @@ backdrop-filter: unset;
 
 ```css
 .box {
-  background-color: rgb(255 255 255 / 0.3);
+  background-color: rgb(255 255 255 / 30%);
   backdrop-filter: blur(10px);
 }
 


### PR DESCRIPTION
Оригінальний вміст: [backdrop-filter@MDN](https://developer.mozilla.org/en-us/docs/Web/CSS/backdrop-filter), [сирці backdrop-filter@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/css/backdrop-filter/index.md)

Нові зміни:
- [Update web\css area to use latest `rgb()` and `hsl()` syntax (#31453)](https://github.com/mdn/content/commit/1c4eb0bfb5f72a26fcc21a83fac91aa3e66c2fb8)