### PR TITLE
update(HTML): web/html/element/input/text

### DIFF
--- a/files/uk/web/html/element/input/text/index.md
+++ b/files/uk/web/html/element/input/text/index.md
@@ -390,13 +390,13 @@ input:valid + span::after {
       <td><strong>Події</strong></td>
       <td>
         {{domxref("HTMLElement/change_event", "change")}} та
-        {{domxref("HTMLElement/input_event", "input")}}
+        {{domxref("Element/input_event", "input")}}
       </td>
     </tr>
     <tr>
       <td><strong>Доступні спільні атрибути</strong></td>
       <td>
-        <a href="/uk/docs/Web/HTML/Element/input#autocomplete-avtozapovnennia"><code>autocomplete</code></a>,
+        <a href="/uk/docs/Web/HTML/Element/input#autocomplete"><code>autocomplete</code></a>,
         <a href="/uk/docs/Web/HTML/Element/input#list-spysok"><code>list</code></a>,
         <a href="/uk/docs/Web/HTML/Element/input#maxlength-maksymalna-dovzhyna"><code>maxlength</code></a>,
         <a href="/uk/docs/Web/HTML/Element/input#minlength-minimalna-dovzhyna"><code>minlength</code></a>,


### PR DESCRIPTION
Оригінальний вміст: [&lt;input type="text"&gt;@MDN](https://developer.mozilla.org/en-us/docs/Web/HTML/Element/input/text), [сирці &lt;input type="text"&gt;@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/html/element/input/text/index.md)

Нові зміни:
- [move `beforeinput` event and `input` event from `HTMLElement` to `Element` (#30288)](https://github.com/mdn/content/commit/72ca3d725e3e56b613de3ac9727bd0d6d619c38a)