### PR TITLE
update(HTML): web/html/element/area

### DIFF
--- a/files/uk/web/html/element/area/index.md
+++ b/files/uk/web/html/element/area/index.md
@@ -138,7 +138,7 @@ browser-compat: html.elements.area
     <tr>
       <th scope="row">Неявна роль ARIA</th>
       <td>
-       <a href="/uk/docs/Web/Accessibility/ARIA/Roles/link_role"><code>link</code></a>, якщо присутній атрибут <a href="/uk/docs/Web/HTML/Element/area#href"><code>href</code></a>, інакше – <a href="/uk/docs/Web/Accessibility/ARIA/Roles/generic_role"><code>generic</code></a>
+       <a href="/uk/docs/Web/Accessibility/ARIA/Roles/link_role"><code>link</code></a>, якщо присутній атрибут <a href="#href"><code>href</code></a>, інакше – <a href="/uk/docs/Web/Accessibility/ARIA/Roles/generic_role"><code>generic</code></a>
       </td>
     </tr>
     <tr>


### PR DESCRIPTION
Оригінальний вміст: ["&lt;area&gt; – Елемент області на карті зображення"@MDN](https://developer.mozilla.org/en-us/docs/Web/HTML/Element/area), [сирці "&lt;area&gt; – Елемент області на карті зображення"@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/html/element/area/index.md)

Нові зміни:
- [chore: fix broken links (#32809)](https://github.com/mdn/content/commit/829db137a01feb14af7beaec178a3ea0118b4777)