### PR TITLE
update(CSS): web/css/reference

### DIFF
--- a/files/uk/web/css/reference/index.md
+++ b/files/uk/web/css/reference/index.md
@@ -130,7 +130,7 @@ div.menu-bar li:hover > ul {
 
 ### Компонування
 
-- [Контекст блокового форматування](/uk/docs/Web/Guide/CSS/Block_formatting_context)
+- [Блоковий контекст форматування](/uk/docs/Web/CSS/CSS_display/Block_formatting_context)
 - [Рамкова модель](/uk/docs/Web/CSS/CSS_box_model/Introduction_to_the_CSS_box_model)
 - [Контейнерний блок](/uk/docs/Web/CSS/Containing_block)
 - [Спосіб компонування](/uk/docs/Web/CSS/Layout_mode)


### PR DESCRIPTION
Оригінальний вміст: [Довідник CSS@MDN](https://developer.mozilla.org/en-us/docs/Web/CSS/Reference), [сирці Довідник CSS@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/css/reference/index.md)

Нові зміни:
- [Moved CSS guide (#31997)](https://github.com/mdn/content/commit/afaf3aeeffa8408cf0a8a46c3d8fb0d347aad9f5)