### PR TITLE
update(JS): web/javascript/reference/global_objects/date/now

### DIFF
--- a/files/uk/web/javascript/reference/global_objects/date/now/index.md
+++ b/files/uk/web/javascript/reference/global_objects/date/now/index.md
@@ -29,7 +29,7 @@ Date.now()
 
 ### Знижена точність часу
 
-Для забезпечення захисту від часових атак і [створення цифрових відбитків](/uk/docs/Glossary/Fingerprinting), точні значення `Date.now()` можуть заокруглюватись залежно від налаштувань браузера. Наприклад, у Firefox опція `privacy.reduceTimerPrecision` — усталено ввімкнена, і усталено дорівнює 20 мкс у Firefox. Також можна увімкнути `privacy.resistFingerprinting`, і в цьому випадку точність дорівнюватиме 100 мс або значенню `privacy.resistFingerprinting.reduceTimerPrecision.microseconds` — залежно від того, яке з цих значень більше.
+Для забезпечення захисту від часових атак і [створення цифрових відбитків](/uk/docs/Glossary/Fingerprinting), точні значення `Date.now()` можуть заокруглюватись залежно від налаштувань браузера. Наприклад, у Firefox опція `privacy.reduceTimerPrecision` — усталено ввімкнена і усталено дорівнює 2 мс у Firefox. Також можна увімкнути `privacy.resistFingerprinting`, і в цьому випадку точність дорівнюватиме 100 мс або значенню `privacy.resistFingerprinting.reduceTimerPrecision.microseconds` — залежно від того, яке з цих значень більше.
 
 Наприклад, за зниженої точності значення часу результат `Date.now()` завжди буде кратним 2 та буде кратним 100 (або `privacy.resistFingerprinting.reduceTimerPrecision.microseconds`), коли ввімкнено `privacy.resistFingerprinting`.
 

--- a/files/uk/web/javascript/reference/global_objects/date/now/index.md
+++ b/files/uk/web/javascript/reference/global_objects/date/now/index.md
@@ -31,7 +31,7 @@ Date.now()
 
 Для забезпечення захисту від часових атак і [створення цифрових відбитків](/uk/docs/Glossary/Fingerprinting), точні значення `Date.now()` можуть заокруглюватись залежно від налаштувань браузера. Наприклад, у Firefox опція `privacy.reduceTimerPrecision` — усталено ввімкнена, і усталено дорівнює 20 мкс у Firefox. Також можна увімкнути `privacy.resistFingerprinting`, і в цьому випадку точність дорівнюватиме 100 мс або значенню `privacy.resistFingerprinting.reduceTimerPrecision.microseconds` — залежно від того, яке з цих значень більше.
 
-Наприклад, при зниженій точності часу результат `Date.now()` завжди буде кратним 2, або кратним 100 (або `privacy.resistFingerprinting.reduceTimerPrecision.microseconds`), коли ввімкнено `privacy.resistFingerprinting`.
+Наприклад, за зниженої точності значення часу результат `Date.now()` завжди буде кратним 2 та буде кратним 100 (або `privacy.resistFingerprinting.reduceTimerPrecision.microseconds`), коли ввімкнено `privacy.resistFingerprinting`.
 
 ```js
 // знижена точність часу (2мс) у Firefox 60

--- a/files/uk/web/javascript/reference/global_objects/date/now/index.md
+++ b/files/uk/web/javascript/reference/global_objects/date/now/index.md
@@ -29,7 +29,7 @@ Date.now()
 
 ### Знижена точність часу
 
-Для забезпечення захисту від часових атак і [створення цифрових відбитків](/uk/docs/Glossary/Fingerprinting), точні значення `Date.now()` можуть заокруглюватись залежно від налаштувань браузера. Наприклад, у Firefox опція `privacy.reduceTimerPrecision` — усталено ввімкнена і усталено дорівнює 2 мс у Firefox. Також можна увімкнути `privacy.resistFingerprinting`, і в цьому випадку точність дорівнюватиме 100 мс або значенню `privacy.resistFingerprinting.reduceTimerPrecision.microseconds` — залежно від того, яке з цих значень більше.
+Для забезпечення захисту від часових атак і [створення цифрових відбитків](/uk/docs/Glossary/Fingerprinting), точні значення `Date.now()` можуть заокруглюватись залежно від налаштувань браузера. Наприклад, у Firefox опція `privacy.reduceTimerPrecision` — усталено ввімкнена й усталено дорівнює 2 мс у Firefox. Також можна увімкнути `privacy.resistFingerprinting`, і в цьому випадку точність дорівнюватиме 100 мс або значенню `privacy.resistFingerprinting.reduceTimerPrecision.microseconds` — залежно від того, яке з цих значень більше.
 
 Наприклад, за зниженої точності значення часу результат `Date.now()` завжди буде кратним 2 та буде кратним 100 (або `privacy.resistFingerprinting.reduceTimerPrecision.microseconds`), коли ввімкнено `privacy.resistFingerprinting`.
 

--- a/files/uk/web/javascript/reference/global_objects/date/now/index.md
+++ b/files/uk/web/javascript/reference/global_objects/date/now/index.md
@@ -31,9 +31,12 @@ Date.now()
 
 Для забезпечення захисту від часових атак і [створення цифрових відбитків](/uk/docs/Glossary/Fingerprinting), точні значення `Date.now()` можуть заокруглюватись залежно від налаштувань браузера. Наприклад, у Firefox опція `privacy.reduceTimerPrecision` — усталено ввімкнена, і усталено дорівнює 20 мкс у Firefox. Також можна увімкнути `privacy.resistFingerprinting`, і в цьому випадку точність дорівнюватиме 100 мс або значенню `privacy.resistFingerprinting.reduceTimerPrecision.microseconds` — залежно від того, яке з цих значень більше.
 
+Наприклад, при зниженій точності часу результат `Date.now()` завжди буде кратним 2, або кратним 100 (або `privacy.resistFingerprinting.reduceTimerPrecision.microseconds`), коли ввімкнено `privacy.resistFingerprinting`.
+
 ```js
 // знижена точність часу (2мс) у Firefox 60
 Date.now();
+// Може бути:
 // 1519211809934
 // 1519211810362
 // 1519211811670
@@ -41,6 +44,7 @@ Date.now();
 
 // знижена точність часу із увімкненою опцією `privacy.resistFingerprinting`
 Date.now();
+// Може бути:
 // 1519129853500
 // 1519129858900
 // 1519129864400


### PR DESCRIPTION
Оригінальний вміст: [Date.now()@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Global_Objects/Date/now), [сирці Date.now()@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/global_objects/date/now/index.md)

Нові зміни:
- [Consistent reduced time precision sections (#34632)](https://github.com/mdn/content/commit/3b5a1c0dfd59257c0a51052a9efa7b0108f8ecca)