### PR TITLE
update(HTML): web/html/element/input/radio

### DIFF
--- a/files/uk/web/html/element/input/radio/index.md
+++ b/files/uk/web/html/element/input/radio/index.md
@@ -293,7 +293,7 @@ button:active {
     </tr>
     <tr>
       <td><strong>Події</strong></td>
-      <td>{{domxref("HTMLElement/change_event", "change")}} та {{domxref("HTMLElement/input_event", "input")}}</td>
+      <td>{{domxref("HTMLElement/change_event", "change")}} та {{domxref("Element/input_event", "input")}}</td>
     </tr>
     <tr>
       <td><strong>Підтримувані загальні атрибути</strong></td>


### PR DESCRIPTION
Оригінальний вміст: [&lt;input type="radio"&gt;@MDN](https://developer.mozilla.org/en-us/docs/Web/HTML/Element/input/radio), [сирці &lt;input type="radio"&gt;@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/html/element/input/radio/index.md)

Нові зміни:
- [move `beforeinput` event and `input` event from `HTMLElement` to `Element` (#30288)](https://github.com/mdn/content/commit/72ca3d725e3e56b613de3ac9727bd0d6d619c38a)