### PR TITLE
update(Glossary): glossary/falsy

### DIFF
--- a/files/uk/glossary/falsy/index.md
+++ b/files/uk/glossary/falsy/index.md
@@ -24,7 +24,7 @@ page-type: glossary-definition
 | `""`                        | String    | Значення порожнього [рядка](/uk/docs/Web/JavaScript/Reference/Global_Objects/String), в тому числі `''` і ` `` `.                                        |
 | {{domxref("document.all")}} | Object    | Єдиний хибний об'єкт у JavaScript – це вбудоване значення {{domxref("document.all")}}.                                                                   |
 
-Значення `null` і `undefined` також є [нульовими](/uk/docs/Glossary/Nullish).
+Значення `null` і `undefined` також є {{Glossary("nullish", "нульовими")}}.
 
 ## Приклади
 


### PR DESCRIPTION
Оригінальний вміст: [Хибні значення@MDN](https://developer.mozilla.org/en-us/docs/Glossary/Falsy), [сирці Хибні значення@GitHub](https://github.com/mdn/content/blob/main/files/en-us/glossary/falsy/index.md)

Нові зміни:
- [feat: improvements on glossary links and their labels (#35246)](https://github.com/mdn/content/commit/50e5edd07155de2eec2a8b6b2ad95820748cfec7)