### PR TITLE
update(CSS): web/css/transform-function/translate

### DIFF
--- a/files/uk/web/css/transform-function/translate/index.md
+++ b/files/uk/web/css/transform-function/translate/index.md
@@ -213,7 +213,7 @@ transform: translate(30%, 50%);
 
 ### Формальний синтаксис
 
-```css
+```plain
 translate({{cssxref("&lt;length-percentage&gt;")}}, {{cssxref("&lt;length-percentage&gt;")}}?)
 ```
 


### PR DESCRIPTION
Оригінальний вміст: [translate()@MDN](https://developer.mozilla.org/en-us/docs/Web/CSS/transform-function/translate), [сирці translate()@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/css/transform-function/translate/index.md)

Нові зміни:
- [fix(css-syntax): change language to plain (#33435)](https://github.com/mdn/content/commit/875d97804293021faaf66c16a76e2f31a6df56e1)