### PR TITLE
update(JS): web/javascript/reference/global_objects/set

### DIFF
--- a/files/uk/web/javascript/reference/global_objects/set/index.md
+++ b/files/uk/web/javascript/reference/global_objects/set/index.md
@@ -118,7 +118,7 @@ const b = new Map([
 console.log(a.union(b)); // Set(4) {1, 2, 3, 4}
 ```
 
-> **Примітка:** Протокол множиноподібності закликає для видачі елементів метод `keys()`, а не [`[@@iterator]()`](/uk/docs/Web/JavaScript/Reference/Global_Objects/Set/@@iterator). Це зроблено для того, щоб відображення були дієвими множиноподібними об'єктами, адже в випадку відображень ітератор видає _записи_, проте метод `has()` приймає _ключі_.
+> **Примітка:** Протокол множиноподібності закликає для видачі елементів метод `keys()`, а не [`[Symbol.iterator]()`](/uk/docs/Web/JavaScript/Reference/Global_Objects/Set/Symbol.iterator). Це зроблено для того, щоб відображення були дієвими множиноподібними об'єктами, адже в випадку відображень ітератор видає _записи_, проте метод `has()` приймає _ключі_.
 > [Масиви](/uk/docs/Web/JavaScript/Reference/Global_Objects/Array) не є множиноподібними, тому що не мають метода `has()` і властивості `size`, а їх метод `keys()` видає індекси, а не елементи. Об'єкти {{jsxref("WeakSet")}} також не є множиноподібними, оскільки не мають метода `keys()`.
 
 ### Set-подібні API браузера
@@ -141,7 +141,7 @@ interface GPUSupportedFeatures {
 
 `Set`-подібні об'єкти – або доступні лише для зчитування, або також і для запису (дивіться ключове слово `readonly` в IDL вище).
 
-- `Set`-подібні об'єкти лише для зчитування мають властивість [`size`](#set.prototype.size) і методи: [`entries()`](#set.prototype.entries), [`forEach()`](#set.prototype.foreach), [`has()`](#set.prototype.has), [`keys()`](#set.prototype.keys), [`values()`](#set.prototype.values) та [`@@iterator`](#set.prototypeiterator).
+- `Set`-подібні об'єкти лише для зчитування мають властивість [`size`](#set.prototype.size) і методи: [`entries()`](#set.prototype.entries), [`forEach()`](#set.prototype.foreach), [`has()`](#set.prototype.has), [`keys()`](#set.prototype.keys), [`values()`](#set.prototype.values) та [`Symbol.iterator`](#set.prototypeiterator).
 - Записні `Set`-подібні об'єкти на додачу мають такі методи: [`clear()`](#set.prototype.clear), [`delete()`](#set.prototype.delete) та [`add()`](#set.prototype.add).
 
 Ці методи та властивості мають таку ж логіку, як рівносильні аналоги в `Set`, окрім обмеження щодо типів елементів.
@@ -164,7 +164,7 @@ interface GPUSupportedFeatures {
 
 ## Статичні властивості
 
-- {{jsxref("Set/@@species", "Set[@@species]")}}
+- [`Set[Symbol.species]`](/uk/docs/Web/JavaScript/Reference/Global_Objects/Set/Symbol.species)
   - : Функція-конструктор, що використовується для створення похідних об'єктів.
 
 ## Властивості примірника
@@ -175,8 +175,8 @@ interface GPUSupportedFeatures {
   - : Функція-конструктор, що створила об'єкт-примірник. Для примірників `Set` початковим значенням є конструктор {{jsxref("Set/Set", "Set")}}.
 - {{jsxref("Set.prototype.size")}} (розмір)
   - : Повертає кількість значень, присутніх в об'єкті `Set`.
-- `Set.prototype[@@toStringTag]`
-  - : Початкове значення властивості [`@@toStringTag`](/uk/docs/Web/JavaScript/Reference/Global_Objects/Symbol/toStringTag) – рядок `"Set"`. Ця властивість використовується в {{jsxref("Object.prototype.toString()")}}.
+- `Set.prototype[Symbol.toStringTag]`
+  - : Початкове значення властивості [`Symbol.toStringTag`](/uk/docs/Web/JavaScript/Reference/Global_Objects/Symbol/toStringTag) – рядок `"Set"`. Ця властивість використовується в {{jsxref("Object.prototype.toString()")}}.
 
 ## Методи примірника
 
@@ -210,7 +210,7 @@ interface GPUSupportedFeatures {
   - : Приймає множину та повертає нову множину, що вміщає елементи, присутні в одній з множин або в них обох.
 - {{jsxref("Set.prototype.values()")}} (значення)
   - : Повертає новий об'єкт-ітератор, що видає **значення** для кожного елемента в об'єкті `Set`, у порядку їх додання.
-- {{jsxref("Set.prototype.@@iterator()", "Set.prototype[@@iterator]()")}}
+- {{jsxref("Set.prototype.Symbol.iterator()", "Set.prototype[Symbol.iterator]()")}}
   - : Повертає новий об'єкт-ітератор, що видає **значення** для кожного елемента в об'єкті `Set`, у порядку їх додання.
 
 ## Приклади


### PR DESCRIPTION
Оригінальний вміст: [Set@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Global_Objects/Set), [сирці Set@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/global_objects/set/index.md)

Нові зміни:
- [Remove all `@@notation` from page slugs (#34824)](https://github.com/mdn/content/commit/6fbdb78c1362fae31fbd545f4b2d9c51987a6bca)
- [Remove all @@notation in JS prose (#34817)](https://github.com/mdn/content/commit/6e93ec8fc9e1f3bd83bf2f77e84e1a39637734f8)