### PR TITLE
update(SVG): web/svg/attribute

### DIFF
--- a/files/uk/web/svg/attribute/index.md
+++ b/files/uk/web/svg/attribute/index.md
@@ -343,26 +343,33 @@ page-type: landing-page
 
 - Головні атрибути
 
-  - : [Головні атрибути](/uk/docs/Web/SVG/Attribute/Core)
-
-    {{SVGAttr("id")}}, {{SVGAttr("lang")}}, {{SVGAttr("tabindex")}}, {{SVGAttr("xml:base")}}, {{SVGAttr("xml:lang")}}, {{SVGAttr("xml:space")}}
-
-- Стилістичні атрибути
-
-  - : [Стилістичні атрибути](/uk/docs/Web/SVG/Attribute/Styling)
-
-    {{SVGAttr("class")}}, {{SVGAttr("style")}}
+  - {{SVGAttr("id")}}
+  - {{SVGAttr("class")}}
+  - {{SVGAttr("style")}}
+  - {{SVGAttr("lang")}}
+  - {{SVGAttr("tabindex")}}
+  - {{SVGAttr("xml:base")}}
+  - {{SVGAttr("xml:lang")}}
+  - {{SVGAttr("xml:space")}}
 
 - Атрибути умовної обробки
-  - : {{SVGAttr("requiredExtensions")}}, {{SVGAttr("requiredFeatures")}}, {{SVGAttr("systemLanguage")}}.
+  - {{SVGAttr("requiredExtensions")}}
+  - {{SVGAttr("requiredFeatures")}}
+  - {{SVGAttr("systemLanguage")}}
 
 ### Атрибути XLink
 
-{{SVGAttr("xlink:href")}}{{deprecated_inline}}, {{SVGAttr("xlink:type")}}, {{SVGAttr("xlink:role")}}, {{SVGAttr("xlink:arcrole")}}, {{SVGAttr("xlink:title")}}, {{SVGAttr("xlink:show")}}, {{SVGAttr("xlink:actuate")}}
+- {{SVGAttr("xlink:href")}}{{deprecated_inline}}
+- {{SVGAttr("xlink:type")}}
+- {{SVGAttr("xlink:role")}}
+- {{SVGAttr("xlink:arcrole")}}
+- {{SVGAttr("xlink:title")}}
+- {{SVGAttr("xlink:show")}}
+- {{SVGAttr("xlink:actuate")}}
 
 ### Атрибути представлення
 
-> **Примітка:** Всі [атрибути представлення SVG](/uk/docs/Web/SVG/Attribute/Presentation) можуть бути використані як властивості CSS.
+> **Примітка:** Всі атрибути представлення SVG можуть бути використані як властивості CSS.
 
 - {{SVGAttr("alignment-baseline")}}
 - {{SVGAttr("baseline-shift")}}
@@ -375,6 +382,7 @@ page-type: landing-page
 - {{SVGAttr("color-profile")}}
 - {{SVGAttr("color-rendering")}}
 - {{SVGAttr("cursor")}}
+- {{SVGAttr("d")}}
 - {{SVGAttr("direction")}}
 - {{SVGAttr("display")}}
 - {{SVGAttr("dominant-baseline")}}
@@ -449,29 +457,73 @@ page-type: landing-page
 
 ### Атрибути подій
 
