### PR TITLE
update(JS): web/javascript/reference/global_objects/math/pow

### DIFF
--- a/files/uk/web/javascript/reference/global_objects/math/pow/index.md
+++ b/files/uk/web/javascript/reference/global_objects/math/pow/index.md
@@ -10,7 +10,9 @@ browser-compat: javascript.builtins.Math.pow
 Статичний метод **`Math.pow()`** (степінь) повертає значення основи, піднесене до степеня. Тобто:
 
 <!-- prettier-ignore-start -->
-<math display="block"><semantics><mrow><mrow><mo lspace="0em" rspace="0.16666666666666666em">𝙼𝚊𝚝𝚑.𝚙𝚘𝚠</mo><mo stretchy="false">(</mo><mi>𝚡</mi><mo>,</mo><mi>𝚢</mi><mo stretchy="false">)</mo></mrow><mo>=</mo><msup><mi>x</mi><mi>y</mi></msup></mrow><annotation encoding="TeX">\mathtt{\operatorname{Math.pow}(x, y)} = x^y</annotation></semantics></math>
+<math display="block">
+  <semantics><mrow><mrow><mo lspace="0em" rspace="0.16666666666666666em">𝙼𝚊𝚝𝚑.𝚙𝚘𝚠</mo><mo stretchy="false">(</mo><mi>𝚡</mi><mo>,</mo><mi>𝚢</mi><mo stretchy="false">)</mo></mrow><mo>=</mo><msup><mi>x</mi><mi>y</mi></msup></mrow><annotation encoding="TeX">\mathtt{\operatorname{Math.pow}(x, y)} = x^y</annotation></semantics>
+</math>
 <!-- prettier-ignore-end -->
 
 {{EmbedInteractiveExample("pages/js/math-pow.html")}}


### PR DESCRIPTION
Оригінальний вміст: [Math.pow()@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Global_Objects/Math/pow), [сирці Math.pow()@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/global_objects/math/pow/index.md)

Нові зміни:
- [Format block MathML (#34751)](https://github.com/mdn/content/commit/761b9047d78876cbd153be811efb1aa77b419877)