### PR TITLE
update(JS): web/javascript/reference/global_objects/intl/numberformat

### DIFF
--- a/files/uk/web/javascript/reference/global_objects/intl/numberformat/index.md
+++ b/files/uk/web/javascript/reference/global_objects/intl/numberformat/index.md
@@ -33,9 +33,9 @@ browser-compat: javascript.builtins.Intl.NumberFormat
 ## Методи примірника
 
 - {{jsxref("Intl/NumberFormat/format", "Intl.NumberFormat.prototype.format()")}}
-  - : Функція-гетер, котра форматує число згідно з локаллю та опціями форматування цього об'єкта {{jsxref("Intl.NumberFormat")}}.
+  - : Функція-гетер, котра форматує число згідно з локаллю та опціями форматування цього об'єкта `Intl.NumberFormat`.
 - {{jsxref("Intl/NumberFormat/formatRange", "Intl.NumberFormat.prototype.formatRange()")}}
-  - : Функція-гетер, котра форматує діапазон чисел згідно з локаллю та опціями форматування об'єкта {{jsxref("Intl.NumberFormat")}}, з якого цей метод викликано.
+  - : Функція-гетер, котра форматує діапазон чисел згідно з локаллю та опціями форматування об'єкта `Intl.NumberFormat`, з якого цей метод викликано.
 - {{jsxref("Intl/NumberFormat/formatRangeToParts", "Intl.NumberFormat.prototype.formatRangeToParts()")}}
   - : Повертає {{jsxref("Array")}} з об'єктів, що представляють діапазон числових рядків у вигляді частин, що можуть бути використані для виконання власного форматування з урахуванням локалі.
 - {{jsxref("Intl/NumberFormat/formatToParts", "Intl.NumberFormat.prototype.formatToParts()")}}


### PR DESCRIPTION
Оригінальний вміст: [Intl.NumberFormat@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat), [сирці Intl.NumberFormat@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/global_objects/intl/numberformat/index.md)

Нові зміни:
- [Remove all self-links in JS docs (#35033)](https://github.com/mdn/content/commit/4436acdeb5087c7fc5afc58fc8b475e30481c801)