### PR TITLE
update(HTML): web/html/element/input/tel

### DIFF
--- a/files/uk/web/html/element/input/tel/index.md
+++ b/files/uk/web/html/element/input/tel/index.md
@@ -175,7 +175,7 @@ browser-compat: html.elements.input.type_tel
 
 #### Пропонування значень
 
-Іще краще: можна запропонувати список з усталених значень номерів телефонів, серед яких користувач може обрати. Щоб таке реалізувати, слід застосувати атрибут [`list`](/uk/docs/Web/HTML/Element/input#list-spysok). Це не обмежує користувача такими варіантами, а й так само дозволяє їм обрати найчастіше вживані номери телефонів швидше. Також це надає підказку для [`autocomplete`](/uk/docs/Web/HTML/Element/input#autocomplete-avtozapovnennia). Атрибут `list` задає ідентифікатор елемента {{HTMLElement("datalist")}}, котрий своєю чергою містить по одному елементу {{HTMLElement("option")}} на пропоноване значення; `value` кожного `option` є відповідним пропонованим значенням для поля номера телефону.
+Іще краще: можна запропонувати список з усталених значень номерів телефонів, серед яких користувач може обрати. Щоб таке реалізувати, слід застосувати атрибут [`list`](/uk/docs/Web/HTML/Element/input#list-spysok). Це не обмежує користувача такими варіантами, а й так само дозволяє їм обрати найчастіше вживані номери телефонів швидше. Також це надає підказку для [`autocomplete`](/uk/docs/Web/HTML/Element/input#autocomplete). Атрибут `list` задає ідентифікатор елемента {{HTMLElement("datalist")}}, котрий своєю чергою містить по одному елементу {{HTMLElement("option")}} на пропоноване значення; `value` кожного `option` є відповідним пропонованим значенням для поля номера телефону.
 
 ```html
 <label for="telNo">Номер телефону: </label>
@@ -462,7 +462,7 @@ input:valid + span::after {
 <table class="properties">
   <tbody>
     <tr>
-      <td><strong><a href="#zhachennia">Значення</a></strong></td>
+      <td><strong><a href="#znachennia">Значення</a></strong></td>
       <td>
         Рядок, що представляє телефонний номер, або є порожнім
       </td>
@@ -471,13 +471,13 @@ input:valid + span::after {
       <td><strong>Події</strong></td>
       <td>
         {{domxref("HTMLElement/change_event", "change")}} та
-        {{domxref("HTMLElement/input_event", "input")}}
+        {{domxref("Element/input_event", "input")}}
       </td>
     </tr>
     <tr>
       <td><strong>Доступні спільні атрибути</strong></td>
       <td>
-        <a href="/uk/docs/Web/HTML/Element/input#autocomplete-avtozapovnennia"><code>autocomplete</code></a>,
+        <a href="/uk/docs/Web/HTML/Element/input#autocomplete"><code>autocomplete</code></a>,
         <a href="/uk/docs/Web/HTML/Element/input#list-spysok"><code>list</code></a>,
         <a href="/uk/docs/Web/HTML/Element/input#maxlength-maksymalna-dovzhyna"><code>maxlength</code></a>,
         <a href="/uk/docs/Web/HTML/Element/input#minlength-minimalna-dovzhyna"><code>minlength</code></a>,


### PR DESCRIPTION
Оригінальний вміст: [&lt;input type="tel"&gt;@MDN](https://developer.mozilla.org/en-us/docs/Web/HTML/Element/input/tel), [сирці &lt;input type="tel"&gt;@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/html/element/input/tel/index.md)

Нові зміни:
- [move `beforeinput` event and `input` event from `HTMLElement` to `Element` (#30288)](https://github.com/mdn/content/commit/72ca3d725e3e56b613de3ac9727bd0d6d619c38a)