### PR TITLE
update(HTML): web/html/attributes

### DIFF
--- a/files/uk/web/html/attributes/index.md
+++ b/files/uk/web/html/attributes/index.md
@@ -815,21 +815,6 @@ page-type: landing-page
     </tr>
     <tr>
       <td>
-        <code><a href="/uk/docs/Web/HTML/Element/html#manifest">manifest</a></code>
-        {{deprecated_inline}}
-      </td>
-      <td>{{HTMLElement("html")}}</td>
-      <td>
-        Задає URL маніфесту кешу документа.
-        <div class="note">
-          <p>
-            <strong>Примітка:</strong> Цей атрибут застарів, замість нього слід використовувати <a href="/uk/docs/Web/Manifest"><code>&#x3C;link rel="manifest"></code></a>.
-          </p>
-        </div>
-      </td>
-    </tr>
-    <tr>
-      <td>
         <code><a href="/uk/docs/Web/HTML/Attributes/max">max</a></code>
       </td>
       <td>


### PR DESCRIPTION
Оригінальний вміст: [Довідка атрибутів HTML@MDN](https://developer.mozilla.org/en-us/docs/Web/HTML/Attributes), [сирці Довідка атрибутів HTML@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/html/attributes/index.md)

Нові зміни:
- [remove the deprecated `manifest` HTML attribute (#33932)](https://github.com/mdn/content/commit/bf671984cfef2f7c6419571d834a146c5424ac10)