### PR TITLE
update(JS): web/javascript/reference/global_objects/bigint

### DIFF
--- a/files/uk/web/javascript/reference/global_objects/bigint/index.md
+++ b/files/uk/web/javascript/reference/global_objects/bigint/index.md
@@ -237,7 +237,7 @@ console.log(parsed);
 - Рядки перетворюються шляхом розбору їх так, ніби вони містять цілочисловий літерал. Будь-яка невдача розбору призводить до {{jsxref("SyntaxError")}}. Синтаксис є підмножиною [рядкових літералів чисел](/uk/docs/Web/JavaScript/Reference/Global_Objects/Number#zvedennia-do-chysla), у якій десятковий розділювач і експоненційний запис – заборонені.
 - [Number](/uk/docs/Web/JavaScript/Reference/Global_Objects/Number) викидають {{jsxref("TypeError")}} для запобігання небажаному неявному зведенню, що призвело б до втрати точності.
 - [Symbol](/uk/docs/Web/JavaScript/Reference/Global_Objects/Symbol) викидають {{jsxref("TypeError")}}.
-- Об'єкти спочатку [перетворюються на примітиви](/uk/docs/Web/JavaScript/Data_structures#zvedennia-do-prymityva) шляхом виклику їх методів [`[@@toPrimitive]()`](/uk/docs/Web/JavaScript/Reference/Global_Objects/Symbol/toPrimitive) (з підказкою `"number"`), `valueOf()` і `toString()` – у такому порядку. Потім результівний примітив перетворюється на BigInt.
+- Об'єкти спочатку [перетворюються на примітиви](/uk/docs/Web/JavaScript/Data_structures#zvedennia-do-prymityva) шляхом виклику їх методів [`[Symbol.toPrimitive]()`](/uk/docs/Web/JavaScript/Reference/Global_Objects/Symbol/toPrimitive) (з підказкою `"number"`), `valueOf()` і `toString()` – у такому порядку. Потім результівний примітив перетворюється на BigInt.
 
 Найкращий спосіб досягнути в JavaScript майже такого ж ефекту – функція [`BigInt()`](/uk/docs/Web/JavaScript/Reference/Global_Objects/BigInt/BigInt): `BigInt(x)` використовує такий же алгоритм для перетворення `x`, окрім того, що [Number](/uk/docs/Web/JavaScript/Reference/Global_Objects/Number) не викидають {{jsxref("TypeError")}}, а перетворюються на BigInt, якщо є цілими числами.
 
@@ -246,7 +246,7 @@ console.log(parsed);
 ## Конструктор
 
 - {{jsxref("BigInt/BigInt", "BigInt()")}}
-  - : Створює нове значення BigInt.
+  - : Повертає примітивні значення типу BigInt. Викидає помилку, коли викликати його з `new`.
 
 ## Статичні методи
 
@@ -261,8 +261,8 @@ console.log(parsed);
 
 - {{jsxref("Object/constructor", "BigInt.prototype.constructor")}}
   - : Функція-конструктор, що створила об'єкт-примірник. Для примірників `BigInt` початкове значення – конструктор {{jsxref("BigInt/BigInt", "BigInt")}}.
-- `BigInt.prototype[@@toStringTag]`
-  - : Початкове значення [`@@toStringTag`](/uk/docs/Web/JavaScript/Reference/Global_Objects/Symbol/toStringTag) – рядок `"BigInt"`. Ця властивість використовується в {{jsxref("Object.prototype.toString()")}}. Проте у зв'язку з тим, що `BigInt` також має власну реалізацію метода [`toString()`](/uk/docs/Web/JavaScript/Reference/Global_Objects/BigInt/toString), ця властивість не використовується, якщо не викликати [`Object.prototype.toString.call()`](/uk/docs/Web/JavaScript/Reference/Global_Objects/Function/call) зі значенням BigInt як `thisArg`.
+- `BigInt.prototype[Symbol.toStringTag]`
+  - : Початкове значення [`[Symbol.toStringTag]`](/uk/docs/Web/JavaScript/Reference/Global_Objects/Symbol/toStringTag) – рядок `"BigInt"`. Ця властивість використовується в {{jsxref("Object.prototype.toString()")}}. Проте у зв'язку з тим, що `BigInt` також має власну реалізацію метода [`toString()`](/uk/docs/Web/JavaScript/Reference/Global_Objects/BigInt/toString), ця властивість не використовується, якщо не викликати [`Object.prototype.toString.call()`](/uk/docs/Web/JavaScript/Reference/Global_Objects/Function/call) зі значенням BigInt як `thisArg`.
 
 ## Методи примірника
 


### PR DESCRIPTION
Оригінальний вміст: [BigInt@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Global_Objects/BigInt), [сирці BigInt@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/global_objects/bigint/index.md)

Нові зміни:
- [Remove all @@notation in JS prose (#34817)](https://github.com/mdn/content/commit/6e93ec8fc9e1f3bd83bf2f77e84e1a39637734f8)
- [Be precise about what primitive ctors return on landing pages (#34107)](https://github.com/mdn/content/commit/9f65c82c3a80e6ab303f7a36bacd2385fd0d019b)