### PR TITLE
update(CSS): web/css/flex-grow

### DIFF
--- a/files/uk/web/css/flex-grow/index.md
+++ b/files/uk/web/css/flex-grow/index.md
@@ -87,12 +87,12 @@ flex-grow: unset;
 
 .small {
   flex-grow: 1;
-  border: 3px solid rgba(0, 0, 0, 0.2);
+  border: 3px solid rgb(0 0 0 / 20%);
 }
 
 .double {
   flex-grow: 2;
-  border: 3px solid rgba(0, 0, 0, 0.2);
+  border: 3px solid rgb(0 0 0 / 20%);
 }
 ```
 


### PR DESCRIPTION
Оригінальний вміст: [flex-grow@MDN](https://developer.mozilla.org/en-us/docs/Web/CSS/flex-grow), [сирці flex-grow@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/css/flex-grow/index.md)

Нові зміни:
- [Update web\css area to use latest `rgb()` and `hsl()` syntax (#31453)](https://github.com/mdn/content/commit/1c4eb0bfb5f72a26fcc21a83fac91aa3e66c2fb8)