### PR TITLE
update(SVG): web/svg/attribute

### DIFF
--- a/files/uk/web/svg/attribute/index.md
+++ b/files/uk/web/svg/attribute/index.md
@@ -49,7 +49,6 @@ page-type: landing-page
 - {{SVGAttr("color")}}
 - {{SVGAttr("color-interpolation")}}
 - {{SVGAttr("color-interpolation-filters")}}
-- {{SVGAttr("color-profile")}}
 - {{SVGAttr("color-rendering")}}
 - {{SVGAttr("crossorigin")}}
 - {{SVGAttr("cursor")}}
@@ -74,7 +73,6 @@ page-type: landing-page
 
 - {{SVGAttr("edgeMode")}}
 - {{SVGAttr("elevation")}}
-- {{SVGAttr("enable-background")}}
 - {{SVGAttr("end")}}
 - {{SVGAttr("exponent")}}
 
@@ -138,7 +136,6 @@ page-type: landing-page
 - {{SVGAttr("k4")}}
 - {{SVGAttr("kernelMatrix")}}
 - {{SVGAttr("kernelUnitLength")}}
-- {{SVGAttr("kerning")}}
 - {{SVGAttr("keyPoints")}}
 - {{SVGAttr("keySplines")}}
 - {{SVGAttr("keyTimes")}}
@@ -322,7 +319,6 @@ page-type: landing-page
 - {{SVGAttr("xlink:show")}}
 - {{SVGAttr("xlink:title")}}
 - {{SVGAttr("xlink:type")}}
-- {{SVGAttr("xml:base")}}
 - {{SVGAttr("xml:lang")}}
 - {{SVGAttr("xml:space")}}
 
@@ -349,7 +345,6 @@ page-type: landing-page
   - {{SVGAttr("style")}}
   - {{SVGAttr("lang")}}
   - {{SVGAttr("tabindex")}}
-  - {{SVGAttr("xml:base")}}
   - {{SVGAttr("xml:lang")}}
   - {{SVGAttr("xml:space")}}
 
@@ -380,14 +375,12 @@ page-type: landing-page
 - {{SVGAttr("color")}}
 - {{SVGAttr("color-interpolation")}}
 - {{SVGAttr("color-interpolation-filters")}}
-- {{SVGAttr("color-profile")}}
 - {{SVGAttr("color-rendering")}}
 - {{SVGAttr("cursor")}}
 - {{SVGAttr("d")}}
 - {{SVGAttr("direction")}}
 - {{SVGAttr("display")}}
 - {{SVGAttr("dominant-baseline")}}
-- {{SVGAttr("enable-background")}}
 - {{SVGAttr("fill")}}
 - {{SVGAttr("fill-opacity")}}
 - {{SVGAttr("fill-rule")}}
@@ -404,7 +397,6 @@ page-type: landing-page
 - {{SVGAttr("glyph-orientation-horizontal")}}
 - {{SVGAttr("glyph-orientation-vertical")}}
 - {{SVGAttr("image-rendering")}}
-- {{SVGAttr("kerning")}}
 - {{SVGAttr("letter-spacing")}}
 - {{SVGAttr("lighting-color")}}
 - {{SVGAttr("marker-end")}}


### PR DESCRIPTION
Оригінальний вміст: [Довідка атрибутів SVG@MDN](https://developer.mozilla.org/en-us/docs/Web/SVG/Attribute), [сирці Довідка атрибутів SVG@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/svg/attribute/index.md)

Нові зміни:
- [Remove SVG xml:base attribute (#34485)](https://github.com/mdn/content/commit/41fa3b54a9095a1c68bd8a3f7982404a65b74d27)
- [Remove SVG color-profile attribute (#34482)](https://github.com/mdn/content/commit/39a5620a712077c4d3828fdbafea28712393ab53)
- [Remove SVG enable-background attribute (#34483)](https://github.com/mdn/content/commit/dc0c59fb0a155a8f94a814de90d7732ee7a0bd99)
- [Remove SVG kerning attribute (#34475)](https://github.com/mdn/content/commit/29d6027a92c08ee23da65755a190e1b7944fa0e8)