### PR TITLE
update(HTML): web/html/element/input/checkbox

### DIFF
--- a/files/uk/web/html/element/input/checkbox/index.md
+++ b/files/uk/web/html/element/input/checkbox/index.md
@@ -166,7 +166,7 @@ function updateDisplay() {
 
 ## Валідація
 
-Поля для галочки підтримують [валідацію](/uk/docs/Web/HTML/Constraint_validation) (доступну всім елементам {{HTMLElement("input")}}). Втім, більшість значень {{domxref("ValidityState")}} завжди буде `false`. Якщо таке поле має атрибут [`required`](/uk/docs/Web/HTML/Element/input#required), але не має галочки, то {{domxref("ValidityState.valueMissing")}} буде `true`.
+Поля для галочки підтримують [валідацію](/uk/docs/Web/HTML/Constraint_validation) (доступну всім елементам {{HTMLElement("input")}}). Втім, більшість значень {{domxref("ValidityState")}} завжди буде `false`. Якщо таке поле має атрибут [`required`](/uk/docs/Web/HTML/Element/input#required-oboviazkovyi), але не має галочки, то {{domxref("ValidityState.valueMissing")}} буде `true`.
 
 ## Приклади
 
@@ -285,7 +285,7 @@ otherCheckbox.addEventListener("change", () => {
     </tr>
     <tr>
       <td><strong>Події</strong></td>
-      <td>{{domxref("HTMLElement/change_event", "change")}} та {{domxref("HTMLElement/input_event", "input")}}</td>
+      <td>{{domxref("HTMLElement/change_event", "change")}} та {{domxref("Element/input_event", "input")}}</td>
     </tr>
     <tr>
       <td><strong>Підтримувані загальні атрибути</strong></td>


### PR DESCRIPTION
Оригінальний вміст: [&lt;input type="checkbox"&gt;@MDN](https://developer.mozilla.org/en-us/docs/Web/HTML/Element/input/checkbox), [сирці &lt;input type="checkbox"&gt;@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/html/element/input/checkbox/index.md)

Нові зміни:
- [move `beforeinput` event and `input` event from `HTMLElement` to `Element` (#30288)](https://github.com/mdn/content/commit/72ca3d725e3e56b613de3ac9727bd0d6d619c38a)