### PR TITLE
update(HTML): web/html/element/div

### DIFF
--- a/files/uk/web/html/element/div/index.md
+++ b/files/uk/web/html/element/div/index.md
@@ -102,8 +102,8 @@ browser-compat: html.elements.div
       </td>
     </tr>
     <tr>
-      <th scope="row">Упускання тегів</th>
-      <td>{{no_tag_omission}}</td>
+      <th scope="row">Пропуск тега</th>
+      <td>Немає; і початковий, і кінцевий теги – обов'язкові.</td>
     </tr>
     <tr>
       <th scope="row">Дозволені предки</th>


### PR DESCRIPTION
Оригінальний вміст: ["&lt;div&gt;: елемент поділу вмісту"@MDN](https://developer.mozilla.org/en-us/docs/Web/HTML/Element/div), [сирці "&lt;div&gt;: елемент поділу вмісту"@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/html/element/div/index.md)

Нові зміни:
- [chore(macros): Replace no_tag_omission macro with single sentence of text (#32394)](https://github.com/mdn/content/commit/fdd3ac5598c3ddceb71e59949b003936ae99f647)