### PR TITLE
update(JS): web/javascript/reference/global_objects/arraybuffer

### DIFF
--- a/files/uk/web/javascript/reference/global_objects/arraybuffer/index.md
+++ b/files/uk/web/javascript/reference/global_objects/arraybuffer/index.md
@@ -41,7 +41,7 @@ browser-compat: javascript.builtins.ArrayBuffer
 
 ## Статичні властивості
 
-- {{jsxref("ArrayBuffer/@@species", "ArrayBuffer[@@species]")}}
+- {{jsxref("ArrayBuffer/Symbol.species", "ArrayBuffer[Symbol.species]")}}
   - : Функція-конструктор, що використовується для створення похідних об'єктів.
 
 ## Статичні методи
@@ -63,8 +63,8 @@ browser-compat: javascript.builtins.ArrayBuffer
   - : Доступна лише для зчитування максимальна довжина, в байтах, до якої може бути змінений розмір `ArrayBuffer`. Це значення задається, коли цей масив конструюється, і не може бути змінене.
 - {{jsxref("ArrayBuffer.prototype.resizable")}}
   - : Лише для зчитування. Повертає `true`, якщо розмір цього `ArrayBuffer` може бути змінений, або `false` – якщо ні.
-- `ArrayBuffer.prototype[@@toStringTag]`
-  - : Початковим значенням властивості [`@@toStringTag`](/uk/docs/Web/JavaScript/Reference/Global_Objects/Symbol/toStringTag) є рядок `"ArrayBuffer"`. Ця властивість використовується в {{jsxref("Object.prototype.toString()")}}.
+- `ArrayBuffer.prototype[Symbol.toStringTag]`
+  - : Початковим значенням властивості [`[Symbol.toStringTag]`](/uk/docs/Web/JavaScript/Reference/Global_Objects/Symbol/toStringTag) є рядок `"ArrayBuffer"`. Ця властивість використовується в {{jsxref("Object.prototype.toString()")}}.
 
 ## Методи примірників
 


### PR DESCRIPTION
Оригінальний вміст: [ArrayBuffer@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer), [сирці ArrayBuffer@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/global_objects/arraybuffer/index.md)

Нові зміни:
- [Remove all `@@notation` from page slugs (#34824)](https://github.com/mdn/content/commit/6fbdb78c1362fae31fbd545f4b2d9c51987a6bca)
- [Remove all @@notation in JS prose (#34817)](https://github.com/mdn/content/commit/6e93ec8fc9e1f3bd83bf2f77e84e1a39637734f8)