### PR TITLE
update(Glossary): glossary/truthy

### DIFF
--- a/files/uk/glossary/truthy/index.md
+++ b/files/uk/glossary/truthy/index.md
@@ -42,7 +42,8 @@ true && "пес"
 
 ## Дивіться також
 
-- {{Glossary("Falsy", "Хибні значення"}}
-- {{Glossary("Type_Coercion", "Зведення типів")}}
-- {{Glossary("Boolean", "Булеве значення")}}
+- Споріднені терміни глосарія:
+  - {{Glossary("Falsy", "Хибні значення")}}
+  - {{Glossary("Type_Coercion", "Зведення типів")}}
+  - {{Glossary("Boolean", "Булеве значення")}}
 - [Зведення до булевого](/uk/docs/Web/JavaScript/Reference/Global_Objects/Boolean#zvedennia-do-bulevoho)


### PR DESCRIPTION
Оригінальний вміст: [Істинні значення@MDN](https://developer.mozilla.org/en-us/docs/Glossary/Truthy), [сирці Істинні значення@GitHub](https://github.com/mdn/content/blob/main/files/en-us/glossary/truthy/index.md)

Нові зміни:
- [improvements on glossary links in see-also (#34454)](https://github.com/mdn/content/commit/50e5e8a9b8a6b7d0dd9877610c9639d8b90f329f)