### PR TITLE
update(HTML): web/html/element/object

### DIFF
--- a/files/uk/web/html/element/object/index.md
+++ b/files/uk/web/html/element/object/index.md
@@ -92,7 +92,7 @@ browser-compat: html.elements.object
     </tr>
     <tr>
       <th scope="row">Пропуск тега</th>
-      <td>{{no_tag_omission}}</td>
+      <td>Немає; і початковий, і кінцевий теги – обов'язкові.</td>
     </tr>
     <tr>
       <th scope="row">Дозволені батьківські елементи</th>


### PR DESCRIPTION
Оригінальний вміст: ["&lt;object&gt; – елемент зовнішнього об'єкта"@MDN](https://developer.mozilla.org/en-us/docs/Web/HTML/Element/object), [сирці "&lt;object&gt; – елемент зовнішнього об'єкта"@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/html/element/object/index.md)

Нові зміни:
- [chore(macros): Replace no_tag_omission macro with single sentence of text (#32394)](https://github.com/mdn/content/commit/fdd3ac5598c3ddceb71e59949b003936ae99f647)