### PR TITLE
update(CSS): web/css/_colon_required

### DIFF
--- a/files/uk/web/css/_colon_required/index.md
+++ b/files/uk/web/css/_colon_required/index.md
@@ -13,7 +13,8 @@ browser-compat: css.selectors.required
 
 Цей псевдоклас корисний для виділення полів, які повинні містити дійсні дані, перш ніж форма може бути подана.
 
-> **Примітка:** Псевдоклас {{cssxref(":optional")}} вибирає _необов'язкові_ поля форм.
+> [!NOTE]
+> Псевдоклас {{cssxref(":optional")}} вибирає _необов'язкові_ поля форм.
 
 ## Синтаксис
 
@@ -22,6 +23,15 @@ browser-compat: css.selectors.required
   /* ... */
 }
 ```
+
+## Доступність
+
+До обов'язкових полів {{htmlelement("input")}} повинен бути застосований атрибут [`required`](/uk/docs/Web/HTML/Element/input#required-oboviazkovyi). Завдяки цьому можна мати впевненість, що люди, які користуються допоміжними технологіями, як то читачем з екрана, зможуть зрозуміти, які поля потребують дійсного вмісту для успішного подання форми.
+
+Якщо форма також містить [необов'язкові](/uk/docs/Web/CSS/:optional) поля, то обов'язкові поля повинні бути візуально позначені, у спосіб, який не покладається лише на колір для передачі змісту. Зазвичай використовують описовий текст чи піктограму.
+
+- [MDN Розуміння WCAG, пояснення Настанови 3.3](/uk/docs/Web/Accessibility/Understanding_WCAG/Understandable#guideline_3.3_%e2%80%94_input_assistance_help_users_avoid_and_correct_mistakes)
+- [Розуміння Критерію успіху 3.3.2 | W3C розуміння WCAG 2.0](https://www.w3.org/TR/UNDERSTANDING-WCAG20/minimize-error-cues.html)
 
 ## Приклади
 
@@ -70,15 +80,6 @@ input:required:invalid {
 #### Результат
 
 {{EmbedLiveSample('pryklady', 600, 120)}}
-
-## Занепокоєння щодо доступності
-
-До обов'язкових полів {{htmlelement("input")}} повинен бути застосований атрибут [`required`](/uk/docs/Web/HTML/Element/input#required-oboviazkovyi). Завдяки цьому можна мати впевненість, що люди, які користуються допоміжними технологіями, як то читачем з екрана, зможуть зрозуміти, які поля потребують дійсного вмісту для успішного подання форми.
-
-Якщо форма також містить [необов'язкові](/uk/docs/Web/CSS/:optional) поля, то обов'язкові поля повинні бути візуально позначені, у спосіб, який не покладається лише на колір для передачі змісту. Зазвичай використовують описовий текст чи піктограму.
-
-- [MDN Розуміння WCAG, пояснення Настанови 3.3](/uk/docs/Web/Accessibility/Understanding_WCAG/Understandable#guideline_3.3_%e2%80%94_input_assistance_help_users_avoid_and_correct_mistakes)
-- [Розуміння Критерію успіху 3.3.2 | W3C розуміння WCAG 2.0](https://www.w3.org/TR/UNDERSTANDING-WCAG20/minimize-error-cues.html)
 
 ## Специфікації
 


### PR DESCRIPTION
Оригінальний вміст: [":required"@MDN](https://developer.mozilla.org/en-us/docs/Web/CSS/:required), [сирці ":required"@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/css/_colon_required/index.md)

Нові зміни:
- [Convert noteblocks for web/css folder (part 1) (#35157)](https://github.com/mdn/content/commit/4cb569f768ec9529724f8fb06539f2903a583a41)
- [Move Accessibility section above Examples for CSS pages (#34985)](https://github.com/mdn/content/commit/3928d2b1004e2435e063ef4b037e06e1906d62f3)