### PR TITLE
update(HTML): web/html/element/video

### DIFF
--- a/files/uk/web/html/element/video/index.md
+++ b/files/uk/web/html/element/video/index.md
@@ -468,7 +468,7 @@ AddType video/webm .webm
         <a href="/uk/docs/Web/HTML/Content_categories#potokovyi-vmist"
           >Потоковий вміст</a
         >, оповідальний вміст, вбудований вміст. Якщо має атрибут
-        <a href="/uk/docs/Web/HTML/Element/video#controls"><code>controls</code></a>: інтерактивний
+        <a href="#controls"><code>controls</code></a>: інтерактивний
         вміст і дотиковий вміст.
       </td>
     </tr>
@@ -476,7 +476,7 @@ AddType video/webm .webm
       <th scope="row">Дозволений вміст</th>
       <td>
         <p>
-          Якщо елемент має атрибут <a href="/uk/docs/Web/HTML/Element/video#src"><code>src</code></a>:
+          Якщо елемент має атрибут <a href="#src"><code>src</code></a>:
           нуль чи більше елементів {{HTMLElement("track")}},
           після котрих – прозорий вміст, що не містить мультимедійних елементів, тобто
           жодних {{HTMLElement("audio")}} чи


### PR DESCRIPTION
Оригінальний вміст: ["&lt;video&gt; – елемент вбудованого відео"@MDN](https://developer.mozilla.org/en-us/docs/Web/HTML/Element/video), [сирці "&lt;video&gt; – елемент вбудованого відео"@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/html/element/video/index.md)

Нові зміни:
- [chore: fix broken links (#32809)](https://github.com/mdn/content/commit/829db137a01feb14af7beaec178a3ea0118b4777)