### PR TITLE
update(HTML): web/html/attributes

### DIFF
--- a/files/uk/web/html/attributes/index.md
+++ b/files/uk/web/html/attributes/index.md
@@ -774,7 +774,7 @@ page-type: landing-page
       <td>Визначає мову сценарію, що вживається в елементі.</td>
     </tr>
     <tr>
-      <td><code>loading</code> {{experimental_inline}}</td>
+      <td><code>loading</code></td>
       <td>
         {{HTMLElement("img")}}, {{HTMLElement("iframe")}}
       </td>


### PR DESCRIPTION
Оригінальний вміст: [Довідка атрибутів HTML@MDN](https://developer.mozilla.org/en-us/docs/Web/HTML/Attributes), [сирці Довідка атрибутів HTML@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/html/attributes/index.md)

Нові зміни:
- [fix: remove inline status macros from unmaintainable pages (#35333)](https://github.com/mdn/content/commit/0d8e5e932d471180075f041b73c03289abdf6b3c)