### PR TITLE
update(HTML): web/html/element/heading_elements

### DIFF
--- a/files/uk/web/html/element/heading_elements/index.md
+++ b/files/uk/web/html/element/heading_elements/index.md
@@ -1,8 +1,14 @@
 ---
-title: "<h1>–<h6>: Елементи заголовків розділів HTML"
+title: <h1>–<h6> – елементи заголовків розділів HTML
 slug: Web/HTML/Element/Heading_Elements
 page-type: html-element
-browser-compat: html.elements.h1
+browser-compat:
+  - html.elements.h1
+  - html.elements.h2
+  - html.elements.h3
+  - html.elements.h4
+  - html.elements.h5
+  - html.elements.h6
 ---
 
 {{HTMLSidebar}}


### PR DESCRIPTION
Оригінальний вміст: ["&lt;h1&gt;–&lt;h6&gt;: Елементи заголовків розділів HTML"@MDN](https://developer.mozilla.org/en-us/docs/Web/HTML/Element/Heading_Elements), [сирці "&lt;h1&gt;–&lt;h6&gt;: Елементи заголовків розділів HTML"@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/html/element/heading_elements/index.md)

Нові зміни:
- [Fix BCD keys (#35502)](https://github.com/mdn/content/commit/0496bb2fcef13172325e1cc25a5fc71410506557)