### PR TITLE
update(HTML): web/html/element/input/week

### DIFF
--- a/files/uk/web/html/element/input/week/index.md
+++ b/files/uk/web/html/element/input/week/index.md
@@ -331,16 +331,16 @@ function populateWeeks() {
       <td><strong>Події</strong></td>
       <td>
         {{domxref("HTMLElement/change_event", "change")}} та
-        {{domxref("HTMLElement/input_event", "input")}}
+        {{domxref("Element/input_event", "input")}}
       </td>
     </tr>
     <tr>
       <td><strong>Доступні спільні атрибути</strong></td>
       <td>
         <a href="/uk/docs/Web/HTML/Element/input#autocomplete"><code>autocomplete</code></a>,
-        <a href="/uk/docs/Web/HTML/Element/input#list"><code>list</code></a>,
-        <a href="/uk/docs/Web/HTML/Element/input#readonly"><code>readonly</code></a> та
-        <a href="/uk/docs/Web/HTML/Element/input#step"><code>step</code></a>
+        <a href="/uk/docs/Web/HTML/Element/input#list-spysok"><code>list</code></a>,
+        <a href="/uk/docs/Web/HTML/Element/input#readonly-lyshe-dlia-chytannia"><code>readonly</code></a> та
+        <a href="/uk/docs/Web/HTML/Element/input#step-krok"><code>step</code></a>
       </td>
     </tr>
     <tr>


### PR DESCRIPTION
Оригінальний вміст: [&lt;input type="week"&gt;@MDN](https://developer.mozilla.org/en-us/docs/Web/HTML/Element/input/week), [сирці &lt;input type="week"&gt;@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/html/element/input/week/index.md)

Нові зміни:
- [move `beforeinput` event and `input` event from `HTMLElement` to `Element` (#30288)](https://github.com/mdn/content/commit/72ca3d725e3e56b613de3ac9727bd0d6d619c38a)