### PR TITLE
update(HTML): web/html/element/input/datetime-local

### DIFF
--- a/files/uk/web/html/element/input/datetime-local/index.md
+++ b/files/uk/web/html/element/input/datetime-local/index.md
@@ -229,14 +229,17 @@ input:valid + span::after {
       <td>
         <a href="/uk/docs/Web/HTML/Element/input#autocomplete"><code>autocomplete</code></a>,
         <a href="/uk/docs/Web/HTML/Element/input#list-spysok"><code>list</code></a>,
-        <a href="/uk/docs/Web/HTML/Element/input#readonly-lyshe-dlia-chytannia"><code>readonly</code></a> і
+        <a href="/uk/docs/Web/HTML/Element/input#readonly-lyshe-dlia-chytannia"><code>readonly</code></a>,
         <a href="/uk/docs/Web/HTML/Element/input#step-krok"><code>step</code></a>
       </td>
     </tr>
     <tr>
       <td><strong>Атрибути IDL</strong></td>
       <td>
-        <code>list</code>, <code>value</code>, <code>valueAsNumber</code>.
+        <a href="/uk/docs/Web/HTML/Element/input#list-spysok"><code>list</code></a>,
+        <a href="/uk/docs/Web/HTML/Element/input#value-znachennia"><code>value</code></a>,
+        <code>valueAsDate</code>,
+        <code>valueAsNumber</code>
       </td>
     </tr>
     <tr>
@@ -271,5 +274,5 @@ input:valid + span::after {
 - Узагальнений елемент {{HTMLElement("input")}}, а також інтерфейс, що використовується для роботи з ним, – {{domxref("HTMLInputElement")}}
 - [`<input type="date">`](/uk/docs/Web/HTML/Element/input/date) і [`<input type="time">`](/uk/docs/Web/HTML/Element/input/time)
 - [Формати дати й часу, що використовуються в HTML](/uk/docs/Web/HTML/Date_and_time_formats)
-- [Підручник з інтерфейсу вибору дати та часу](/uk/docs/Learn/Forms/Basic_native_form_controls#interfeis-vyboru-daty-ta-chasu)
+- [Підручник з інтерфейсу вибору дати та часу](/uk/docs/Learn/Forms/HTML5_input_types#interfeis-vyboru-daty-ta-chasu)
 - [Сумісність властивостей CSS](/uk/docs/Learn/Forms/Property_compatibility_table_for_form_controls)


### PR DESCRIPTION
Оригінальний вміст: [&lt;input type="datetime-local"&gt;@MDN](https://developer.mozilla.org/en-us/docs/Web/HTML/Element/input/datetime-local), [сирці &lt;input type="datetime-local"&gt;@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/html/element/input/datetime-local/index.md)

Нові зміни:
- [enhance: html input element - technical summary - attributes (#31639)](https://github.com/mdn/content/commit/68ee1b1496bfd5dd779feed417e52a91fa55d789)
- [Fix anchors, JS/HTTP/HTML (#34539)](https://github.com/mdn/content/commit/d7e274e727920f0f85f14e0bdd18e6e585419a90)
- [Fix broken anchor in datetime-local (#32217)](https://github.com/mdn/content/commit/f8066bc2967fb16c5107c2b4bdab7a99f26f7d72)