### PR TITLE
update(CSS): web/css/border

### DIFF
--- a/files/uk/web/css/border/index.md
+++ b/files/uk/web/css/border/index.md
@@ -15,9 +15,9 @@ browser-compat: css.properties.border
 
 Ця властивість є скороченим записом наступних властивостей CSS:
 
-- [`border-color`](/uk/docs/Web/CSS/border-color) (колір меж)
-- [`border-style`](/uk/docs/Web/CSS/border-style) (стиль меж)
 - [`border-width`](/uk/docs/Web/CSS/border-width) (ширина меж)
+- [`border-style`](/uk/docs/Web/CSS/border-style) (стиль меж)
+- [`border-color`](/uk/docs/Web/CSS/border-color) (колір меж)
 
 ## Синтаксис
 
@@ -44,7 +44,8 @@ border: unset;
 
 Властивість `border` може бути вказана за допомогою одного, двох чи трьох значень, перелічених нижче. Порядок значень не важливий.
 
-> **Примітка:** Межі будуть невидимими, якщо не вказаний їх стиль. Так виходить, тому що усталений стиль – `none`.
+> [!NOTE]
+> Межі будуть невидимими, якщо не вказаний їх стиль. Так виходить, тому що усталений стиль – `none`.
 
 ### Значення
 


### PR DESCRIPTION
Оригінальний вміст: [border@MDN](https://developer.mozilla.org/en-us/docs/Web/CSS/border), [сирці border@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/css/border/index.md)

Нові зміни:
- [chore: convert noteblocks for `/web/css` (part 2) (#35148)](https://github.com/mdn/content/commit/4e508e2f543c0d77c9c04f406ebc8e9db7e965be)
- [fix(css): enforce canonical order on border and outline pages (#34995)](https://github.com/mdn/content/commit/aa714bb37625b21b0f40db1f1ea557e773456fa2)