### PR TITLE
update(JS): web/javascript/reference/operators/new

### DIFF
--- a/files/uk/web/javascript/reference/operators/new/index.md
+++ b/files/uk/web/javascript/reference/operators/new/index.md
@@ -24,7 +24,7 @@ new constructor(arg1, arg2, /* …, */ argN)
 ### Параметри
 
 - `constructor`
-  - : Клас чи функція, що задає тип примірника об'єкта. Цей вираз може бути чим завгодно, що має достатній [пріоритет](/uk/docs/Web/JavaScript/Reference/Operators/Operator_precedence#tablytsia), в тому числі ідентифікатором, [звертанням до властивості](/uk/docs/Web/JavaScript/Reference/Operators/Property_accessors) чи ще одним виразом `new`, проте [необов'язкові ланцюжки](/uk/docs/Web/JavaScript/Reference/Operators/Optional_chaining) тут заборонені.
+  - : Клас чи функція, що задає тип примірника об'єкта. Цей вираз може бути чим завгодно, що має достатній [пріоритет](/uk/docs/Web/JavaScript/Reference/Operators/Operator_precedence#tablytsia), включно з ідентифікатором, [звертанням до властивості](/uk/docs/Web/JavaScript/Reference/Operators/Property_accessors) чи ще одним виразом `new`, проте [необов'язкові ланцюжки](/uk/docs/Web/JavaScript/Reference/Operators/Optional_chaining) тут заборонені.
 - `arg1`, `arg2`, …, `argN`
   - : Список значень, з якими буде викликаний `constructor`. Запис `new Foo` – рівносильний `new Foo()`, тобто якщо список аргументів не заданий, то `Foo` викликається без аргументів.
 

--- a/files/uk/web/javascript/reference/operators/new/index.md
+++ b/files/uk/web/javascript/reference/operators/new/index.md
@@ -24,7 +24,7 @@ new constructor(arg1, arg2, /* …, */ argN)
 ### Параметри
 
 - `constructor`
-  - : Клас чи функція, що задає тип примірника об'єкта.
+  - : Клас чи функція, що задає тип примірника об'єкта. Цей вираз може бути чим завгодно, що має достатній [пріоритет](/uk/docs/Web/JavaScript/Reference/Operators/Operator_precedence#tablytsia), в тому числі ідентифікатором, [звертанням до властивості](/uk/docs/Web/JavaScript/Reference/Operators/Property_accessors) чи ще одним виразом `new`, проте [необов'язкові ланцюжки](/uk/docs/Web/JavaScript/Reference/Operators/Optional_chaining) тут заборонені.
 - `arg1`, `arg2`, …, `argN`
   - : Список значень, з якими буде викликаний `constructor`. Запис `new Foo` – рівносильний `new Foo()`, тобто якщо список аргументів не заданий, то `Foo` викликається без аргументів.
 


### PR DESCRIPTION
Оригінальний вміст: [new@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Operators/new), [сирці new@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/operators/new/index.md)

Нові зміни:
- [Add reference for two optional chain SyntaxErrors (#34676)](https://github.com/mdn/content/commit/7ca1d16101f5f4a1adf7293f2ad295ca337c59b2)