### PR TITLE
update(HTML): web/html/element/datalist

### DIFF
--- a/files/uk/web/html/element/datalist/index.md
+++ b/files/uk/web/html/element/datalist/index.md
@@ -144,7 +144,7 @@ browser-compat: html.elements.datalist
     </tr>
     <tr>
       <th scope="row">Пропуск тега</th>
-      <td>{{no_tag_omission}}</td>
+      <td>Немає; і початковий, і кінцевий теги – обов'язкові.</td>
     </tr>
     <tr>
       <th scope="row">Дозволені батьківські елементи</th>


### PR DESCRIPTION
Оригінальний вміст: ["&lt;datalist&gt;: Елемент HTML списку даних"@MDN](https://developer.mozilla.org/en-us/docs/Web/HTML/Element/datalist), [сирці "&lt;datalist&gt;: Елемент HTML списку даних"@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/html/element/datalist/index.md)

Нові зміни:
- [chore(macros): Replace no_tag_omission macro with single sentence of text (#32394)](https://github.com/mdn/content/commit/fdd3ac5598c3ddceb71e59949b003936ae99f647)