### PR TITLE
update(HTML): web/html/content_categories

### DIFF
--- a/files/uk/web/html/content_categories/index.md
+++ b/files/uk/web/html/content_categories/index.md
@@ -118,7 +118,6 @@ page-type: guide
 - {{HTMLElement("area")}}, коли є нащадком елемента {{HTMLElement("map")}}
 - {{HTMLElement("link")}}, коли присутній атрибут [itemprop](/uk/docs/Web/HTML/Global_attributes/itemprop)
 - {{HTMLElement("meta")}}, коли присутній атрибут [itemprop](/uk/docs/Web/HTML/Global_attributes/itemprop)
-- {{HTMLElement("style")}}, коли присутній атрибут `scoped` {{deprecated_inline}}
 
 ### Розділовий вміст
 


### PR DESCRIPTION
Оригінальний вміст: [Категорії вмісту@MDN](https://developer.mozilla.org/en-us/docs/Web/HTML/Content_categories), [сирці Категорії вмісту@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/html/content_categories/index.md)

Нові зміни:
- [Removed obsolete style scoped attribute (#32755)](https://github.com/mdn/content/commit/7faf606354aaa79ba24d20d4591cbf3af462331d)