### PR TITLE
update(HTML): web/html/element/input/button

### DIFF
--- a/files/uk/web/html/element/input/button/index.md
+++ b/files/uk/web/html/element/input/button/index.md
@@ -169,7 +169,7 @@ function disableButton() {
 
 {{EmbedLiveSample("uspadkuvannia-stanu-vymknenosti", 650, 100)}}
 
-> **Примітка:** Firefox, на відміну від решти браузерів, усталено [зберігає динамічний стан вимкненості](https://stackoverflow.com/questions/5985839/bug-with-firefox-disabled-attribute-of-input-not-resetting-when-refreshing) елемента {{HTMLElement("button")}} між окремими завантаженнями сторінки. Для контролю цієї можливості слід використовувати атрибут [`autocomplete`](/uk/docs/Web/HTML/Element/button#autocomplete).
+> **Примітка:** Firefox, на відміну від решти браузерів, зберігає стан `disabled` елемента `<input>` при перезавантаженні сторінки. Щоб це обійти, можна задати атрибут [`autocomplete`](/uk/docs/Web/HTML/Element/button#autocomplete) елемента `<input>` зі значенням `off`. (Дивіться подробиці у [Ваді Firefox 654072](https://bugzil.la/654072).)
 
 ## Валідація
 


### PR DESCRIPTION
Оригінальний вміст: [&lt;input type="button"&gt;@MDN](https://developer.mozilla.org/en-us/docs/Web/HTML/Element/input/button), [сирці &lt;input type="button"&gt;@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/html/element/input/button/index.md)

Нові зміни:
- [Fix #32105 | Fix incorrect note about `autocomplete` attribute of `&lt;input&gt;` element of `button` type (#32112)](https://github.com/mdn/content/commit/cc032eaae8b14c1253216ded69c076242c4f757c)