### PR TITLE
update(CSS): web/css/css_text

### DIFF
--- a/files/uk/web/css/css_text/index.md
+++ b/files/uk/web/css/css_text/index.md
@@ -29,9 +29,9 @@ spec-urls:
 - {{cssxref("text-justify")}}
 - {{cssxref("text-size-adjust")}}
 - {{cssxref("text-transform")}}
-- {{cssxref("text-wrap")}} {{experimental_inline}}
+- {{cssxref("text-wrap")}}
 - {{cssxref("white-space")}}
-- {{cssxref("white-space-collapse")}} {{experimental_inline}}
+- {{cssxref("white-space-collapse")}}
 - {{cssxref("word-break")}}
 - {{cssxref("word-spacing")}}
 


### PR DESCRIPTION
Оригінальний вміст: [Текст CSS@MDN](https://developer.mozilla.org/en-us/docs/Web/CSS/CSS_text), [сирці Текст CSS@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/css/css_text/index.md)

Нові зміни:
- [fix(macro): remove inline status macros from CSS value sections, part 2 (#32820)](https://github.com/mdn/content/commit/8d4fb1e2934111a13989d2796152dc601468e7b5)