### PR TITLE
update(CSS): web/css/css_backgrounds_and_borders

### DIFF
--- a/files/uk/web/css/css_backgrounds_and_borders/index.md
+++ b/files/uk/web/css/css_backgrounds_and_borders/index.md
@@ -38,10 +38,10 @@ spec-urls: https://drafts.csswg.org/css-backgrounds/
 - {{cssxref("background-repeat")}}
 - {{cssxref("background-size")}}
 - Скорочення {{cssxref("background")}}
-- {{cssxref("background-position-x")}} {{experimental_inline}}
-- {{cssxref("background-position-y")}} {{experimental_inline}}
-- {{cssxref("background-position-inline")}} {{experimental_inline}}
-- {{cssxref("background-position-block")}} {{experimental_inline}}
+- {{cssxref("background-position-x")}}
+- {{cssxref("background-position-y")}}
+- {{cssxref("background-position-inline")}}
+- {{cssxref("background-position-block")}}
 
 - {{cssxref("border-bottom-color")}}
 - {{cssxref("border-bottom-style")}}


### PR DESCRIPTION
Оригінальний вміст: [Фони та межі CSS@MDN](https://developer.mozilla.org/en-us/docs/Web/CSS/CSS_backgrounds_and_borders), [сирці Фони та межі CSS@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/css/css_backgrounds_and_borders/index.md)

Нові зміни:
- [fix(macro): remove inline status macros from CSS value sections, part 2 (#32820)](https://github.com/mdn/content/commit/8d4fb1e2934111a13989d2796152dc601468e7b5)