### PR TITLE
update(CSS): web/css/containing_block

### DIFF
--- a/files/uk/web/css/containing_block/index.md
+++ b/files/uk/web/css/containing_block/index.md
@@ -263,6 +263,6 @@ p {
 - [Блоковий контекст форматування](/uk/docs/Web/CSS/CSS_display/Block_formatting_context)
 - [Контекст нагромадження](/uk/docs/Web/CSS/CSS_positioned_layout/Understanding_z-index/Stacking_context)
 - [Перекриття зовнішніх полів](/uk/docs/Web/CSS/CSS_box_model/Mastering_margin_collapsing)
-- [Початкові](/uk/docs/Web/CSS/initial_value), [обраховані](/uk/docs/Web/CSS/computed_value), [вжиті](/uk/docs/Web/CSS/used_value) та [фактичні](/uk/docs/Web/CSS/actual_value) значення
+- [Початкові](/uk/docs/Web/CSS/initial_value), [обчислені](/uk/docs/Web/CSS/computed_value), [вжиті](/uk/docs/Web/CSS/used_value) та [фактичні](/uk/docs/Web/CSS/actual_value) значення
 - [Заміщені елементи](/uk/docs/Web/CSS/Replaced_element)
 - {{glossary("Intrinsic size", "Природний розмір")}}

--- a/files/uk/web/css/containing_block/index.md
+++ b/files/uk/web/css/containing_block/index.md
@@ -250,22 +250,19 @@ p {
 
 ## Дивіться також
 
-- Властивість {{cssxref("all")}} відкидає усі оголошення CSS до заданого відомого стану
-- Ключові концепції CSS:
-  - [Синтаксис CSS](/uk/docs/Web/CSS/Syntax)
-  - [Директиви](/uk/docs/Web/CSS/At-rule)
-  - [Коментарі](/uk/docs/Web/CSS/Comments)
-  - [Специфічність](/uk/docs/Web/CSS/Specificity)
-  - [Успадкування](/uk/docs/Web/CSS/Inheritance)
-  - [Рамкова модель](/uk/docs/Web/CSS/CSS_box_model/Introduction_to_the_CSS_box_model)
-  - [Режими компонування](/uk/docs/Web/CSS/Layout_mode)
-  - [Моделі візуального форматування](/uk/docs/Web/CSS/Visual_formatting_model)
-  - [Перекриття зовнішніх відступів](/uk/docs/Web/CSS/CSS_box_model/Mastering_margin_collapsing)
-  - Значення
-    - [Початкові значення](/uk/docs/Web/CSS/initial_value)
-    - [Обчислені значення](/uk/docs/Web/CSS/computed_value)
-    - [Застосовані значення](/uk/docs/Web/CSS/used_value)
-    - [Фактичні значення](/uk/docs/Web/CSS/actual_value)
-  - [Синтаксис визначення значень](/uk/docs/Web/CSS/Value_definition_syntax)
-  - [Властивості-скорочення](/uk/docs/Web/CSS/Shorthand_properties)
-  - [Заміщені елементи](/uk/docs/Web/CSS/Replaced_element)
+- Властивість {{cssxref("all")}}
+- Властивість {{cssxref("contain")}}
+- Властивість {{cssxref("aspect-ratio")}}
+- Властивість {{cssxref("box-sizing")}}
+- Значення розміру {{cssxref("min-content")}} і {{cssxref("max-content")}}
+- [Цеглинка – Розміри елементів у CSS](/uk/docs/Learn/CSS/Building_blocks/Sizing_items_in_CSS)
+- [Рамкова модель](/uk/docs/Web/CSS/CSS_box_model/Introduction_to_the_CSS_box_model)
+- Модуль [Рамкової моделі CSS](/uk/docs/Web/CSS/CSS_box_model) module
+- [Режими компонування](/uk/docs/Web/CSS/Layout_mode)
+- [Моделі візуального форматування](/uk/docs/Web/CSS/Visual_formatting_model)
+- [Блоковий контекст форматування](/uk/docs/Web/CSS/CSS_display/Block_formatting_context)
+- [Контекст нагромадження](/uk/docs/Web/CSS/CSS_positioned_layout/Understanding_z-index/Stacking_context)
+- [Перекриття зовнішніх полів](/uk/docs/Web/CSS/CSS_box_model/Mastering_margin_collapsing)
+- [Початкові](/uk/docs/Web/CSS/initial_value), [обраховані](/uk/docs/Web/CSS/computed_value), [вжиті](/uk/docs/Web/CSS/used_value) та [фактичні](/uk/docs/Web/CSS/actual_value) значення
+- [Заміщені елементи](/uk/docs/Web/CSS/Replaced_element)
+- {{glossary("Intrinsic size", "Природний розмір")}}


### PR DESCRIPTION
Оригінальний вміст: [Компонування та контейнерний блок@MDN](https://developer.mozilla.org/en-us/docs/Web/CSS/Containing_block), [сирці Компонування та контейнерний блок@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/css/containing_block/index.md)

Нові зміни:
- [CSS maintenance: more relevant see also links (#34847)](https://github.com/mdn/content/commit/ce07a52c8ffd27f402b0490aca5626caa623923f)