### PR TITLE
update(CSS): web/css/width

### DIFF
--- a/files/uk/web/css/width/index.md
+++ b/files/uk/web/css/width/index.md
@@ -60,12 +60,12 @@ width: unset;
 - `fit-content({{cssxref("&lt;length-percentage&gt;")}})`
   - : Використовує формулу fit-content щодо доступного простору, заміненого вказаним аргументом, тобто `min(max-content, max(min-content, <length-percentage>))`.
 
-## Занепокоєння щодо доступності
+## Доступність
 
 Слід пересвідчитись, що елементи, для котрих вказана `width`, не обрізаються і не затуляються іншим вмістом, коли до сторінки застосовується збільшення для укрупнення тексту.
 
 - [MDN Розуміння WCAG, Пояснення Настанов 1.4](/uk/docs/Web/Accessibility/Understanding_WCAG/Perceivable#nastanovy-1.4-polehshennia-perehliadu-ta-proslukhovuvannia-dlia-korystuvachiv-vkliuchno-iz-viddilenniam-perednioho-planu-vid-tla)
-- [Розуміння мірила успіху 1.4.4 | W3C Розуміння WCAG 2.0 (англ.)](https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-scale.html)
+- [Розуміння мірила успіху 1.4.4 | W3C Розуміння WCAG 2.0](https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-scale.html)
 
 ## Формальне визначення
 


### PR DESCRIPTION
Оригінальний вміст: [width@MDN](https://developer.mozilla.org/en-us/docs/Web/CSS/width), [сирці width@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/css/width/index.md)

Нові зміни:
- [fix typos (#35209)](https://github.com/mdn/content/commit/59a92ab5609f0a021602f11843f3b00b16e67e6d)
- [Move Accessibility section above Examples for CSS pages (#34985)](https://github.com/mdn/content/commit/3928d2b1004e2435e063ef4b037e06e1906d62f3)