### PR TITLE
update(CSS): web/css/width

### DIFF
--- a/files/uk/web/css/width/index.md
+++ b/files/uk/web/css/width/index.md
@@ -55,7 +55,7 @@ width: unset;
   - : Внутрішньо найменша можлива ширина.
 - `fit-content`
   - : Використовує доступний простір, але не більше, ніж [max-content](/uk/docs/Web/CSS/max-content), тобто `min(max-content, max(min-content, stretch))`.
-- `fit-content({{cssxref("&lt;length-percentage&gt;")}})` {{Experimental_Inline}}
+- `fit-content({{cssxref("&lt;length-percentage&gt;")}})`
   - : Використовує формулу fit-content щодо доступного простору, заміненого вказаним аргументом, тобто `min(max-content, max(min-content, <length-percentage>))`.
 
 ## Занепокоєння щодо доступності


### PR DESCRIPTION
Оригінальний вміст: [width@MDN](https://developer.mozilla.org/en-us/docs/Web/CSS/width), [сирці width@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/css/width/index.md)

Нові зміни:
- [fix(macro): remove inline status macros from CSS value sections, part 1 (#32756)](https://github.com/mdn/content/commit/69f98c69898886886f3267a4fa5f450f32133ca1)