### PR TITLE
update(HTML): web/html/element/label

### DIFF
--- a/files/uk/web/html/element/label/index.md
+++ b/files/uk/web/html/element/label/index.md
@@ -171,8 +171,8 @@ browser-compat: html.elements.label
       </td>
     </tr>
     <tr>
-      <th scope="row">Упускання тега</th>
-      <td>{{no_tag_omission}}</td>
+      <th scope="row">Пропуск тега</th>
+      <td>Немає; і початковий, і кінцевий теги – обов'язкові.</td>
     </tr>
     <tr>
       <th scope="row">Дозволені батьківські елементи</th>


### PR DESCRIPTION
Оригінальний вміст: ["&lt;label&gt;: Елемент підпису"@MDN](https://developer.mozilla.org/en-us/docs/Web/HTML/Element/label), [сирці "&lt;label&gt;: Елемент підпису"@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/html/element/label/index.md)

Нові зміни:
- [chore(macros): Replace no_tag_omission macro with single sentence of text (#32394)](https://github.com/mdn/content/commit/fdd3ac5598c3ddceb71e59949b003936ae99f647)