### PR TITLE
update(CSS): web/css/css_selectors

### DIFF
--- a/files/uk/web/css/css_selectors/index.md
+++ b/files/uk/web/css/css_selectors/index.md
@@ -19,7 +19,7 @@ spec-urls: https://drafts.csswg.org/selectors/
 
 - `+` ([Комбінатор наступної сестри](/uk/docs/Web/CSS/Next-sibling_combinator))
 - `>` ([Дочірній комбінатор](/uk/docs/Web/CSS/Child_combinator))
-- `||` ([Колонковий комбінатор](/uk/docs/Web/CSS/Column_combinator)) {{Experimental_Inline}}
+- `||` ([Колонковий комбінатор](/uk/docs/Web/CSS/Column_combinator))
 - `~` ([Комбінатор подальших сестер](/uk/docs/Web/CSS/Subsequent-sibling_combinator))
 - " " ([Комбінатор нащадків](/uk/docs/Web/CSS/Descendant_combinator))
 - `|` ([Розділювач областей імен](/uk/docs/Web/CSS/Namespace_separator))


### PR DESCRIPTION
Оригінальний вміст: [Селектори CSS@MDN](https://developer.mozilla.org/en-us/docs/Web/CSS/CSS_selectors), [сирці Селектори CSS@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/css/css_selectors/index.md)

Нові зміни:
- [fix(macro): remove inline status macros from CSS value sections, part 2 (#32820)](https://github.com/mdn/content/commit/8d4fb1e2934111a13989d2796152dc601468e7b5)