### PR TITLE
update(JS): web/javascript/reference/global_objects/intl/numberformat

### DIFF
--- a/files/uk/web/javascript/reference/global_objects/intl/numberformat/index.md
+++ b/files/uk/web/javascript/reference/global_objects/intl/numberformat/index.md
@@ -27,8 +27,8 @@ browser-compat: javascript.builtins.Intl.NumberFormat
 
 - {{jsxref("Object/constructor", "Intl.NumberFormat.prototype.constructor")}}
   - : Функція-конструктор, котра створила цей об'єкт-примірник. Для примірників `Intl.NumberFormat` початковим значенням є конструктор {{jsxref("Intl/NumberFormat/NumberFormat", "Intl.NumberFormat")}}.
-- `Intl.NumberFormat.prototype[@@toStringTag]`
-  - : Початковим значенням властивості [`@@toStringTag`](/uk/docs/Web/JavaScript/Reference/Global_Objects/Symbol/toStringTag) є рядок `"Intl.NumberFormat"`. Ця властивість використовується в {{jsxref("Object.prototype.toString()")}}.
+- `Intl.NumberFormat.prototype[Symbol.toStringTag]`
+  - : Початковим значенням властивості [`Symbol.toStringTag`](/uk/docs/Web/JavaScript/Reference/Global_Objects/Symbol/toStringTag) є рядок `"Intl.NumberFormat"`. Ця властивість використовується в {{jsxref("Object.prototype.toString()")}}.
 
 ## Методи примірника
 


### PR DESCRIPTION
Оригінальний вміст: [Intl.NumberFormat@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat), [сирці Intl.NumberFormat@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/global_objects/intl/numberformat/index.md)

Нові зміни:
- [Remove all @@notation in JS prose (#34817)](https://github.com/mdn/content/commit/6e93ec8fc9e1f3bd83bf2f77e84e1a39637734f8)