### PR TITLE
update(JS): web/javascript/reference/global_objects/arraybuffer/detached

### DIFF
--- a/files/uk/web/javascript/reference/global_objects/arraybuffer/detached/index.md
+++ b/files/uk/web/javascript/reference/global_objects/arraybuffer/detached/index.md
@@ -35,6 +35,7 @@ console.log(newBuffer.detached); // false
 
 ## Дивіться також
 
+- [Поліфіл `ArrayBuffer.prototype.detached` у складі `core-js`](https://github.com/zloirock/core-js#arraybufferprototypetransfer-and-friends)
 - {{jsxref("ArrayBuffer")}}
 - {{jsxref("ArrayBuffer.prototype.transfer()")}}
 - {{jsxref("ArrayBuffer.prototype.transferToFixedLength()")}}


### PR DESCRIPTION
Оригінальний вміст: [ArrayBuffer.prototype.detached@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer/detached), [сирці ArrayBuffer.prototype.detached@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/global_objects/arraybuffer/detached/index.md)

Нові зміни:
- [FF122 ArrayBuffer.transfer() and friends - remove experimental tagging (#31213)](https://github.com/mdn/content/commit/a0b5c6af9c854702d15ec800b529064fb7d297db)