### PR TITLE
update(HTML): web/html/element/form

### DIFF
--- a/files/uk/web/html/element/form/index.md
+++ b/files/uk/web/html/element/form/index.md
@@ -142,7 +142,7 @@ browser-compat: html.elements.form
     </tr>
     <tr>
       <th scope="row">Пропуск тега</th>
-      <td>{{no_tag_omission}}</td>
+      <td>Немає; і початковий, і кінцевий теги – обов'язкові.</td>
     </tr>
     <tr>
       <th scope="row">Дозволені батьківські елементи</th>

--- a/files/uk/web/html/element/form/index.md
+++ b/files/uk/web/html/element/form/index.md
@@ -30,7 +30,7 @@ browser-compat: html.elements.form
 
 - `autocapitalize`
 
-- : Контролює те, чи додаються великі літери до тексту, введеного у поля вводу, а також, якщо так — то яким чином. Шукайте більше інформації на сторінці глобального атрибута [`autocapitalize`](/uk/docs/Web/HTML/Global_attributes/autocapitalize).
+  - : Контролює те, чи додаються великі літери до тексту, введеного у поля вводу, а також, якщо так — то яким чином. Шукайте більше інформації на сторінці глобального атрибута [`autocapitalize`](/uk/docs/Web/HTML/Global_attributes/autocapitalize).
 
 - `autocomplete`
 


### PR DESCRIPTION
Оригінальний вміст: ["&lt;form&gt; – елемент форми"@MDN](https://developer.mozilla.org/en-us/docs/Web/HTML/Element/form), [сирці "&lt;form&gt; – елемент форми"@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/html/element/form/index.md)

Нові зміни:
- [chore(macros): Replace no_tag_omission macro with single sentence of text (#32394)](https://github.com/mdn/content/commit/fdd3ac5598c3ddceb71e59949b003936ae99f647)