### PR TITLE
update(HTML): web/html/element/input/date

### DIFF
--- a/files/uk/web/html/element/input/date/index.md
+++ b/files/uk/web/html/element/input/date/index.md
@@ -444,7 +444,7 @@ daySelect.onchange = () => {
       <td><strong>Події</strong></td>
       <td>
         {{domxref("HTMLElement/change_event", "change")}} та
-        {{domxref("HTMLElement/input_event", "input")}}
+        {{domxref("Element/input_event", "input")}}
       </td>
     </tr>
     <tr>


### PR DESCRIPTION
Оригінальний вміст: [&lt;input type="date"&gt;@MDN](https://developer.mozilla.org/en-us/docs/Web/HTML/Element/input/date), [сирці &lt;input type="date"&gt;@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/html/element/input/date/index.md)

Нові зміни:
- [move `beforeinput` event and `input` event from `HTMLElement` to `Element` (#30288)](https://github.com/mdn/content/commit/72ca3d725e3e56b613de3ac9727bd0d6d619c38a)
- [Format /web/html using Prettier (#24057)](https://github.com/mdn/content/commit/e04d8d2766c468f149445c0bf438d09f9b2d188c)