### PR TITLE
update(HTML): web/html/element/i

### DIFF
--- a/files/uk/web/html/element/i/index.md
+++ b/files/uk/web/html/element/i/index.md
@@ -80,7 +80,7 @@ browser-compat: html.elements.i
     </tr>
     <tr>
       <th scope="row">Пропуск тега</th>
-      <td>{{no_tag_omission}}</td>
+      <td>Немає; і початковий, і кінцевий теги – обов'язкові.</td>
     </tr>
     <tr>
       <th scope="row">Дозволені батьківські елементи</th>


### PR DESCRIPTION
Оригінальний вміст: ["&lt;i&gt; – елемент ідіоматичного тексту"@MDN](https://developer.mozilla.org/en-us/docs/Web/HTML/Element/i), [сирці "&lt;i&gt; – елемент ідіоматичного тексту"@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/html/element/i/index.md)

Нові зміни:
- [chore(macros): Replace no_tag_omission macro with single sentence of text (#32394)](https://github.com/mdn/content/commit/fdd3ac5598c3ddceb71e59949b003936ae99f647)