### PR TITLE
update(CSS): web/css/css_selectors

### DIFF
--- a/files/uk/web/css/css_selectors/index.md
+++ b/files/uk/web/css/css_selectors/index.md
@@ -102,10 +102,10 @@ spec-urls: https://drafts.csswg.org/selectors/
 - Термін глосарія {{glossary("Pseudo-class", "псевдоклас")}}
 - [Функційні псевдокласи](/uk/docs/Web/CSS/Pseudo-classes#funktsiini-psevdoklasy)
 - [Комбінатори](/uk/docs/Web/CSS/CSS_selectors/Selectors_and_combinators#kombinatory)
-- [Простий селектор](/uk/docs/Web/CSS/CSS_selectors/Selectors_and_combinators#prostyi-selektor)
-- [Складений селектор](/uk/docs/Web/CSS/CSS_selectors/Selectors_and_combinators#skladenyi-selektor)
-- [Складний селектор](/uk/docs/Web/CSS/CSS_selectors/Selectors_and_combinators#skladnyi-selektor)
-- [Відносний селектор](/uk/docs/Web/CSS/CSS_selectors/Selectors_and_combinators#vidnosnyi-selektor)
+- [Простий селектор](/uk/docs/Web/CSS/CSS_selectors/Selector_structure#prostyi-selektor)
+- [Складений селектор](/uk/docs/Web/CSS/CSS_selectors/Selector_structure#skladenyi-selektor)
+- [Складний селектор](/uk/docs/Web/CSS/CSS_selectors/Selector_structure#skladnyi-selektor)
+- [Відносний селектор](/uk/docs/Web/CSS/CSS_selectors/Selector_structure#vidnosnyi-selektor)
 - [Список селекторів](/uk/docs/Web/CSS/Selector_list)
 - [Специфічність](/uk/docs/Web/CSS/Specificity)
 


### PR DESCRIPTION
Оригінальний вміст: [Селектори CSS@MDN](https://developer.mozilla.org/en-us/docs/Web/CSS/CSS_selectors), [сирці Селектори CSS@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/css/css_selectors/index.md)

Нові зміни:
- [Fix some fragment links (#31967)](https://github.com/mdn/content/commit/2077d0702d038c9ccc743a53d8ad1c0c21fef5be)