### PR TITLE
update(JS): web/javascript/reference/operators/property_accessors

### DIFF
--- a/files/uk/web/javascript/reference/operators/property_accessors/index.md
+++ b/files/uk/web/javascript/reference/operators/property_accessors/index.md
@@ -16,6 +16,7 @@ browser-compat: javascript.operators.property_accessors
 ```js-nolint
 object.propertyName
 object[expression]
+object.#privateProperty
 ```
 
 ## Опис
@@ -66,6 +67,8 @@ document.createElement("pre");
 77.0.toExponential();
 // тому що 77. === 77.0, немає двозначності
 ```
+
+На додачу до цього, до [приватної властивості](/uk/docs/Web/JavaScript/Reference/Classes/Private_properties) можна звертатися лише за допомогою крапкової нотації всередині класу, який її визначає.
 
 ### Дужкова нотація
 


### PR DESCRIPTION
Оригінальний вміст: [Аксесори властивостей@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Operators/Property_accessors), [сирці Аксесори властивостей@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/operators/property_accessors/index.md)

Нові зміни:
- [Show how to access private properties in syntax section (#31593)](https://github.com/mdn/content/commit/7f29a27a26e52f91ff127fb447d90cc79667b9e4)