### PR TITLE
update(HTML): web/html/attributes

### DIFF
--- a/files/uk/web/html/attributes/index.md
+++ b/files/uk/web/html/attributes/index.md
@@ -192,19 +192,6 @@ page-type: landing-page
     </tr>
     <tr>
       <td>
-        <code><a href="/uk/docs/Web/HTML/Attributes/buffered">buffered</a></code>
-      </td>
-      <td>
-        {{HTMLElement("audio")}},
-        {{HTMLElement("video")}}
-      </td>
-      <td>
-        Вміщає часовий діапазон вже буферизованих медіаданих.
-      </td>
-      </td>
-    </tr>
-    <tr>
-      <td>
         <code><a href="/uk/docs/Web/HTML/Attributes/capture">capture</a></code>
       </td>
       <td>{{HTMLElement("input")}}</td>


### PR DESCRIPTION
Оригінальний вміст: [Довідка атрибутів HTML@MDN](https://developer.mozilla.org/en-us/docs/Web/HTML/Attributes), [сирці Довідка атрибутів HTML@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/html/attributes/index.md)

Нові зміни:
- [Remove `buffered` from HTML attributes list (#32064)](https://github.com/mdn/content/commit/a0d283119b6ce5e02265265dda824ab26c057881)