### PR TITLE
update(CSS): web/css/gradient/linear-gradient

### DIFF
--- a/files/uk/web/css/gradient/linear-gradient/index.md
+++ b/files/uk/web/css/gradient/linear-gradient/index.md
@@ -64,7 +64,8 @@ linear-gradient(45deg, red 0 50%, blue 50% 100%)
 - `<color-hint>`
   - : Підказка {{glossary("interpolation", "інтерполяції")}}, котра визначає те, як градієнт просувається між зупинками кольору. Довжина визначає те, у якій точці між двома кольоровими зупинками колір градієнта повинен досягнути середньої точки переходу кольору. Якщо цього значення немає, то середнє значення кольору досягається в середній точці між двома зупинками кольору.
 
-> **Примітка:** Відображення [кольорових зупинок градієнтів CSS](#kompozytsiia-liniinykh-hradiientiv) відповідає тим само правилам, що й кольорові зупинки [градієнтів SVG](/uk/docs/Web/SVG/Tutorial/Gradients).
+> [!NOTE]
+> Відображення [кольорових зупинок градієнтів CSS](#kompozytsiia-liniinykh-hradiientiv) відповідає тим само правилам, що й кольорові зупинки [градієнтів SVG](/uk/docs/Web/SVG/Tutorial/Gradients).
 
 ## Опис
 
@@ -172,7 +173,7 @@ body {
 }
 ```
 
-{{EmbedLiveSample("interpoliatsiia-v-pryamokutnomu-kolorovomu-prostori", 120, 120)}}
+{{EmbedLiveSample("interpoliatsiia-v-priamokutnomu-kolorovomu-prostori", 120, 120)}}
 
 ### Інтерполяція з відтінком
 


### PR DESCRIPTION
Оригінальний вміст: [linear-gradient()@MDN](https://developer.mozilla.org/en-us/docs/Web/CSS/gradient/linear-gradient), [сирці linear-gradient()@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/css/gradient/linear-gradient/index.md)

Нові зміни:
- [Convert noteblocks for web/css folder (part 3) (#35159)](https://github.com/mdn/content/commit/14515827c44f3cb814261a1c6bd487ae8bfcde1b)