### PR TITLE
update(HTML): web/html/element/form

### DIFF
--- a/files/uk/web/html/element/form/index.md
+++ b/files/uk/web/html/element/form/index.md
@@ -1,5 +1,5 @@
 ---
-title: "<form> – елемент форми"
+title: <form> – елемент форми
 slug: Web/HTML/Element/form
 page-type: html-element
 browser-compat: html.elements.form
@@ -32,18 +32,18 @@ browser-compat: html.elements.form
 
   - : Контролює те, чи додаються великі літери до тексту, введеного у поля вводу, а також, якщо так — то яким чином. Шукайте більше інформації на сторінці глобального атрибута [`autocapitalize`](/uk/docs/Web/HTML/Global_attributes/autocapitalize).
 
-- `autocomplete`
+- [`autocomplete`](/uk/docs/Web/HTML/Attributes/autocomplete)
 
   - : Позначає те, чи можуть поля введення усталено автоматично заповнюватись браузером. Атрибути `autocomplete` на елементах форми відкидають такий атрибут на `<form>`. Можливі значення:
 
-    - `off`: Браузер може не заповнювати автоматично поля. (Браузери мають тенденцію ігнорувати це там, де підозрюють форми автентифікації; дивіться [Атрибут autocomplete і поля автентифікації](/uk/docs/Web/Security/Securing_your_site/Turning_off_form_autocompletion#atrybut-autocomplete-i-polia-avtentyfikatsii).)
+    - `off`: Браузер може не заповнювати автоматично поля. (Браузери мають тенденцію ігнорувати це там, де підозрюють форми автентифікації; дивіться [Контроль автозаповнення для полів автентифікації](/uk/docs/Web/Security/Practical_implementation_guides/Turning_off_form_autocompletion#kontrol-avtozapovnennia-dlia-poliv-avtentyfikatsii).)
     - `on`: Браузер може заповнювати поля автоматично.
 
 - `name`
 
   - : Ім'я форми. Значення мусить не бути порожнім рядком, і бути унікальним серед елементів `form` у колекції форм, в котрій лежить форма, якщо така є.
 
-- `rel`
+- [`rel`](/uk/docs/Web/HTML/Attributes/rel)
   - : Контролює анотації й те, якого роду посилання породжує форма. Серед анотацій: [`external`](/uk/docs/Web/HTML/Attributes/rel#external), [`nofollow`](/uk/docs/Web/HTML/Attributes/rel#nofollow), [`opener`](/uk/docs/Web/HTML/Attributes/rel#opener), [`noopener`](/uk/docs/Web/HTML/Attributes/rel#noopener) і [`noreferrer`](/uk/docs/Web/HTML/Attributes/rel#noreferrer). Серед різновидів посилань: [`help`](/uk/docs/Web/HTML/Attributes/rel#help), [`prev`](/uk/docs/Web/HTML/Attributes/rel#prev), [`next`](/uk/docs/Web/HTML/Attributes/rel#next), [`search`](/uk/docs/Web/HTML/Attributes/rel#search) і [`license`](/uk/docs/Web/HTML/Attributes/rel#license). Значення [`rel`](/uk/docs/Web/HTML/Attributes/rel) є розділеним пробілами списком таких значень.
 
 ### Атрибути для подання форми


### PR DESCRIPTION
Оригінальний вміст: ["&lt;form&gt; – елемент форми"@MDN](https://developer.mozilla.org/en-us/docs/Web/HTML/Element/form), [сирці "&lt;form&gt; – елемент форми"@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/html/element/form/index.md)

Нові зміни:
- [HTML element attr list should link to attr page (#34523)](https://github.com/mdn/content/commit/991385e7cfb9ac8589332b07aadcc4b38edea512)
- [Add Observatory docs to MDN (#33793)](https://github.com/mdn/content/commit/75e254fe894a22724a3d01ef6b20b9848e9f5309)