### PR TITLE
update(JS): web/javascript/reference/global_objects/math

### DIFF
--- a/files/uk/web/javascript/reference/global_objects/math/index.md
+++ b/files/uk/web/javascript/reference/global_objects/math/index.md
@@ -37,8 +37,8 @@ browser-compat: javascript.builtins.Math
   - : Квадратний корінь з ½. Наближено дорівнює `0.707`.
 - {{jsxref("Math.SQRT2")}}
   - : Квадратний корінь з `2`. Наближено дорівнює `1.414`.
-- `Math[@@toStringTag]`
-  - : Початкове значення властивості [`@@toStringTag`](/uk/docs/Web/JavaScript/Reference/Global_Objects/Symbol/toStringTag) – рядок `"Math"`. Ця властивість використовується в {{jsxref("Object.prototype.toString()")}}.
+- `Math[Symbol.toStringTag]`
+  - : Початкове значення властивості [`Symbol.toStringTag`](/uk/docs/Web/JavaScript/Reference/Global_Objects/Symbol/toStringTag) – рядок `"Math"`. Ця властивість використовується в {{jsxref("Object.prototype.toString()")}}.
 
 ## Статичні методи
 


### PR DESCRIPTION
Оригінальний вміст: [Math@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Global_Objects/Math), [сирці Math@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/global_objects/math/index.md)

Нові зміни:
- [Remove all @@notation in JS prose (#34817)](https://github.com/mdn/content/commit/6e93ec8fc9e1f3bd83bf2f77e84e1a39637734f8)