### PR TITLE
update(JS): web/javascript/reference/global_objects/object/constructor

### DIFF
--- a/files/uk/web/javascript/reference/global_objects/object/constructor/index.md
+++ b/files/uk/web/javascript/reference/global_objects/object/constructor/index.md
@@ -136,7 +136,7 @@ Child.prototype = Object.create(Parent.prototype);
 
 Значенням `constructor` примірників `Child` буде `Parent`, оскільки `Child.prototype` присвоєно нове значення.
 
-Зазвичай це не є великою проблемою: мова майже ніколи не читає властивість `constructor` об'єкта. Єдиним винятком є використання [`@@species`](/uk/docs/Web/JavaScript/Reference/Global_Objects/Symbol/species) для створення нових екземплярів класу, але такі випадки рідкісні, та й усе одно слід використовувати запис [`extends`](/uk/docs/Web/JavaScript/Reference/Classes/extends) для підкласів вбудованих класів.
+Зазвичай це не є великою проблемою: мова майже ніколи не читає властивість `constructor` об'єкта. Єдиним винятком є використання [`[Symbol.species]`](/uk/docs/Web/JavaScript/Reference/Global_Objects/Symbol/species) для створення нових екземплярів класу, але такі випадки рідкісні, та й усе одно слід використовувати запис [`extends`](/uk/docs/Web/JavaScript/Reference/Classes/extends) для підкласів вбудованих класів.
 
 Проте слідкувати, що `Child.prototype.constructor` завжди посилається на сам `Child`, важливо, коли якийсь викликач використовує `constructor` для доступу до початкового класу з екземпляра. Розгляньте наступний випадок: об'єкт має метод `create()`, щоб створювати себе.
 


### PR DESCRIPTION
Оригінальний вміст: [Object.prototype.constructor@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Global_Objects/Object/constructor), [сирці Object.prototype.constructor@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/global_objects/object/constructor/index.md)

Нові зміни:
- [Remove all @@notation in JS prose (#34817)](https://github.com/mdn/content/commit/6e93ec8fc9e1f3bd83bf2f77e84e1a39637734f8)