### PR TITLE
update(CSS): web/css/@media

### DIFF
--- a/files/uk/web/css/@media/index.md
+++ b/files/uk/web/css/@media/index.md
@@ -15,7 +15,7 @@ browser-compat: css.at-rules.media
 
 ## Синтаксис
 
-Директива `@media` повинна стояти на зовнішньому рівні коду або бути вкладена в якусь іншу [умовну групову директиву](/uk/docs/Web/CSS/At-rule#umovni-hrupovi-dyrektyvy).
+Директива `@media` повинна стояти на зовнішньому рівні коду або бути вкладена в якусь іншу умовну групову директиву.
 
 ```css
 /* На зовнішньому рівні коду */
@@ -42,7 +42,7 @@ browser-compat: css.at-rules.media
 ### Типи медіа
 
 _Типи медіа_ описують загальні категорії пристроїв.
-Коли не використовуються логічні оператори `not` і `only`, тип медіа є необов'язковим, – якщо він не вказаний, то вважається, що він дорівнює `all`.
+Коли не використовується логічний оператор `only`, тип медіа є необов'язковим, – якщо він не вказаний, то вважається, що він дорівнює `all`.
 
 - `all`
   - : Підходить для всіх пристроїв.
@@ -82,7 +82,7 @@ _Можливості медіа_ описують конкретні харак
 - {{cssxref("@media/device-width", "device-width")}}
   - : Ширина поверхні візуалізації пристрою виведення. Нерекомендований від Медіазапитів рівня 4.
 - {{cssxref("@media/display-mode", "display-mode")}}
-  - : Режим, у якому виводиться застосунок: наприклад, [повноекранний](/uk/docs/Web/API/Fullscreen_API) або [режим зображення в зображенні](/uk/docs/Web/API/Document_Picture-in-Picture_API).
+  - : Режим, у якому виводиться застосунок: наприклад, [повноекранний](/uk/docs/Web/CSS/@media/display-mode#fullscreen) або [режим зображення в зображенні](/uk/docs/Web/CSS/@media/display-mode#picture-in-picture).
     Додано в Медіазапитах рівня 5.
 - {{cssxref("@media/dynamic-range", "dynamic-range")}}
   - : Поєднання яскравості, контрастності та глибини кольору, які підтримуються користувацьким агентом і пристроєм виведення. Додано в Медіазапитах рівня 5.
@@ -148,7 +148,6 @@ _Логічні оператори_ `not`, `and`, `only` й `or` можуть в
 
   - : Використовується для заперечення медіазапиту, повертаючи `true`, якщо інакше запит повернув би `false`.
     Якщо цей оператор присутній в розділеному комами списку запитів, то заперечує лише конкретний запит, до якого застосовується.
-    Якщо використовується оператор `not`, то _обов'язково_ повинен бути вказаний тип медіа.
 
     > **Примітка:** На рівні 3 ключове слово `not` не може використовуватися для заперечення окремого виразу можливості медіа, а лише цілого медіазапиту.
 
@@ -173,9 +172,9 @@ _Логічні оператори_ `not`, `and`, `only` й `or` можуть в
 
 ## Занепокоєння щодо доступності
 
-Щоб якнайкраще врахувати потреби людей, які змінюють розмір тексту на сайті, слід використовувати для ваших [медіазапитів](/uk/docs/Web/CSS/CSS_media_queries/Using_media_queries) одиниці [`em`](/uk/docs/Learn/CSS/Building_blocks/Values_and_units#chyslovi-znachennia), коли потрібні значення {{cssxref("&lt;length&gt;")}}.
+Щоб якнайкраще врахувати потреби людей, які змінюють розмір тексту на сайті, слід використовувати для ваших [медіазапитів](/uk/docs/Web/CSS/CSS_media_queries/Using_media_queries) одиниці [`em`](/uk/docs/Web/CSS/CSS_Values_and_Units#chyslovi-typy-danykh), коли потрібні значення {{cssxref("&lt;length&gt;")}}.
 
-Як [`em`](/uk/docs/Learn/CSS/Building_blocks/Values_and_units#chyslovi-znachennia), так і [`px`](/uk/docs/Learn/CSS/Building_blocks/Values_and_units#chyslovi-znachennia) є дійсними одиницями, але [`em`](/uk/docs/Learn/CSS/Building_blocks/Values_and_units#chyslovi-znachennia) працює краще, якщо користувач змінює розмір тексту в браузері.
+Як [`em`](/uk/docs/Web/CSS/CSS_Values_and_Units#chyslovi-znachennia), так і [`px`](/uk/docs/Web/CSS/CSS_Values_and_Units#chyslovi-znachennia) є дійсними одиницями, але [`em`](/uk/docs/Web/CSS/CSS_Values_and_Units#chyslovi-znachennia) працює краще, якщо користувач змінює розмір тексту в браузері.
 
 Також варто розглянути медіазапити чи [клієнтські підказки користувацькому агентові](/uk/docs/Web/HTTP/Client_hints#kliientski-pidkazky-korystuvatskomu-ahentovi), щоб покращити користувацький досвід.
 Наприклад, медіазапит [`prefers-reduced-motion`](/uk/docs/Web/CSS/@media/prefers-reduced-motion) або відповідний заголовок {{HTTPHeader("Sec-CH-Prefers-Reduced-Motion")}}) можна використати для мінімізації кількості анімації чи руху, на основі побажань користувача.


### PR DESCRIPTION
Оригінальний вміст: ["@media"@MDN](https://developer.mozilla.org/en-us/docs/Web/CSS/@media), [сирці "@media"@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/css/@media/index.md)

Нові зміни:
- [fix(css): update at-rule page (#34709)](https://github.com/mdn/content/commit/bf601f2987ac1f45bcc03ad682e6284e9579df21)
- [Remove mention that `not` must be used with media type (#34509)](https://github.com/mdn/content/commit/525ef44e8a116b5c578205e4ce7fcca1ad35c94e)
- [Fix anchors, CSS batch 1 (#34544)](https://github.com/mdn/content/commit/1b9f8e62afc890f2f00d6f9043f3ce0ff2ac4dfb)
- [fix(css): Fix the `display-mode` links in the `@media` feature (#34387)](https://github.com/mdn/content/commit/61cf2b2cbef67a5dc43beda6797219f4ef28965d)