### PR TITLE
update(Glossary): glossary/deep_copy

### DIFF
--- a/files/uk/glossary/deep_copy/index.md
+++ b/files/uk/glossary/deep_copy/index.md
@@ -52,5 +52,5 @@ API Вебу [`structuredClone()`](/uk/docs/Web/API/structuredClone) також 
 
 ## Дивіться також
 
-- [Поверхнева копія](/uk/docs/Glossary/Shallow_copy)
+- {{glossary("Shallow copy", "Поверхневе копіювання")}}
 - [`window.structuredClone()`](/uk/docs/Web/API/structuredClone)


### PR DESCRIPTION
Оригінальний вміст: [Глибоке копіювання@MDN](https://developer.mozilla.org/en-us/docs/Glossary/Deep_copy), [сирці Глибоке копіювання@GitHub](https://github.com/mdn/content/blob/main/files/en-us/glossary/deep_copy/index.md)

Нові зміни:
- [feat: improvements on glossary articles (#33413)](https://github.com/mdn/content/commit/7a551aaa034fbada3eb99e6fc924a0313b78307f)