### PR TITLE
update(JS): web/javascript/reference/global_objects/array/splice

### DIFF
--- a/files/uk/web/javascript/reference/global_objects/array/splice/index.md
+++ b/files/uk/web/javascript/reference/global_objects/array/splice/index.md
@@ -55,7 +55,7 @@ splice(start, deleteCount, item1, item2, /* …, */ itemN)
 
 ## Опис
 
-Метод `splice()` – це [змінювальний метод](/uk/docs/Web/JavaScript/Reference/Global_Objects/Array#kopiiuvalni-ta-zminiuvalni-metody). Він може змінити вміст `this`. Якщо кількість наданих для вставки елементів відрізняється від кількості елементів, які видаляються, властивість `length` масиву зміниться також. Крім того, він використовує [`@@species`](/uk/docs/Web/JavaScript/Reference/Global_Objects/Array/@@species) для створення нового примірника масиву, що повертається.
+Метод `splice()` – це [змінювальний метод](/uk/docs/Web/JavaScript/Reference/Global_Objects/Array#kopiiuvalni-ta-zminiuvalni-metody). Він може змінити вміст `this`. Якщо кількість наданих для вставки елементів відрізняється від кількості елементів, які видаляються, властивість `length` масиву зміниться також. Крім того, він використовує [`Symbol.species`](/uk/docs/Web/JavaScript/Reference/Global_Objects/Array/Symbol.species) для створення нового примірника масиву, що повертається.
 
 Якщо видалена частка є [розрідженою](/uk/docs/Web/JavaScript/Guide/Indexed_collections#rozridzheni-masyvy), то повернений `splice()` масив також буде розрідженим, і відповідні індекси будуть порожніми комірками.
 


### PR DESCRIPTION
Оригінальний вміст: [Array.prototype.splice()@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Global_Objects/Array/splice), [сирці Array.prototype.splice()@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/global_objects/array/splice/index.md)

Нові зміни:
- [Remove all `@@notation` from page slugs (#34824)](https://github.com/mdn/content/commit/6fbdb78c1362fae31fbd545f4b2d9c51987a6bca)
- [Remove all @@notation in JS prose (#34817)](https://github.com/mdn/content/commit/6e93ec8fc9e1f3bd83bf2f77e84e1a39637734f8)