### PR TITLE
update(CSS): web/css/type_selectors

### DIFF
--- a/files/uk/web/css/type_selectors/index.md
+++ b/files/uk/web/css/type_selectors/index.md
@@ -55,7 +55,7 @@ span {
 У цьому прикладі селектор дає збіг лише з елементами `<h1>` у просторі імен example.
 
 ```css
-@namespace example url(http://www.example.com);
+@namespace example url(http://www.example.com/);
 example|h1 {
   color: blue;
 }


### PR DESCRIPTION
Оригінальний вміст: [Селектори типу@MDN](https://developer.mozilla.org/en-us/docs/Web/CSS/Type_selectors), [сирці Селектори типу@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/css/type_selectors/index.md)

Нові зміни:
- [Update redirected links, part 8 (#35338)](https://github.com/mdn/content/commit/d71da812ee94c20658cb1916a123a42254ea545c)