### PR TITLE
update(HTML): web/html/element/heading_elements

### DIFF
--- a/files/uk/web/html/element/heading_elements/index.md
+++ b/files/uk/web/html/element/heading_elements/index.md
@@ -188,8 +188,8 @@ browser-compat: html.elements.h1
       </td>
     </tr>
     <tr>
-      <th scope="row">Упускання тегів</th>
-      <td>{{no_tag_omission}}</td>
+      <th scope="row">Пропуск тега</th>
+      <td>Немає; і початковий, і кінцевий теги – обов'язкові.</td>
     </tr>
     <tr>
       <th scope="row">Дозволені батьківські елементи</th>


### PR DESCRIPTION
Оригінальний вміст: ["&lt;h1&gt;–&lt;h6&gt;: Елементи заголовків розділів HTML"@MDN](https://developer.mozilla.org/en-us/docs/Web/HTML/Element/Heading_Elements), [сирці "&lt;h1&gt;–&lt;h6&gt;: Елементи заголовків розділів HTML"@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/html/element/heading_elements/index.md)

Нові зміни:
- [chore(macros): Replace no_tag_omission macro with single sentence of text (#32394)](https://github.com/mdn/content/commit/fdd3ac5598c3ddceb71e59949b003936ae99f647)