### PR TITLE
update(HTML): web/html/element/audio

### DIFF
--- a/files/uk/web/html/element/audio/index.md
+++ b/files/uk/web/html/element/audio/index.md
@@ -235,8 +235,9 @@ browser-compat: html.elements.audio
   <source src="myAudio.mp3" type="audio/mpeg" />
   <source src="myAudio.ogg" type="audio/ogg" />
   <p>
-    Стягнути аудіо в форматі <a href="myAudio.mp3">MP3</a> або
-    <a href="myAudio.ogg">OGG</a>.
+    Стягнути аудіо в форматі
+    <a href="myAudio.mp3" download="myAudio.mp3">MP3</a> або
+    <a href="myAudio.ogg" download="myAudio.ogg">OGG</a>.
   </p>
 </audio>
 ```
@@ -305,7 +306,9 @@ elem.audioTrackList.onremovetrack = (event) => {
 ```html
 <!-- Просте відтворення аудіо -->
 <audio src="AudioTest.ogg" autoplay>
-  <a href="AudioTest.ogg">Стягнути аудіо у форматі OGG</a>.
+  <a href="AudioTest.ogg" download="AudioTest.ogg"
+    >Стягнути аудіо у форматі OGG</a
+  >.
 </audio>
 ```
 
@@ -318,7 +321,7 @@ elem.audioTrackList.onremovetrack = (event) => {
 ```html
 <audio controls>
   <source src="foo.wav" type="audio/wav" />
-  <a href="foo.wav">Стягнути аудіо у форматі WAV</a>.
+  <a href="foo.wav" download="foo.wav">Стягнути аудіо у форматі WAV</a>.
 </audio>
 ```
 
@@ -366,13 +369,13 @@ elem.audioTrackList.onremovetrack = (event) => {
   <source src="myAudio.ogg" type="audio/ogg" />
   <p>
     Стягнути аудіо у форматах <a href="myAudio.mp3">MP3</a> або
-    <a href="myAudio.ogg">OGG</a>.
+    <a href="myAudio.ogg" download="myAudio.ogg">OGG</a>.
   </p>
 </audio>
 ```
 
 - [Формат текстових доріжок вебвідео (WebVTT)](/uk/docs/Web/API/WebVTT_API)
-- [WebAIM – Субтитри, стенограми та описи аудіо](https://webaim.org/techniques/captions/
+- [WebAIM – Субтитри, стенограми та описи аудіо](https://webaim.org/techniques/captions/)
 - [MDN Розуміння WCAG, пояснення Настанови 1.2](/uk/docs/Web/Accessibility/Understanding_WCAG/Perceivable#nastanova-1-2-nadannia-tekstovykh-alternatyv-chasozalezhnym-nosiiam)
 - [Розуміння критерію успіху 1.2.1 | W3C Розуміння WCAG 2.0](https://www.w3.org/TR/UNDERSTANDING-WCAG20/media-equiv-av-only-alt.html)
 - [Розуміння критерію успіху 1.2.2 | W3C Розуміння WCAG 2.0](https://www.w3.org/TR/UNDERSTANDING-WCAG20/media-equiv-captions.html)


### PR DESCRIPTION
Оригінальний вміст: ["&lt;audio&gt; – елемент вбудованого аудіо"@MDN](https://developer.mozilla.org/en-us/docs/Web/HTML/Element/audio), [сирці "&lt;audio&gt; – елемент вбудованого аудіо"@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/html/element/audio/index.md)

Нові зміни:
- [Fix spell error brought in #29287 (#32126)](https://github.com/mdn/content/commit/429d8e4261450a61f390e11c3378c88b799f64e3)
- [download attribute for &lt;a&gt; on &lt;audio&gt; element page (#29287)](https://github.com/mdn/content/commit/94354fa6c5e8a2d4d394a3098b83fb0228dfa082)