### PR TITLE
update(HTML): web/html/element/a

### DIFF
--- a/files/uk/web/html/element/a/index.md
+++ b/files/uk/web/html/element/a/index.md
@@ -458,8 +458,8 @@ document
       </td>
     </tr>
     <tr>
-      <th scope="row">Упущення тегів</th>
-      <td>{{no_tag_omission}}</td>
+      <th scope="row">Пропуск тега</th>
+      <td>Немає; і початковий, і кінцевий теги – обов'язкові.</td>
     </tr>
     <tr>
       <th scope="row">Дозволені батьківські елементи</th>


### PR DESCRIPTION
Оригінальний вміст: ["&lt;a&gt;: Якірний елемент"@MDN](https://developer.mozilla.org/en-us/docs/Web/HTML/Element/a), [сирці "&lt;a&gt;: Якірний елемент"@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/html/element/a/index.md)

Нові зміни:
- [chore(macros): Replace no_tag_omission macro with single sentence of text (#32394)](https://github.com/mdn/content/commit/fdd3ac5598c3ddceb71e59949b003936ae99f647)