### PR TITLE
update(Glossary): glossary/falsy

### DIFF
--- a/files/uk/glossary/falsy/index.md
+++ b/files/uk/glossary/falsy/index.md
@@ -78,7 +78,8 @@ console.log(0 && "пес");
 
 ## Дивіться також
 
-- {{Glossary("Truthy", "Істинні значення")}}
-- {{Glossary("Type_coercion", "Зведення типів")}}
-- {{Glossary("Boolean", "Булеве значення")}}
+- Споріднені терміни глосарія:
+  - {{Glossary("Truthy", "Істинні значення")}}
+  - {{Glossary("Type_coercion", "Зведення типів")}}
+  - {{Glossary("Boolean", "Булеве значення")}}
 - [Зведення до булевого](/uk/docs/Web/JavaScript/Reference/Global_Objects/Boolean#zvedennia-do-bulevoho)


### PR DESCRIPTION
Оригінальний вміст: [Хибні значення@MDN](https://developer.mozilla.org/en-us/docs/Glossary/Falsy), [сирці Хибні значення@GitHub](https://github.com/mdn/content/blob/main/files/en-us/glossary/falsy/index.md)

Нові зміни:
- [improvements on glossary links in see-also (#34454)](https://github.com/mdn/content/commit/50e5e8a9b8a6b7d0dd9877610c9639d8b90f329f)