### PR TITLE
update(CSS): web/css/transform-function

### DIFF
--- a/files/uk/web/css/transform-function/index.md
+++ b/files/uk/web/css/transform-function/index.md
@@ -189,32 +189,32 @@ main {
 }
 
 .front {
-  background: rgba(90, 90, 90, 0.7);
+  background: rgb(90 90 90 / 70%);
   transform: translateZ(50px);
 }
 
 .back {
-  background: rgba(0, 210, 0, 0.7);
+  background: rgb(0 210 0 / 70%);
   transform: rotateY(180deg) translateZ(50px);
 }
 
 .right {
-  background: rgba(210, 0, 0, 0.7);
+  background: rgb(210 0 0 / 70%);
   transform: rotateY(90deg) translateZ(50px);
 }
 
 .left {
-  background: rgba(0, 0, 210, 0.7);
+  background: rgb(0 0 210 / 70%);
   transform: rotateY(-90deg) translateZ(50px);
 }
 
 .top {
-  background: rgba(210, 210, 0, 0.7);
+  background: rgb(210 210 0 / 70%);
   transform: rotateX(90deg) translateZ(50px);
 }
 
 .bottom {
-  background: rgba(210, 0, 210, 0.7);
+  background: rgb(210 0 210 / 70%);
   transform: rotateX(-90deg) translateZ(50px);
 }
 


### PR DESCRIPTION
Оригінальний вміст: [&lt;transform-function&gt;@MDN](https://developer.mozilla.org/en-us/docs/Web/CSS/transform-function), [сирці &lt;transform-function&gt;@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/css/transform-function/index.md)

Нові зміни:
- [Update web\css area to use latest `rgb()` and `hsl()` syntax (#31453)](https://github.com/mdn/content/commit/1c4eb0bfb5f72a26fcc21a83fac91aa3e66c2fb8)