### PR TITLE
update(JS): web/javascript/guide/regular_expressions

### DIFF
--- a/files/uk/web/javascript/guide/regular_expressions/index.md
+++ b/files/uk/web/javascript/guide/regular_expressions/index.md
@@ -298,7 +298,7 @@ console.log("Поле lastIndex має значення " + /d(b+)d/g.lastIndex)
 | `d`      | Згенерувати індекси для збігів підрядків.                                             | {{jsxref("RegExp/hasIndices", "hasIndices")}}   |
 | `g`      | Глобальний пошук.                                                                     | {{jsxref("RegExp/global", "global")}}           |
 | `i`      | Пошук, нечутливий до регістру.                                                        | {{jsxref("RegExp/ignoreCase", "ignoreCase")}}   |
-| `m`      | Дозволяє `^` та `$` давати збіг з символами нового рядка.                             | {{jsxref("RegExp/multiline", "multiline")}}     |
+| `m`      | Дозволяє `^` та `$` давати збіг поруч з символами нового рядка.                       | {{jsxref("RegExp/multiline", "multiline")}}     |
 | `s`      | Дозволяє символові `.` давати збіг з символами нового рядка.                          | {{jsxref("RegExp/dotAll", "dotAll")}}           |
 | `u`      | "Unicode"; сприймає патерн як послідовність кодових точок Unicode.                    | {{jsxref("RegExp/unicode", "unicode")}}         |
 | `v`      | Оновлена версія режиму `u`, з більшою кількістю можливостей Unicode.                  | {{jsxref("RegExp/unicodeSets", "unicodeSets")}} |


### PR DESCRIPTION
Оригінальний вміст: [Регулярні вирази@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Guide/Regular_expressions), [сирці Регулярні вирази@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/guide/regular_expressions/index.md)

Нові зміни:
- [Fix description of m flag (#31471)](https://github.com/mdn/content/commit/b971f6d0e4b999fdb873bc718544cce0763827b9)