### PR TITLE
update(CSS): web/css/background

### DIFF
--- a/files/uk/web/css/background/index.md
+++ b/files/uk/web/css/background/index.md
@@ -5,7 +5,7 @@ page-type: css-shorthand-property
 browser-compat: css.properties.background
 ---
 
-{{CSSRef("CSS Background")}}
+{{CSSRef}}
 
 Властивість-[скорочення](/uk/docs/Web/CSS/Shorthand_properties) [CSS](/uk/docs/Web/CSS) **`background`** ("тло", "фон") встановлює усі властивості стилю тла за раз: колір, зображення, вихідне положення, розмір, метод повторення. Властивості-складові, не задані у складі скорочення `background`, отримують свої усталені значення.
 


### PR DESCRIPTION
Оригінальний вміст: [background@MDN](https://developer.mozilla.org/en-us/docs/Web/CSS/background), [сирці background@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/css/background/index.md)

Нові зміни:
- [Unify `{{CSSRef}}` macro usage (remove unused parameter) (#31843)](https://github.com/mdn/content/commit/7fa9b134e7a886b47bd8c6e3135ba329ee0ddf09)