### PR TITLE
update(HTML): web/html/global_attributes

### DIFF
--- a/files/uk/web/html/global_attributes/index.md
+++ b/files/uk/web/html/global_attributes/index.md
@@ -71,7 +71,8 @@ browser-compat: html.global_attributes
 - [`is`](/uk/docs/Web/HTML/Global_attributes/is)
   - : Дає змогу вказати, що стандартний елемент HTML повинен поводитись як зареєстрований користувацький вбудований елемент (подробиці у [Використанні користувацьких елементів](/uk/docs/Web/API/Web_components/Using_custom_elements)).
 
-> **Примітка:** Атрибути `item*` є частиною [Функціональності мікроданих HTML WHATWG (англ.)](https://html.spec.whatwg.org/multipage/microdata.html#microdata).
+> [!NOTE]
+> Атрибути `item*` є частиною [Функціональності мікроданих HTML WHATWG](https://html.spec.whatwg.org/multipage/microdata.html#microdata).
 
 - [`itemid`](/uk/docs/Web/HTML/Global_attributes/itemid)
   - : Унікальний, глобальний ідентифікатор елемента даних.
@@ -127,6 +128,13 @@ browser-compat: html.global_attributes
 
     - `auto` або _порожній рядок_ – коли на елемент перевели фокус або торкнулися його, автоматично виводиться віртуальна клавіатура.
     - `manual` – фокус і дотик елемента відв'язані від стану віртуальної клавіатури.
+
+- [`writingsuggestions`](/uk/docs/Web/HTML/Global_attributes/writingsuggestions)
+
+  - : Використовується для контролю логіки пропозицій щодо написання з боку браузера й може застосовуватись до поля введення, розділу чи всієї сторінки.
+
+    - `false`, що вимикає пропозиції з боку браузера.
+    - `true` або _порожній рядок_, що вмикає пропозиції.
 
 ## Специфікації
 


### PR DESCRIPTION
Оригінальний вміст: [Глобальні атрибути@MDN](https://developer.mozilla.org/en-us/docs/Web/HTML/Global_attributes), [сирці Глобальні атрибути@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/html/global_attributes/index.md)

Нові зміни:
- [Docs for the `writingsuggestions` HTML attribute (#35445)](https://github.com/mdn/content/commit/87b1277782f71a58693aeb6a83464e3ccabbfa20)
- [Convert noteblocks for web/html/global_attributes folder (#35086)](https://github.com/mdn/content/commit/926f83641b980fcda58914649748b0368eeca1cd)