### PR TITLE
update(HTML): web/html/element/ol

### DIFF
--- a/files/uk/web/html/element/ol/index.md
+++ b/files/uk/web/html/element/ol/index.md
@@ -139,7 +139,7 @@ browser-compat: html.elements.ol
 
 #### Результат
 
-{{EmbedLiveSample("nevporyadkovanyi-spysok-useredyni-vporyadkovanoho", 400, 150)}}
+{{EmbedLiveSample("nevporiadkovanyi-spysok-useredyni-vporiadkovanoho", 400, 150)}}
 
 ## Технічний підсумок
 
@@ -163,7 +163,7 @@ browser-compat: html.elements.ol
     </tr>
     <tr>
       <th scope="row">Пропуск тега</th>
-      <td>{{no_tag_omission}}</td>
+      <td>Немає; і початковий, і кінцевий теги – обов'язкові.</td>
     </tr>
     <tr>
       <th scope="row">Дозволені батьківські елементи</th>


### PR DESCRIPTION
Оригінальний вміст: ["&lt;ol&gt; – елемент упорядкованого списку"@MDN](https://developer.mozilla.org/en-us/docs/Web/HTML/Element/ol), [сирці "&lt;ol&gt; – елемент упорядкованого списку"@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/html/element/ol/index.md)

Нові зміни:
- [chore(macros): Replace no_tag_omission macro with single sentence of text (#32394)](https://github.com/mdn/content/commit/fdd3ac5598c3ddceb71e59949b003936ae99f647)