### PR TITLE
update(JS): web/javascript/reference/global_objects/object/valueof

### DIFF
--- a/files/uk/web/javascript/reference/global_objects/object/valueof/index.md
+++ b/files/uk/web/javascript/reference/global_objects/object/valueof/index.md
@@ -25,13 +25,14 @@ valueOf()
 
 Значення `this` перетворене на об'єкт.
 
-> **Примітка:** Щоб `valueOf` був корисним під час перетворення типів, він мусить повертати примітив. Через те, що всі примітивні типи мають власні методи `valueOf()`, загалом `aPrimitiveValue.valueOf()` не закликає `Object.prototype.valueOf()`.
+> [!NOTE]
+> Щоб `valueOf` був корисним під час перетворення типів, він мусить повертати примітив. Через те, що всі примітивні типи мають власні методи `valueOf()`, загалом `aPrimitiveValue.valueOf()` не закликає `Object.prototype.valueOf()`.
 
 ## Опис
 
 JavaScript викликає метод `valueOf` для [перетворення об'єкта на примітивне значення](/uk/docs/Web/JavaScript/Data_structures#zvedennia-typiv). Закликати `valueOf` власноруч доводиться рідко; його автоматично закликає JavaScript, коли зустрічає об'єкт у місці, де очікується примітив.
 
-Цей метод у першу чергу викликається алгоритмами [зведення до числового значення](/uk/docs/Web/JavaScript/Data_structures#zvedennia-do-chysla) та [зведення до примітива](/uk/docs/Web/JavaScript/Data_structures#zvedennia-do-prymityva), однак [зведення до рядка](/uk/docs/Web/JavaScript/Reference/Global_Objects/String#zvedennia-do-riadka) у першу чергу викликає `toString()`, а `toString()`, із високою імовірністю, поверне рядкове значення (навіть у базовій реалізації {{jsxref("Object.prototype.toString()")}}), тож `valueOf()` у цьому випадку зазвичай не викликається.
+Цей метод у першу чергу викликається алгоритмами [зведення до числового значення](/uk/docs/Web/JavaScript/Data_structures#zvedennia-do-chyslovoho) та [зведення до примітива](/uk/docs/Web/JavaScript/Data_structures#zvedennia-do-prymityva), однак [зведення до рядка](/uk/docs/Web/JavaScript/Reference/Global_Objects/String#zvedennia-do-riadka) у першу чергу викликає `toString()`, а `toString()`, із високою імовірністю, поверне рядкове значення (навіть у базовій реалізації {{jsxref("Object.prototype.toString()")}}), тож `valueOf()` у цьому випадку зазвичай не викликається.
 
 Усі об'єкти, що успадковують від `Object.prototype` (тобто всі, крім [`null`-прототипних об'єктів](/uk/docs/Web/JavaScript/Reference/Global_Objects/Object#null-prototypni-obiekty)), успадковують метод `toString()`. Базова реалізація `Object.prototype.valueOf()` навмисно зроблена непридатною: вона повертає об'єкт, тож повернене нею значення ніколи не буде використано жодним [алгоритмом зведення до примітива](/uk/docs/Web/JavaScript/Data_structures#zvedennia-typiv). Чимало вбудованих об'єктів перевизначає цей метод, аби повертати відповідне примітивне значення. При створенні власного об'єкта можна перевизначити `valueOf()`, аби викликався власний метод, щоб такий власний об'єкт міг бути перетворений на примітивне значення. Загалом, `valueOf()` використовується для повертання значення, що є найсуттєвішим в об'єкті – на відміну від `toString()`, це не обов'язково повинен бути рядок. Інший варіант: можна додати метод [`[Symbol.toPrimitive]()`](/uk/docs/Web/JavaScript/Reference/Global_Objects/Symbol/toPrimitive), котрий дає змогу іще краще контролювати процес перетворення; такий об'єкт завжди матиме пріоритет над `valueOf` і `toString`, при будь-якому перетворенні типів.
 


### PR DESCRIPTION
Оригінальний вміст: [Object.prototype.valueOf()@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Global_Objects/Object/valueOf), [сирці Object.prototype.valueOf()@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/global_objects/object/valueof/index.md)

Нові зміни:
- [Convert noteblocks for web/javascript/reference/global_objects folder (#35091)](https://github.com/mdn/content/commit/8421c0cd94fa5aa237c833ac6d24885edbc7d721)