### PR TITLE
update(HTML): web/html/element/select

### DIFF
--- a/files/uk/web/html/element/select/index.md
+++ b/files/uk/web/html/element/select/index.md
@@ -672,6 +672,6 @@ document.forms[0].onsubmit = (e) => {
 
 ## Дивіться також
 
-- Події, що їх викидає `<select>`: {{domxref("HTMLElement/change_event", "change")}}, {{domxref("HTMLElement/input_event", "input")}}
+- Події, що їх викидає `<select>`: {{domxref("HTMLElement/change_event", "change")}}, {{domxref("Element/input_event", "input")}}
 - Елемент {{HTMLElement("option")}}
 - Елемент {{HTMLElement("optgroup")}}


### PR DESCRIPTION
Оригінальний вміст: ["&lt;select&gt;: Елемент вибору HTML"@MDN](https://developer.mozilla.org/en-us/docs/Web/HTML/Element/select), [сирці "&lt;select&gt;: Елемент вибору HTML"@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/html/element/select/index.md)

Нові зміни:
- [move `beforeinput` event and `input` event from `HTMLElement` to `Element` (#30288)](https://github.com/mdn/content/commit/72ca3d725e3e56b613de3ac9727bd0d6d619c38a)