### PR TITLE
update(HTML): web/html/element/button

### DIFF
--- a/files/uk/web/html/element/button/index.md
+++ b/files/uk/web/html/element/button/index.md
@@ -19,8 +19,6 @@ browser-compat: html.elements.button
 
 - `autofocus`
   - : Цей булів атрибут вказує, що кнопка повинна отримати [фокус](/uk/docs/Web/API/HTMLElement/focus) введення, коли сторінка завантажилась. **Лише один елемент в документі може мати такий атрибут.**
-- `autocomplete` {{non-standard_inline}}
-  - : Цей атрибут {{HTMLElement("button")}} є нестандартним, специфічним для Firefox. На відміну від інших браузерів, [Firefox зберігає динамічний стан вимкненості (англ.)](https://stackoverflow.com/questions/5985839/bug-with-firefox-disabled-attribute-of-input-not-resetting-when-refreshing) елемента {{HTMLElement("button")}} між завантаженнями сторінки. Встановлення на кнопці `autocomplete="off"` вимикає цю функціональність; дивіться [ваду Firefox 654072](https://bugzil.la/654072).
 - `disabled`
 
   - : Цей булів атрибут не дає користувачеві взаємодіяти з кнопкою: вона не може бути натиснута чи отримати фокус.


### PR DESCRIPTION
Оригінальний вміст: ["&lt;button&gt;: Елемент кнопки"@MDN](https://developer.mozilla.org/en-us/docs/Web/HTML/Element/button), [сирці "&lt;button&gt;: Елемент кнопки"@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/html/element/button/index.md)

Нові зміни:
- [Remove `autocomplete` attribute of `&lt;button&gt;` element (#31605)](https://github.com/mdn/content/commit/b05dec8ec5ede7ad507e07d8f33dea33e3bd8531)