### PR TITLE
update(JS): web/javascript/reference/global_objects/set

### DIFF
--- a/files/uk/web/javascript/reference/global_objects/set/index.md
+++ b/files/uk/web/javascript/reference/global_objects/set/index.md
@@ -210,7 +210,7 @@ interface GPUSupportedFeatures {
   - : Приймає множину та повертає нову множину, що вміщає елементи, присутні в одній з множин або в них обох.
 - {{jsxref("Set.prototype.values()")}} (значення)
   - : Повертає новий об'єкт-ітератор, що видає **значення** для кожного елемента в об'єкті `Set`, у порядку їх додання.
-- {{jsxref("Set.prototype.Symbol.iterator()", "Set.prototype[Symbol.iterator]()")}}
+- [`Set.prototype[Symbol.iterator]()`](/uk/docs/Web/JavaScript/Reference/Global_Objects/Set/Symbol.iterator)
   - : Повертає новий об'єкт-ітератор, що видає **значення** для кожного елемента в об'єкті `Set`, у порядку їх додання.
 
 ## Приклади


### PR DESCRIPTION
Оригінальний вміст: [Set@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Global_Objects/Set), [сирці Set@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/global_objects/set/index.md)

Нові зміни:
- [chore: fix broken links and spacing (#34869)](https://github.com/mdn/content/commit/e2dd7ae35f27c814d6017b79dac87e23c7996837)