### PR TITLE
update(HTML): web/html/element/audio

### DIFF
--- a/files/uk/web/html/element/audio/index.md
+++ b/files/uk/web/html/element/audio/index.md
@@ -405,7 +405,7 @@ elem.audioTrackList.onremovetrack = (event) => {
     </tr>
     <tr>
       <th scope="row">Пропуск тега</th>
-      <td>{{no_tag_omission}}</td>
+      <td>Немає; і початковий, і кінцевий теги – обов'язкові.</td>
     </tr>
     <tr>
       <th scope="row">Дозволені батьківські елементи</th>


### PR DESCRIPTION
Оригінальний вміст: ["&lt;audio&gt; – елемент вбудованого аудіо"@MDN](https://developer.mozilla.org/en-us/docs/Web/HTML/Element/audio), [сирці "&lt;audio&gt; – елемент вбудованого аудіо"@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/html/element/audio/index.md)

Нові зміни:
- [chore(macros): Replace no_tag_omission macro with single sentence of text (#32394)](https://github.com/mdn/content/commit/fdd3ac5598c3ddceb71e59949b003936ae99f647)