### PR TITLE
update(HTML): web/html/element/textarea

### DIFF
--- a/files/uk/web/html/element/textarea/index.md
+++ b/files/uk/web/html/element/textarea/index.md
@@ -26,7 +26,7 @@ browser-compat: html.elements.textarea
 
 - `autocapitalize`
 
-- : Контролює те, чи додаються великі літери до тексту, введеного у поля вводу, а також, якщо так, то яким чином. Шукайте більше інформації на сторінці глобального атрибута [`autocapitalize`](/uk/docs/Web/HTML/Global_attributes/autocapitalize).
+  - : Контролює те, чи додаються великі літери до тексту, введеного у поля вводу, а також, якщо так, то яким чином. Шукайте більше інформації на сторінці глобального атрибута [`autocapitalize`](/uk/docs/Web/HTML/Global_attributes/autocapitalize).
 
 - `autocomplete`
 
@@ -240,8 +240,8 @@ textarea:valid {
       <td>Текст</td>
     </tr>
     <tr>
-      <th scope="row">Упускання тега</th>
-      <td>{{no_tag_omission}}</td>
+      <th scope="row">Пропуск тега</th>
+      <td>Немає; і початковий, і кінцевий теги – обов'язкові.</td>
     </tr>
     <tr>
       <th scope="row">Дозволені батьківські елементи</th>


### PR DESCRIPTION
Оригінальний вміст: ["&lt;textarea&gt;: Елемент текстової області"@MDN](https://developer.mozilla.org/en-us/docs/Web/HTML/Element/textarea), [сирці "&lt;textarea&gt;: Елемент текстової області"@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/html/element/textarea/index.md)

Нові зміни:
- [chore(macros): Replace no_tag_omission macro with single sentence of text (#32394)](https://github.com/mdn/content/commit/fdd3ac5598c3ddceb71e59949b003936ae99f647)