### PR TITLE
update(HTML): web/html/attributes/rel

### DIFF
--- a/files/uk/web/html/attributes/rel/index.md
+++ b/files/uk/web/html/attributes/rel/index.md
@@ -73,7 +73,7 @@ browser-compat:
       ```
 
     - Вкупі з атрибутом [`hreflang`](/uk/docs/Web/HTML/Element/link#hreflang), що відрізняється від мови документа, це позначає переклад.
-    - Вкупі з атрибутом [`type`](/uk/docs/Web/HTML/Element/link#type) зі значенням `"application/rss+xml"`або `"application/atom+xml"`, це утворює гіперпосилання, що вказує на стрічку синдикації.
+    - Вкупі з атрибутом [`type`](/uk/docs/Web/HTML/Element/link#type) зі значенням `"application/rss+xml"` або `"application/atom+xml"`, це утворює гіперпосилання, що вказує на стрічку синдикації.
 
       ```html
       <link


### PR DESCRIPTION
Оригінальний вміст: [Атрибут HTML – rel@MDN](https://developer.mozilla.org/en-us/docs/Web/HTML/Attributes/rel), [сирці Атрибут HTML – rel@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/html/attributes/rel/index.md)

Нові зміни:
- [Fix spacing-related typos (#35401)](https://github.com/mdn/content/commit/bb48907e64eb4bf60f17efd7d39b46c771d220a0)