### PR TITLE
update(JS): web/javascript/reference/global_objects/symbol

### DIFF
--- a/files/uk/web/javascript/reference/global_objects/symbol/index.md
+++ b/files/uk/web/javascript/reference/global_objects/symbol/index.md
@@ -66,7 +66,7 @@ Symbol.keyFor(Symbol.for("tokenString")) === "tokenString"; // true
 
 До появи загальновідомих символів JavaScript, для реалізації певних вбудованих операцій, використовував звичайні властивості. Наприклад, функція [`JSON.stringify`](/uk/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify) намагається викликати на кожному об'єкті метод `toJSON()`, а функція [`String`](/uk/docs/Web/JavaScript/Reference/Global_Objects/String/String) викликає на об'єкті методи `toString()` і `valueOf()`. Проте, із доданням до мови більшої кількості операцій, виділення кожній з них "магічної властивості" могло зламати зворотну сумісність й ускладнити роботу з логікою мови. Загальновідомі символи дають кастомізаціям змогу бути "невидимими" для звичайного коду, котрий зазвичай зчитує лише рядкові властивості.
 
-На MDN та інших джерелах загальновідомі символьні значення стилізовані за допомогою префікса `@@`. Наприклад, {{jsxref("Symbol.hasInstance")}} записується як `@@hasInstance`. Це тому, що символи не мають фактичних літеральних форматів, а використання `Symbol.hasInstance` не відображає можливість використання інших псевдонімів для посилання на той самий символ. Це схоже на різницю між `Function.name` та `"Function"`.
+> **Примітка:** Раніше специфікація користувалася для позначення загальновідомих символів записом `@@<symbol-name>`. Наприклад, {{jsxref("Symbol.hasInstance")}} записувався як `@@hasInstance`, а метод `Array.prototype[Symbol.iterator]()` називався `Array.prototype[@@iterator]()`. Цей запис більше не вживається у специфікації, але його досі можна зустріти в старій документації й обговореннях.
 
 Загальновідомі символи не мають концепції збирання збирачем сміття, тому що вони входять до фіксованого набору і є унікальними протягом усього життя програми, подібно до вбудованих об'єктів, як то `Array.prototype`, тож вони також дозволені в об'єктах {{jsxref("WeakMap")}}, {{jsxref("WeakSet")}}, {{jsxref("WeakRef")}} і {{jsxref("FinalizationRegistry")}}.
 
@@ -125,8 +125,8 @@ Symbol.keyFor(Symbol.for("tokenString")) === "tokenString"; // true
   - : Функція-конструктор, що створила об'єкт-примірник. Для примірників `Symbol` початковим значенням є конструктор {{jsxref("Symbol/Symbol", "Symbol")}}.
 - {{jsxref("Symbol.prototype.description")}}
   - : Рядок лише для зчитування, що містить опис символу.
-- `Symbol.prototype[@@toStringTag]`
-  - : Початкове значення властивості [`@@toStringTag`](/uk/docs/Web/JavaScript/Reference/Global_Objects/Symbol/toStringTag) – рядок `"Symbol"`. Ця властивість використовується в методі {{jsxref("Object.prototype.toString()")}}. Проте через те, що `Symbol` має власний метод [`toString()`](/uk/docs/Web/JavaScript/Reference/Global_Objects/Symbol/toString), то ця властивість не використовується, якщо не викликати [`Object.prototype.toString.call()`](/uk/docs/Web/JavaScript/Reference/Global_Objects/Function/call) з символьним значенням як `thisArg`.
+- `Symbol.prototype[Symbol.toStringTag]`
+  - : Початкове значення властивості [`[Symbol.toStringTag]`](/uk/docs/Web/JavaScript/Reference/Global_Objects/Symbol/toStringTag) – рядок `"Symbol"`. Ця властивість використовується в методі {{jsxref("Object.prototype.toString()")}}. Проте через те, що `Symbol` має власний метод [`toString()`](/uk/docs/Web/JavaScript/Reference/Global_Objects/Symbol/toString), то ця властивість не використовується, якщо не викликати [`Object.prototype.toString.call()`](/uk/docs/Web/JavaScript/Reference/Global_Objects/Function/call) з символьним значенням як `thisArg`.
 
 ## Методи примірника
 
@@ -134,7 +134,7 @@ Symbol.keyFor(Symbol.for("tokenString")) === "tokenString"; // true
   - : Повертає рядок, що містить опис символу. Заміщає метод {{jsxref("Object.prototype.toString()")}}.
 - {{jsxref("Symbol.prototype.valueOf()")}}
   - : Повертає той же символ. Заміщає метод {{jsxref("Object.prototype.valueOf()")}}.
-- [`Symbol.prototype[@@toPrimitive]()`](/uk/docs/Web/JavaScript/Reference/Global_Objects/Symbol/@@toPrimitive)
+- [`Symbol.prototype[Symbol.toPrimitive]()`](/uk/docs/Web/JavaScript/Reference/Global_Objects/Symbol/Symbol.toPrimitive)
   - : Повертає той же символ.
 
 ## Приклади


### PR DESCRIPTION
Оригінальний вміст: [Symbol@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Global_Objects/Symbol), [сирці Symbol@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/global_objects/symbol/index.md)

Нові зміни:
- [Remove all `@@notation` from page slugs (#34824)](https://github.com/mdn/content/commit/6fbdb78c1362fae31fbd545f4b2d9c51987a6bca)
- [Remove all @@notation in JS prose (#34817)](https://github.com/mdn/content/commit/6e93ec8fc9e1f3bd83bf2f77e84e1a39637734f8)