### PR TITLE
update(CSS): web/css/_colon_indeterminate

### DIFF
--- a/files/uk/web/css/_colon_indeterminate/index.md
+++ b/files/uk/web/css/_colon_indeterminate/index.md
@@ -137,6 +137,6 @@ progress:indeterminate {
 
 - [Вебформи – Робота з користувацькими даними](/uk/docs/Learn/Forms)
 - [Оформлення вебформ](/uk/docs/Learn/Forms/Styling_web_forms)
-- Атрибут [`indeterminate`](/uk/docs/Web/HTML/Element/input/checkbox#polia-dlia-halochok-z-nevyznachenym-stanom) елемента [`<input type="checkbox">`](/uk/docs/Web/HTML/Element/input/checkbox)
+- Властивість [`indeterminate`](/uk/docs/Web/HTML/Element/input/checkbox#polia-dlia-halochok-z-nevyznachenym-stanom) елемента [`<input type="checkbox">`](/uk/docs/Web/HTML/Element/input/checkbox)
 - Елемент {{HTMLElement("input")}} і інтерфейс {{domxref("HTMLInputElement")}}, який його реалізує.
 - Селектор CSS {{cssxref(":checked")}} дає змогу оформлювати поля для галочок на основі того, чи є вони вибраними, чи ні

--- a/files/uk/web/css/_colon_indeterminate/index.md
+++ b/files/uk/web/css/_colon_indeterminate/index.md
@@ -7,7 +7,7 @@ browser-compat: css.selectors.indeterminate
 
 {{CSSRef}}
 
-[Псевдоклас](/uk/docs/Web/CSS/Pseudo-classes) [CSS](/uk/docs/Web/CSS) **`:indeterminate`** (невизначене) представляє будь-який елемент форми, чий стан – невизначений, наприклад, поля для галочки, які мають атрибут HTML [`indeterminate`](/uk/docs/Web/HTML/Element/input/checkbox#indeterminate_state_checkboxes) зі значенням `true`, кнопки-перемикачі, які є членами групи, в якій всі кнопки-перемикачі не вибрані, та елементи {{HTMLElement("progress")}} в невизначеному стані.
+[Псевдоклас](/uk/docs/Web/CSS/Pseudo-classes) [CSS](/uk/docs/Web/CSS) **`:indeterminate`** (невизначене) представляє будь-який елемент форми, чий стан – невизначений, наприклад, поля для галочки, які мають стан [`indeterminate`](/uk/docs/Web/HTML/Element/input/checkbox#polia-dlia-halochok-z-nevyznachenym-stanom), заданий за допомогою JavaScript, кнопки-перемикачі, які є членами групи, в якій всі кнопки-перемикачі не вибрані, та елементи {{HTMLElement("progress")}} без атрибута `value`.
 
 ```css
 /* Вибирає всі елементи <input>, стан яких є невизначеним */


### PR DESCRIPTION
Оригінальний вміст: [":indeterminate"@MDN](https://developer.mozilla.org/en-us/docs/Web/CSS/:indeterminate), [сирці ":indeterminate"@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/css/_colon_indeterminate/index.md)

Нові зміни:
- [Replace 'attribute' with 'property' for 'indeterminate' (#31737)](https://github.com/mdn/content/commit/328b6b07216cd7588dd63272a5005f709b8d501a)