### PR TITLE
update(CSS): web/css/_colon_out-of-range

### DIFF
--- a/files/uk/web/css/_colon_out-of-range/index.md
+++ b/files/uk/web/css/_colon_out-of-range/index.md
@@ -59,11 +59,11 @@ input {
 }
 
 input:in-range {
-  background-color: rgba(0, 255, 0, 0.25);
+  background-color: rgb(0 255 0 / 25%);
 }
 
 input:out-of-range {
-  background-color: rgba(255, 0, 0, 0.25);
+  background-color: rgb(255 0 0 / 25%);
   border: 2px solid red;
 }
 


### PR DESCRIPTION
Оригінальний вміст: [":out-of-range"@MDN](https://developer.mozilla.org/en-us/docs/Web/CSS/:out-of-range), [сирці ":out-of-range"@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/css/_colon_out-of-range/index.md)

Нові зміни:
- [Update web\css area to use latest `rgb()` and `hsl()` syntax (#31453)](https://github.com/mdn/content/commit/1c4eb0bfb5f72a26fcc21a83fac91aa3e66c2fb8)