### PR TITLE
update(JS): web/javascript/reference/global_objects/object/constructor

### DIFF
--- a/files/uk/web/javascript/reference/global_objects/object/constructor/index.md
+++ b/files/uk/web/javascript/reference/global_objects/object/constructor/index.md
@@ -45,6 +45,8 @@ n.constructor === Number; // true
 ```js
 const o = new TypeError(); // Успадкування: TypeError -> Error -> Object
 const proto = Object.getPrototypeOf;
+
+Object.hasOwn(o, "constructor"); // false
 proto(o).constructor === TypeError; // true
 proto(proto(o)).constructor === Error; // true
 proto(proto(proto(o))).constructor === Object; // true


### PR DESCRIPTION
Оригінальний вміст: [Object.prototype.constructor@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Global_Objects/Object/constructor), [сирці Object.prototype.constructor@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/global_objects/object/constructor/index.md)

Нові зміни:
- [Show that objects usually inherit the `constructor` property (#31645)](https://github.com/mdn/content/commit/42d459068e64ea5893a23fb059c17549cb4c64a7)