### PR TITLE
update(HTML): web/html/element/span

### DIFF
--- a/files/uk/web/html/element/span/index.md
+++ b/files/uk/web/html/element/span/index.md
@@ -81,8 +81,8 @@ li span {
       </td>
     </tr>
     <tr>
-      <th scope="row">Упускання тега</th>
-      <td>{{no_tag_omission}}</td>
+      <th scope="row">Пропуск тега</th>
+      <td>Немає; і початковий, і кінцевий теги – обов'язкові.</td>
     </tr>
     <tr>
       <th scope="row">Дозволені батьківські елементи</th>


### PR DESCRIPTION
Оригінальний вміст: ["&lt;span&gt;: Елемент відрізка вмісту"@MDN](https://developer.mozilla.org/en-us/docs/Web/HTML/Element/span), [сирці "&lt;span&gt;: Елемент відрізка вмісту"@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/html/element/span/index.md)

Нові зміни:
- [chore(macros): Replace no_tag_omission macro with single sentence of text (#32394)](https://github.com/mdn/content/commit/fdd3ac5598c3ddceb71e59949b003936ae99f647)