### PR TITLE
update(HTML): web/html/element/meter

### DIFF
--- a/files/uk/web/html/element/meter/index.md
+++ b/files/uk/web/html/element/meter/index.md
@@ -103,7 +103,7 @@ browser-compat: html.elements.meter
     </tr>
     <tr>
       <th scope="row">Пропуск тега</th>
-      <td>{{no_tag_omission}}</td>
+      <td>Немає; і початковий, і кінцевий теги – обов'язкові.</td>
     </tr>
     <tr>
       <th scope="row">Дозволені батьківські елементи</th>


### PR DESCRIPTION
Оригінальний вміст: ["&lt;meter&gt;: Елемент лічильника HTML"@MDN](https://developer.mozilla.org/en-us/docs/Web/HTML/Element/meter), [сирці "&lt;meter&gt;: Елемент лічильника HTML"@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/html/element/meter/index.md)

Нові зміни:
- [chore(macros): Replace no_tag_omission macro with single sentence of text (#32394)](https://github.com/mdn/content/commit/fdd3ac5598c3ddceb71e59949b003936ae99f647)