### PR TITLE
update(CSS): web/css/css_media_queries

### DIFF
--- a/files/uk/web/css/css_media_queries/index.md
+++ b/files/uk/web/css/css_media_queries/index.md
@@ -18,7 +18,7 @@ spec-urls:
 
 У [CSS](/uk/docs/Web/CSS) можна скористатися [директивою](/uk/docs/Web/CSS/At-rule) {{cssxref("@media")}}, щоб умовно застосувати частину списку стилів на основі результату медіазапиту. Щоб умовно застосувати весь список стилів, краще скористатися директивою {{cssxref("@import")}}.
 
-При розробці компонентів HTML для багаторазового використання також можна скористатися [контейнерними запитами](/uk/docs/Web/CSS/CSS_container_queries), які дають змогу застосовувати стилі на основі розміру контейнерного елемента, а не області перегляду чи інших характеристик пристрою.
+При розробці компонентів HTML для багаторазового використання також можна скористатися [контейнерними запитами](/uk/docs/Web/CSS/CSS_containment/Container_queries), які дають змогу застосовувати стилі на основі розміру контейнерного елемента, а не області перегляду чи інших характеристик пристрою.
 
 ## Довідка
 
@@ -107,8 +107,8 @@ spec-urls:
 
 - Модуль [Утримання CSS](/uk/docs/Web/CSS/CSS_containment)
   - Директива {{cssxref("@container")}}
-  - [Застосування контейнерних запитів](/uk/docs/Web/CSS/CSS_container_queries)
-- Модуль [Умовні правила CSS](/uk/docs/Web/CSS/CSS_container_queries)
+  - [Застосування контейнерних запитів](/uk/docs/Web/CSS/CSS_containment/Container_queries)
+- Модуль [Умовні правила CSS](/uk/docs/Web/CSS/CSS_conditional_rules)
   - Директива {{cssxref("@supports")}}
   - [Застосування запитів можливостей](/uk/docs/Web/CSS/CSS_conditional_rules/Using_feature_queries)
 - Модуль [Сторінкових медій CSS](/uk/docs/Web/CSS/CSS_paged_media) module
@@ -133,7 +133,7 @@ spec-urls:
 
 ## Дивіться також
 
