### PR TITLE
update(JS): web/javascript/reference/global_objects/string/length

### DIFF
--- a/files/uk/web/javascript/reference/global_objects/string/length/index.md
+++ b/files/uk/web/javascript/reference/global_objects/string/length/index.md
@@ -41,7 +41,7 @@ const str = new TextDecoder().decode(buffer); // Цей рядок має роз
 
 Статична властивість `String.length` не має жодного відношення до довжин рядків. Це [арність](/uk/docs/Web/JavaScript/Reference/Global_Objects/Function/length) функції `String` (в широкому розумінні — число формальних аргументів функції), яка дорівнює 1.
 
-Оскільки довжина `length` рахує кодові одиниці, а не символи, то якщо необхідно отримати саме кількість символів, можна спершу розбити рядок за допомогою його [ітератора](/uk/docs/Web/JavaScript/Reference/Global_Objects/String/@@iterator), що працює за символами:
+Оскільки довжина `length` рахує кодові одиниці, а не символи, то якщо необхідно отримати саме кількість символів, можна спершу розбити рядок за допомогою його [ітератора](/uk/docs/Web/JavaScript/Reference/Global_Objects/String/Symbol.iterator), що працює за символами:
 
 ```js
 function getCharacterLength(str) {


### PR DESCRIPTION
Оригінальний вміст: ["String: length"@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Global_Objects/String/length), [сирці "String: length"@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/global_objects/string/length/index.md)

Нові зміни:
- [Remove all `@@notation` from page slugs (#34824)](https://github.com/mdn/content/commit/6fbdb78c1362fae31fbd545f4b2d9c51987a6bca)