### PR TITLE
update(CSS): web/css/color_value/light-dark

### DIFF
--- a/files/uk/web/css/color_value/light-dark/index.md
+++ b/files/uk/web/css/color_value/light-dark/index.md
@@ -142,4 +142,8 @@ section {
 
 - {{CSSXref("color-scheme")}}
 - {{CSSXref("&lt;color&gt;")}}
-- Модуль [Колір CSS](/uk/docs/Web/CSS/CSS_colors)
+- Модуль [Кольорів CSS](/uk/docs/Web/CSS/CSS_colors)
+- {{cssxref("@media", "Медійна")}} ознака [`prefers-contrast`](/uk/docs/Web/CSS/@media/prefers-contrast)
+- [`contrast()`](/uk/docs/Web/CSS/filter-function/contrast)
+- [WCAG – колірний контраст](/uk/docs/Web/Accessibility/Understanding_WCAG/Perceivable/Color_contrast)
+- {{cssxref('--*', 'Кастомні властивості CSS')}} і {{cssxref("var")}}


### PR DESCRIPTION
Оригінальний вміст: [light-dark()@MDN](https://developer.mozilla.org/en-us/docs/Web/CSS/color_value/light-dark), [сирці light-dark()@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/css/color_value/light-dark/index.md)

Нові зміни:
- [Several minor edits regarding CSS colors (#33025)](https://github.com/mdn/content/commit/8a22e494736dbe7cc8ba38127a0d928b9fe8e700)
- [Fix spelling of demonstation (#32904)](https://github.com/mdn/content/commit/03757b2e8c058e22d2e8f7b3bf74003d99c616a0)