### PR TITLE
update(CSS): web/css/css_grid_layout

### DIFF
--- a/files/uk/web/css/css_grid_layout/index.md
+++ b/files/uk/web/css/css_grid_layout/index.md
@@ -106,9 +106,9 @@ spec-urls: https://drafts.csswg.org/css-grid/
 - {{CSSxRef("row-gap")}}
 - {{CSSxRef("column-gap")}}
 - {{CSSxRef("gap")}}
-- {{CSSxRef("masonry-auto-flow")}} {{Experimental_Inline}}
-- {{CSSxRef("align-tracks")}} {{Experimental_Inline}}
-- {{CSSxRef("justify-tracks")}} {{Experimental_Inline}}
+- {{CSSxRef("masonry-auto-flow")}}
+- {{CSSxRef("align-tracks")}}
+- {{CSSxRef("justify-tracks")}}
 
 ### Функції
 
@@ -133,7 +133,7 @@ spec-urls: https://drafts.csswg.org/css-grid/
 - [Сіткове компонування та доступність](/uk/docs/Web/CSS/CSS_grid_layout/Grid_layout_and_accessibility)
 - [Реалізація поширених макетів за допомогою сіток](/uk/docs/Web/CSS/CSS_grid_layout/Realizing_common_layouts_using_grids)
 - [Підсітка](/uk/docs/Web/CSS/CSS_grid_layout/Subgrid)
-- [Кладкове компонування](/uk/docs/Web/CSS/CSS_grid_layout/Masonry_layout) {{Experimental_Inline}}
+- [Кладкове компонування](/uk/docs/Web/CSS/CSS_grid_layout/Masonry_layout)
 
 ## Специфікації
 


### PR DESCRIPTION
Оригінальний вміст: [Сіткове компонування CSS@MDN](https://developer.mozilla.org/en-us/docs/Web/CSS/CSS_grid_layout), [сирці Сіткове компонування CSS@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/css/css_grid_layout/index.md)

Нові зміни:
- [fix(macro): remove inline status macros from CSS value sections, part 2 (#32820)](https://github.com/mdn/content/commit/8d4fb1e2934111a13989d2796152dc601468e7b5)