### PR TITLE
update(CSS): web/css/_colon_read-only

### DIFF
--- a/files/uk/web/css/_colon_read-only/index.md
+++ b/files/uk/web/css/_colon_read-only/index.md
@@ -28,8 +28,6 @@ browser-compat: css.selectors.read-only
 Псевдоклас `:read-only` вживається для усунення всього оформлення, завдяки якому поля мають вигляд інтерактивних, а натомість змушує їх мати вигляд абзаців, доступних лише для зчитування. Псевдоклас `:read-write`, з іншого боку, використовується для надання трохи красивішого оформлення редагованому елементу `<textarea>`.
 
 ```css
-input:-moz-read-only,
-textarea:-moz-read-only,
 input:read-only,
 textarea:read-only {
   border: 0;
@@ -37,7 +35,6 @@ textarea:read-only {
   background-color: white;
 }
 
-textarea:-moz-read-write,
 textarea:read-write {
   box-shadow: inset 1px 1px 3px #ccc;
   border-radius: 5px;
@@ -77,7 +74,7 @@ p:read-write {
 }
 ```
 
-{{EmbedLiveSample('oformlennia-neformovykh-kontrolknykh-elementiv-lyshe-dlia-zchytuvannia', '100%', 400)}}
+{{EmbedLiveSample('oformlennia-neformovykh-kontrolnykh-elementiv-lyshe-dlia-zchytuvannia', '100%', 400)}}
 
 ## Специфікації
 


### PR DESCRIPTION
Оригінальний вміст: [":read-only"@MDN](https://developer.mozilla.org/en-us/docs/Web/CSS/:read-only), [сирці ":read-only"@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/css/_colon_read-only/index.md)

Нові зміни:
- [Remove prefixed :read-only selectors (#31718)](https://github.com/mdn/content/commit/b13d7297d208abc29ad6235d6fcc0ff2ccb07512)