### PR TITLE
update(CSS): web/css/cursor

### DIFF
--- a/files/uk/web/css/cursor/index.md
+++ b/files/uk/web/css/cursor/index.md
@@ -182,7 +182,7 @@ cursor: unset;
             <img src="no-drop.gif" alt="піктограма вказівника і піктограма заборони" />
           </td>
           <td>
-            Елемент не може бути кинутим в поточному положенні.<br />[Вада Firefox 275173](https://bugzil.la/275173): На Windows та macOS <code>no-drop</code> еквівалентно <code>not-allowed</code>.
+            Елемент не може бути кинутим в поточному положенні.<br /><a href="https://bugzil.la/275173">Вада Firefox 275173</a>: На Windows та macOS <code>no-drop</code> еквівалентно <code>not-allowed</code>.
           </td>
         </tr>
         <tr style="cursor: not-allowed">
@@ -208,7 +208,7 @@ cursor: unset;
           <td><img alt="піктограма крапки середнього розміру з чотирма трикутниками навколо." src="all-scroll.gif" /></td>
           <td>
             Дещо може бути прокручено у будь-якому напрямку (панорамовано).<br />
-            [Вада Firefox 275174](https://bugzil.la/275174): На Windows <code>all-scroll</code> еквівалентно <code>move</code>.
+            <a href="https://bugzil.la/275174">Вада Firefox 275174</a>: На Windows <code>all-scroll</code> еквівалентно <code>move</code>.
           </td>
         </tr>
         <tr style="cursor: col-resize">


### PR DESCRIPTION
Оригінальний вміст: [cursor@MDN](https://developer.mozilla.org/en-us/docs/Web/CSS/cursor), [сирці cursor@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/css/cursor/index.md)

Нові зміни:
- [Fix unrendered Markdown (#35293)](https://github.com/mdn/content/commit/245715b48674c1729cb63417e4a27628e30ae28c)
- [Fix "thing lines" to "thin lines" (#31508)](https://github.com/mdn/content/commit/43c32d8e6433c6029996a632b594e393c38a9de0)