+- [Контейнерні запити](/uk/docs/Web/CSS/CSS_containment/Container_queries)
 - [Використання атрибутів `srcset` і `sizes`](/uk/docs/Web/HTML/Element/img#vykorystannia-atrybutiv-srcset-i-sizes)
-- [Контейнерні запити](/uk/docs/Web/CSS/CSS_container_queries)
 - [Сторінкові медії CSS](/uk/docs/Web/CSS/CSS_paged_media)
 - Використовуйте {{cssxref("@supports")}}, щоб застосовувати стилі, що залежать від браузерної підтримки різних технологій CSS.

--- a/files/uk/web/css/css_media_queries/index.md
+++ b/files/uk/web/css/css_media_queries/index.md
@@ -3,38 +3,22 @@ title: Медіазапити CSS
 slug: Web/CSS/CSS_media_queries
 page-type: css-module
 spec-urls:
+  - https://drafts.csswg.org/mediaqueries-3/
   - https://drafts.csswg.org/mediaqueries/
-  - https://drafts.csswg.org/css-conditional/
+  - https://drafts.csswg.org/mediaqueries-5/
 ---
 
 {{CSSRef}}
 
-**Медіазапити CSS** – це ключова компонента [чуйного дизайну](/uk/docs/Learn/CSS/CSS_layout/Responsive_Design), який дає змогу застосовувати стилі CSS в залежності від наявності або значень характеристик пристрою.
+Модуль **Медіазапитів CSS** дає змогу перевіряти та робити запити щодо значень області перегляду та характеристик браузера чи пристрою, щоб умовно застосовувати стилі CSS на основі поточного користувацького середовища. Медіазапити використовуються в директиві CSS `@media` та інших контекстах та мовах, таких як HTML та JavaScript.
 
-Заведено застосовувати медіазапит на основі розміру {{Glossary("viewport", "області перегляду")}}, щоб можна було приймати рішення щодо компонування для пристроїв з різними розмірами екранів. Наприклад, може бути менший розмір шрифту для менших екранів, збільшити внутрішній відступ між абзацами, коли сторінка переглядається в портретному режимі, або збільшити розмір кнопок на сенсорних екранах.
+Медіазапити – це ключова компонента [чуйного дизайну](/uk/docs/Learn/CSS/CSS_layout/Responsive_Design). Вони дають змогу умовно задавати стилі CSS, залежно від присутності чи значень характеристик пристрою. Поширено використання медіазапитів на основі розміру {{Glossary("viewport", "області перегляду")}}, щоб задавати відповідні макети на пристроях з різними розмірами екранів – наприклад, три колонки на широкому екрані чи одна колонка на вузькому.
 
-![Ноутбук і мобільний пристрій з різними розмірами області перегляду, які можна перевіряти за допомогою медіазапитів, і можна спостерігати за тим, як вміст компонується по-різному.](media-queries.svg)
+Серед інших поширених прикладів – збільшення розміру шрифту та приховування навігаційних меню при друку сторінки, припасування внутрішніх відступів між абзацами, коли сторінку переглядають у портретному чи ландшафтному режимі, або збільшення розміру кнопок, щоб забезпечити більшу площу для натискання на сенсорних екранах.
 
-У [CSS](/uk/docs/Web/CSS) можна використати [директиву](/uk/docs/Web/CSS/At-rule) {{cssxref("@media")}}, щоб умовно застосувати частину списку стилів на основі результату медіазапиту.
-Щоб умовно застосувати цілий список стилів, слід використати {{cssxref("@import")}}.
+У [CSS](/uk/docs/Web/CSS) можна скористатися [директивою](/uk/docs/Web/CSS/At-rule) {{cssxref("@media")}}, щоб умовно застосувати частину списку стилів на основі результату медіазапиту. Щоб умовно застосувати весь список стилів, краще скористатися директивою {{cssxref("@import")}}.
 
 При розробці компонентів HTML для багаторазового використання також можна скористатися [контейнерними запитами](/uk/docs/Web/CSS/CSS_container_queries), які дають змогу застосовувати стилі на основі розміру контейнерного елемента, а не області перегляду чи інших характеристик пристрою.
-
-### Медіазапити в HTML
-
-В [HTML](/uk/docs/Web/HTML) медіазапити можуть застосовуватися до різних елементів:
-
-- В атрибуті [`media`](/uk/docs/Web/HTML/Element/link#media) елемента {{HTMLElement("link")}} вони визначають засоби візуалізації, до яких повинен застосовуватися сполучений ресурс (зазвичай CSS).
-- В атрибуті [`media`](/uk/docs/Web/HTML/Element/source#media) елемента {{HTMLElement("source")}} вони визначають засоби візуалізації, до яких повинен застосовуватися вихідний код. (Це діє лише всередині елементів {{HTMLElement("picture")}}.)
-- В атрибуті [`media`](/uk/docs/Web/HTML/Element/style#media) елемента {{HTMLElement("style")}} вони визначають засоби візуалізації, до яких стиль повинен бути застосований.
-
-### Медіазапити в JavaScript
-
-У [JavaScript](/uk/docs/Web/JavaScript) можна скористатися методом {{domxref("Window.matchMedia()")}}, щоб перевірити вікно на відповідність медіазапитові.
-Також можна використати {{domxref("MediaQueryList.addListener()")}}, щоб отримати сповіщення про зміну стану запиту.
-З такою функціональністю сайт або застосунок може реагувати на зміни в конфігурації, орієнтації чи стані пристрою.
-
-Дізнатися більше про програмне використання медіазапитів можна на сторінці [Перевірка медіазапитів](/uk/docs/Web/CSS/CSS_media_queries/Testing_media_queries).
 
 ## Довідка
 
@@ -43,16 +27,105 @@ spec-urls:
 - {{cssxref("@import")}}
 - {{cssxref("@media")}}
 
+### Дескриптори
+
+- {{cssxref("@media/any-hover", "any-hover")}}
+- {{cssxref("@media/any-pointer", "any-pointer")}}
+- {{cssxref("@media/aspect-ratio", "aspect-ratio")}}
+- {{cssxref("@media/color", "color")}}
+- {{cssxref("@media/color-gamut", "color-gamut")}}
+- {{cssxref("@media/color-index", "color-index")}}
+- {{cssxref("@media/device-aspect-ratio", "device-aspect-ratio")}}
+- {{cssxref("@media/device-height", "device-height")}}
+- {{cssxref("@media/device-width", "device-width")}}
+- {{cssxref("@media/display-mode", "display-mode")}}
+- {{cssxref("@media/dynamic-range", "dynamic-range")}}
+- {{cssxref("@media/forced-colors", "forced-colors")}}
+- {{cssxref("@media/grid", "grid")}}
+- {{cssxref("@media/height", "height")}}
+- {{cssxref("@media/hover", "hover")}}
+- {{cssxref("@media/inverted-colors", "inverted-colors")}}
+- {{cssxref("@media/monochrome", "monochrome")}}
+- {{cssxref("@media/orientation", "orientation")}}
+- {{cssxref("@media/overflow-block", "overflow-block")}}
+- {{cssxref("@media/overflow-inline", "overflow-inline")}}
+- {{cssxref("@media/pointer", "pointer")}}
+- {{cssxref("@media/prefers-color-scheme", "prefers-color-scheme")}}
+- {{cssxref("@media/prefers-contrast", "prefers-contrast")}}
+- {{cssxref("@media/prefers-reduced-data", "prefers-reduced-data")}}
+- {{cssxref("@media/prefers-reduced-motion", "prefers-reduced-motion")}}
+- {{cssxref("@media/prefers-reduced-transparency", "prefers-reduced-transparency")}}
+- {{cssxref("@media/resolution", "resolution")}}
+- {{cssxref("@media/scan", "scan")}}
+- {{cssxref("@media/scripting", "scripting")}}
+- {{cssxref("@media/update", "update")}}
+- {{cssxref("@media/video-dynamic-range", "video-dynamic-range")}}
+- {{cssxref("@media/width", "width")}}
+
+> **Примітка:** Медіазапити CSS рівня 5 додали п'ять дескрипторів `@media`, які ще не отримали реалізації: {{cssxref("@media/environment-blending", "environment-blending")}}, {{cssxref("@media/horizontal-viewport-segments", "horizontal-viewport-segments")}}, {{cssxref("@media/nav-controls", "nav-controls")}}, {{cssxref("@media/vertical-viewport-segments", "vertical-viewport-segments")}} і {{cssxref("@media/video-color-gamut", "video-color-gamut")}}.
+> **Примітка:** Медіазапити CSS рівня 4 зробили нерекомендованими три дескриптори `@media`: {{cssxref("@media/device-aspect-ratio", "device-aspect-ratio")}}, {{cssxref("@media/device-height", "device-height")}} і {{cssxref("@media/device-width", "device-width")}}.
+
+### Типи даних та оператори
+
+- [`<media-types>`](/uk/docs/Web/CSS/@media#mediini-typy)
+- [`<media-features>`](/uk/docs/Web/CSS/@media#mediini-mozhlyvosti)
+- [`<resolution>`](/uk/docs/Web/CSS/resolution)
+- [Логічні оператори](/uk/docs/Web/CSS/@media#lohichni_operatory)
+
+### Терміни глосарія
+
+- [медія](/uk/docs/Glossary/Media/CSS)
+- [медійний запит](/uk/docs/Glossary/Media_query)
+
 ## Посібники
 
 - [Застосування медіазапитів](/uk/docs/Web/CSS/CSS_media_queries/Using_media_queries)
-  - : Знайомить з медіазапитом, їхнім синтаксисом, а також операторами та можливостями медіа, що використовуються для конструювання виразів медіазапитів.
-- [Перевірка медіазапитів програмно](/uk/docs/Web/CSS/CSS_media_queries/Testing_media_queries)
+
+  - : Знайомить з медіазапитами, їхнім синтаксисом, а також операторами та медійними можливостями, які використовуються для створення виразів медіазапитів.
+
+- [Посібник початківця з медіазапитів](/uk/docs/Learn/CSS/CSS_layout/Media_queries)
+
+  - : Знайомить з медіазапитами та підходами до їхнього використання для створення чуйних дизайнів.
+
+- [Перевірка медіазапитів](/uk/docs/Web/CSS/CSS_media_queries/Testing_media_queries)
+
   - : Описує, як використовувати медіазапити в коді JavaScript, щоб з'ясовувати стан пристрою, а також задавати слухачів, що сповіщають код, коли результати медіазапитів змінюються (наприклад, коли користувач обертає екран або змінює розмір вікна браузера).
+
 - [Використання медіазапитів заради доступності](/uk/docs/Web/CSS/CSS_media_queries/Using_media_queries_for_accessibility)
-  - : Дізнайтеся, як Медіазапити можуть допомогти розуміти ваш вебсайт краще.
+
+  - : Дізнайтеся, як медіазапити можуть допомогти користувачам краще розуміти ваш вебсайт.
+
 - [Друк](/uk/docs/Web/CSS/CSS_media_queries/Printing)
+
   - : Поради та техніки, які допоможуть покращити виведення вебвмісту на принтер.
+
+- [Вивчення – чуйні зображення](/uk/docs/Learn/HTML/Multimedia_and_embedding/Responsive_images)
+
+  - : Дізнайтеся, як використовувати медіазапити вкупі з `sizes` для реалізації чуйних зображень на вебсайтах.
+
+## Споріднені концепції
+
+- Модуль [Утримання CSS](/uk/docs/Web/CSS/CSS_containment)
+  - Директива {{cssxref("@container")}}
+  - [Застосування контейнерних запитів](/uk/docs/Web/CSS/CSS_container_queries)
+- Модуль [Умовні правила CSS](/uk/docs/Web/CSS/CSS_container_queries)
+  - Директива {{cssxref("@supports")}}
+  - [Застосування запитів можливостей](/uk/docs/Web/CSS/CSS_conditional_rules/Using_feature_queries)
+- Модуль [Сторінкових медій CSS](/uk/docs/Web/CSS/CSS_paged_media) module
+  - Директива {{cssxref("@page")}}
+- Модуль [Об'єктна модель CSS](/uk/docs/Web/API/CSS_Object_Model)
+  - Інтерфейс {{DOMxRef("MediaQueryList")}}
+    - Властивість {{DOMxRef("MediaQueryList.matches", "matches")}}
+    - Властивість {{DOMxRef("MediaQueryList.media", "media")}}
+    - Подія {{DOMxRef("MediaQueryList.change_event", "change")}}
+  - Інтерфейс {{DOMxRef("MediaList")}}
+    - Властивість {{DOMxRef("MediaList.mediaText", "mediaText")}}
+  - Об'єкт {{DOMxRef("MediaQueryListEvent")}}
+- HTML
+  - Атрибут `sizes` для [`<img>`](/uk/docs/Web/HTML/Element/img#sizes), [`<link>`](/uk/docs/Web/HTML/Element/link#sizes), а також [`<source>`](/uk/docs/Web/HTML/Element/source#sizes) для {{HTMLElement("picture")}}
+  - Атрибут `media` для [`<link>`](/uk/docs/Web/HTML/Element/link#media), [`<source>`](/uk/docs/Web/HTML/Element/source#media) і [`<style>`](/uk/docs/Web/HTML/Element/style#media) [HTML](/uk/docs/Web/HTML)
+  - [Тег `<meta>` області перегляду](/uk/docs/Web/HTML/Viewport_meta_tag)
+- Атрибут SVG [`media`](/uk/docs/Web/SVG/Attribute/media)
 
 ## Специфікації
 
@@ -60,5 +133,7 @@ spec-urls:
 
 ## Дивіться також
 
+- [Використання атрибутів `srcset` і `sizes`](/uk/docs/Web/HTML/Element/img#vykorystannia-atrybutiv-srcset-i-sizes)
 - [Контейнерні запити](/uk/docs/Web/CSS/CSS_container_queries)
+- [Сторінкові медії CSS](/uk/docs/Web/CSS/CSS_paged_media)
 - Використовуйте {{cssxref("@supports")}}, щоб застосовувати стилі, що залежать від браузерної підтримки різних технологій CSS.

--- a/files/uk/web/css/css_media_queries/index.md
+++ b/files/uk/web/css/css_media_queries/index.md
@@ -108,6 +108,7 @@ spec-urls:
 - Модуль [Утримання CSS](/uk/docs/Web/CSS/CSS_containment)
   - Директива {{cssxref("@container")}}
   - [Застосування контейнерних запитів](/uk/docs/Web/CSS/CSS_containment/Container_queries)
+  - [Застосування контейнерних запитів розміру та стилю](/uk/docs/Web/CSS/CSS_containment/Container_size_and_style_queries)
 - Модуль [Умовні правила CSS](/uk/docs/Web/CSS/CSS_conditional_rules)
   - Директива {{cssxref("@supports")}}
   - [Застосування запитів можливостей](/uk/docs/Web/CSS/CSS_conditional_rules/Using_feature_queries)

--- a/files/uk/web/css/css_media_queries/index.md
+++ b/files/uk/web/css/css_media_queries/index.md
@@ -74,7 +74,7 @@ spec-urls:
 
 ### Терміни глосарія
 
-- [медія](/uk/docs/Glossary/Media/CSS)
+- [медіа](/uk/docs/Glossary/Media/CSS)
 - [медійний запит](/uk/docs/Glossary/Media_query)
 
 ## Посібники


### PR DESCRIPTION
Оригінальний вміст: [Медіазапити CSS@MDN](https://developer.mozilla.org/en-us/docs/Web/CSS/CSS_media_queries), [сирці Медіазапити CSS@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/css/css_media_queries/index.md)

Нові зміни:
- [Links to the new container style query guide (#32318)](https://github.com/mdn/content/commit/4b6b77bc36496c88dcbe477ec46da678a85d8e6e)
- [Containment module (#31950)](https://github.com/mdn/content/commit/4bf03c104b1bca2068dbff927020e7f802c4af7e)
- [Media queries module (#31903)](https://github.com/mdn/content/commit/f7daf15512ea736498837b68bcc36d82d6a323f4)