### PR TITLE
update(HTML): web/html/element/video

### DIFF
--- a/files/uk/web/html/element/video/index.md
+++ b/files/uk/web/html/element/video/index.md
@@ -491,8 +491,8 @@ AddType video/webm .webm
       </td>
     </tr>
     <tr>
-      <th scope="row">Упускання тегів</th>
-      <td>{{no_tag_omission}}</td>
+      <th scope="row">Пропуск тега</th>
+      <td>Немає; і початковий, і кінцевий теги – обов'язкові.</td>
     </tr>
     <tr>
       <th scope="row">Дозволені батьківські елементи</th>


### PR DESCRIPTION
Оригінальний вміст: ["&lt;video&gt; – елемент вбудованого відео"@MDN](https://developer.mozilla.org/en-us/docs/Web/HTML/Element/video), [сирці "&lt;video&gt; – елемент вбудованого відео"@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/html/element/video/index.md)

Нові зміни:
- [chore(macros): Replace no_tag_omission macro with single sentence of text (#32394)](https://github.com/mdn/content/commit/fdd3ac5598c3ddceb71e59949b003936ae99f647)