-- Атрибути подій анімації
-
-  - : [Атрибути подій анімації](/uk/docs/Web/SVG/Attribute/Events#atrybuty-podii-animatsii)
-
-    **`onbegin`**, **`onend`**, **`onrepeat`**
-
-- Атрибути подій документа
-
-  - : [Атрибути подій документа](/uk/docs/Web/SVG/Attribute/Events#atrybuty-podii-dokumenta)
-
-    **`onabort`**, **`onerror`**, **`onresize`**, **`onscroll`**, **`onunload`**
-
-- Глобальні атрибути подій
-
-  - : [Глобальні атрибути подій](/uk/docs/Web/SVG/Attribute/Events#hlobalni-atrybuty-podii)
-
-    **`oncancel`**, **`oncanplay`**, **`oncanplaythrough`**, **`onchange`**, **`onclick`**, **`onclose`**, **`oncuechange`**, **`ondblclick`**, **`ondrag`**, **`ondragend`**, **`ondragenter`**, **`ondragleave`**, **`ondragover`**, **`ondragstart`**, **`ondrop`**, **`ondurationchange`**, **`onemptied`**, **`onended`**, **`onerror`**, **`onfocus`**, **`oninput`**, **`oninvalid`**, **`onkeydown`**, **`onkeypress`**, **`onkeyup`**, **`onload`**, **`onloadeddata`**, **`onloadedmetadata`**, **`onloadstart`**, **`onmousedown`**, **`onmouseenter`**, **`onmouseleave`**, **`onmousemove`**, **`onmouseout`**, **`onmouseover`**, **`onmouseup`**, **`onmousewheel`**, **`onpause`**, **`onplay`**, **`onplaying`**, **`onprogress`**, **`onratechange`**, **`onreset`**, **`onresize`**, **`onscroll`**, **`onseeked`**, **`onseeking`**, **`onselect`**, **`onshow`**, **`onstalled`**, **`onsubmit`**, **`onsuspend`**, **`ontimeupdate`**, **`ontoggle`**, **`onvolumechange`**, **`onwaiting`**
-
-- Атрибути графічних подій
-
-  - : [Атрибути графічних подій](/uk/docs/Web/SVG/Attribute/Events#atrybuty-hrafichnykh-podii)
-
-    **`onactivate`**, **`onfocusin`**, **`onfocusout`**
+- **`onabort`**
+- **`onactivate`**
+- **`onbegin`**
+- **`oncancel`**
+- **`oncanplay`**
+- **`oncanplaythrough`**
+- **`onchange`**
+- **`onclick`**
+- **`onclose`**
+- **`oncuechange`**
+- **`ondblclick`**
+- **`ondrag`**
+- **`ondragend`**
+- **`ondragenter`**
+- **`ondragleave`**
+- **`ondragover`**
+- **`ondragstart`**
+- **`ondrop`**
+- **`ondurationchange`**
+- **`onemptied`**
+- **`onend`**
+- **`onended`**
+- **`onerror`**
+- **`onerror`**
+- **`onfocus`**
+- **`onfocusin`**
+- **`onfocusout`**
+- **`oninput`**
+- **`oninvalid`**
+- **`onkeydown`**
+- **`onkeypress`**
+- **`onkeyup`**
+- **`onload`**
+- **`onloadeddata`**
+- **`onloadedmetadata`**
+- **`onloadstart`**
+- **`onmousedown`**
+- **`onmouseenter`**
+- **`onmouseleave`**
+- **`onmousemove`**
+- **`onmouseout`**
+- **`onmouseover`**
+- **`onmouseup`**
+- **`onmousewheel`**
+- **`onpause`**
+- **`onplay`**
+- **`onplaying`**
+- **`onprogress`**
+- **`onratechange`**
+- **`onrepeat`**
+- **`onreset`**
+- **`onresize`**
+- **`onresize`**
+- **`onscroll`**
+- **`onscroll`**
+- **`onseeked`**
+- **`onseeking`**
+- **`onselect`**
+- **`onshow`**
+- **`onstalled`**
+- **`onsubmit`**
+- **`onsuspend`**
+- **`ontimeupdate`**
+- **`ontoggle`**
+- **`onunload`**
+- **`onvolumechange`**
+- **`onwaiting`**
 
 ## Дивіться також
 


### PR DESCRIPTION
Оригінальний вміст: [Довідка атрибутів SVG@MDN](https://developer.mozilla.org/en-us/docs/Web/SVG/Attribute), [сирці Довідка атрибутів SVG@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/svg/attribute/index.md)

Нові зміни:
- [Remove landing pages for attribute categories (#32477)](https://github.com/mdn/content/commit/667bbe712207f92681d4c995fd0f18a230e6c8e6)