### PR TITLE
update(HTML): web/html/element/select

### DIFF
--- a/files/uk/web/html/element/select/index.md
+++ b/files/uk/web/html/element/select/index.md
@@ -631,8 +631,8 @@ document.forms[0].onsubmit = (e) => {
       </td>
     </tr>
     <tr>
-      <th scope="row">Упущення тегів</th>
-      <td>{{no_tag_omission}}</td>
+      <th scope="row">Пропуск тега</th>
+      <td>Немає; і початковий, і кінцевий теги – обов'язкові.</td>
     </tr>
     <tr>
       <th scope="row">Дозволені предки</th>


### PR DESCRIPTION
Оригінальний вміст: ["&lt;select&gt;: Елемент вибору HTML"@MDN](https://developer.mozilla.org/en-us/docs/Web/HTML/Element/select), [сирці "&lt;select&gt;: Елемент вибору HTML"@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/html/element/select/index.md)

Нові зміни:
- [chore(macros): Replace no_tag_omission macro with single sentence of text (#32394)](https://github.com/mdn/content/commit/fdd3ac5598c3ddceb71e59949b003936ae99f647)