### PR TITLE
update(Glossary): glossary/deep_copy

### DIFF
--- a/files/uk/glossary/deep_copy/index.md
+++ b/files/uk/glossary/deep_copy/index.md
@@ -52,5 +52,6 @@ API Вебу [`structuredClone()`](/uk/docs/Web/API/structuredClone) також 
 
 ## Дивіться також
 
-- {{glossary("Shallow copy", "Поверхневе копіювання")}}
+- Споріднені терміни глосарія:
+  - {{glossary("Shallow copy", "Поверхневе копіювання")}}
 - [`window.structuredClone()`](/uk/docs/Web/API/structuredClone)


### PR DESCRIPTION
Оригінальний вміст: [Глибоке копіювання@MDN](https://developer.mozilla.org/en-us/docs/Glossary/Deep_copy), [сирці Глибоке копіювання@GitHub](https://github.com/mdn/content/blob/main/files/en-us/glossary/deep_copy/index.md)

Нові зміни:
- [improvements on glossary links in see-also (#34454)](https://github.com/mdn/content/commit/50e5e8a9b8a6b7d0dd9877610c9639d8b90f329f)