### PR TITLE
update(CSS): web/css/background-image

### DIFF
--- a/files/uk/web/css/background-image/index.md
+++ b/files/uk/web/css/background-image/index.md
@@ -24,8 +24,8 @@ browser-compat: css.properties.background-image
 ```css
 background-image: linear-gradient(
     to bottom,
-    rgba(255, 255, 0, 0.5),
-    rgba(0, 0, 255, 0.5)
+    rgb(255 255 0 / 50%),
+    rgb(0 0 255 / 50%)
   ), url("catfront.png");
 
 /* Глобальні значення */


### PR DESCRIPTION
Оригінальний вміст: [background-image@MDN](https://developer.mozilla.org/en-us/docs/Web/CSS/background-image), [сирці background-image@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/css/background-image/index.md)

Нові зміни:
- [Update web\css area to use latest `rgb()` and `hsl()` syntax (#31453)](https://github.com/mdn/content/commit/1c4eb0bfb5f72a26fcc21a83fac91aa3e66c2fb8)