### PR TITLE
update(CSS): web/css/shorthand_properties

### DIFF
--- a/files/uk/web/css/shorthand_properties/index.md
+++ b/files/uk/web/css/shorthand_properties/index.md
@@ -226,6 +226,7 @@ CSS має універсальну властивість-скорочення,
   - {{cssxref("list-style")}}
   - {{cssxref("margin")}}
   - {{cssxref("mask")}}
+  - {{cssxref("mask-border")}}
   - {{cssxref("offset")}}
   - {{cssxref("outline")}}
   - {{cssxref("overflow")}}


### PR DESCRIPTION
Оригінальний вміст: [Властивості-скорочення@MDN](https://developer.mozilla.org/en-us/docs/Web/CSS/Shorthand_properties), [сирці Властивості-скорочення@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/css/shorthand_properties/index.md)

Нові зміни:
- [Add mask-border to shorthand references (#31513)](https://github.com/mdn/content/commit/63fb6a902f11436081fe5be28ac31a8c727fff28)