### PR TITLE
update(CSS): web/css/css_box_model

### DIFF
--- a/files/uk/web/css/css_box_model/index.md
+++ b/files/uk/web/css/css_box_model/index.md
@@ -43,7 +43,7 @@ spec-urls: https://drafts.csswg.org/css-box/
 - {{CSSxRef("margin-left")}}
 - {{CSSxRef("margin-right")}}
 - {{CSSxRef("margin-top")}}
-- {{CSSxRef("margin-trim")}} {{Experimental_Inline}}
+- {{CSSxRef("margin-trim")}}
 
 ### Властивості для контролю внутрішніх відступів рамки
 


### PR DESCRIPTION
Оригінальний вміст: [Рамкова модель CSS@MDN](https://developer.mozilla.org/en-us/docs/Web/CSS/CSS_box_model), [сирці Рамкова модель CSS@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/css/css_box_model/index.md)

Нові зміни:
- [fix(macro): remove inline status macros from CSS value sections, part 2 (#32820)](https://github.com/mdn/content/commit/8d4fb1e2934111a13989d2796152dc601468e7b5)