### PR TITLE
update(HTML): web/html/element/input/submit

### DIFF
--- a/files/uk/web/html/element/input/submit/index.md
+++ b/files/uk/web/html/element/input/submit/index.md
@@ -46,7 +46,7 @@ browser-compat: html.elements.input.type_submit
 Рядок, що позначає метод кодування при поданні даних форми на сервер. Є три дозволені значення:
 
 - `application/x-www-form-urlencoded`
-  - : Це усталене значення, котре надсилає дані форми як рядок після [відсоткового кодування](https://uk.wikipedia.org/wiki/%D0%92%D1%96%D0%B4%D1%81%D0%BE%D1%82%D0%BA%D0%BE%D0%B2%D0%B5_%D0%BA%D0%BE%D0%B4%D1%83%D0%B2%D0%B0%D0%BD%D0%BD%D1%8F) тексту за допомогою алгоритму штибу {{jsxref("encodeURI", "encodeURI()")}}.
+  - : Це усталене значення, котре надсилає дані форми як рядок після {{Glossary("Percent-encoding", "відсоткового кодування")}} тексту за допомогою алгоритму штибу {{jsxref("encodeURI", "encodeURI()")}}.
 - `multipart/form-data`
   - : Використовує для керування даними API {{domxref("FormData")}}, даючи змогу подавати на сервер файли. Цей тип кодування _повинен_ використовуватися, якщо форма містить елементи {{HTMLElement("input")}} з [`type`](/uk/docs/Web/HTML/Element/input#type-typ) `file` ([`<input type="file">`](/uk/docs/Web/HTML/Element/input/file)).
 - `text/plain`
@@ -158,7 +158,8 @@ browser-compat: html.elements.input.type_submit
 
 На ходу вмикати та вимикати кнопки можна шляхом присвоєння `disabled` зі значенням `true` або `false`; у JavaScript це має вигляд `btn.disabled = true` або `btn.disabled = false`.
 
-> **Примітка:** Більше ідей щодо вмикання та вимикання кнопок дивіться на сторінці [`<input type="button">`](/uk/docs/Web/HTML/Element/input/button#vymknennia-ta-vmykannia-knopky).
+> [!NOTE]
+> Більше ідей щодо вмикання та вимикання кнопок дивіться на сторінці [`<input type="button">`](/uk/docs/Web/HTML/Element/input/button#vymknennia-ta-vmykannia-knopky).
 
 ## Валідація
 


### PR DESCRIPTION
Оригінальний вміст: [&lt;input type="submit"&gt;@MDN](https://developer.mozilla.org/en-us/docs/Web/HTML/Element/input/submit), [сирці &lt;input type="submit"&gt;@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/html/element/input/submit/index.md)

Нові зміни:
- [Convert noteblocks for web/html/element folder (#35085)](https://github.com/mdn/content/commit/b7955e77cd4293adf45ef23686df50b0305f02ad)
- [Use link to `Percent-encoding` in Glossary instead of Wikipedia (#34910)](https://github.com/mdn/content/commit/a2847ff3788f224ffb4cdf05cb0139e07fde7533)
- [Use officially known term "percent-encoding" instead of "URL encoding" (#34855)](https://github.com/mdn/content/commit/b4e74204332a30028aab437bcb89e3d202841676)