### PR TITLE
update(CSS): web/css/caret-color

### DIFF
--- a/files/uk/web/css/caret-color/index.md
+++ b/files/uk/web/css/caret-color/index.md
@@ -7,7 +7,7 @@ browser-compat: css.properties.caret-color
 
 {{CSSRef}}
 
-Властивість CSS **`caret-color`** (колір каретки) задає колір **каретки вставлення**, видимого маркера в місці, куди буде вставлено наступний набраний символ. Його іноді називають **курсором текстового введення**. Каретка з'являється в елементах штибу {{HTMLElement("input")}} або тих, що мають атрибут [`contenteditable`](/uk/docs/Web/HTML/Global_attributes#contenteditable). Зазвичай вона є тонкою вертикальною лінією, яка блимає, щоб бути більш помітною. Усталено вона чорна, але її колір можна змінити за допомогою цієї властивості.
+Властивість [CSS](/uk/docs/Web/CSS) **`caret-color`** (колір каретки) задає колір **каретки вставлення**, видимого маркера в місці, куди буде вставлено наступний набраний символ. Його іноді називають **курсором текстового введення**. Каретка з'являється в елементах штибу {{HTMLElement("input")}} або тих, що мають атрибут [`contenteditable`](/uk/docs/Web/HTML/Global_attributes#contenteditable). Зазвичай вона є тонкою вертикальною лінією, яка блимає, щоб бути більш помітною. Усталено вона чорна, але її колір можна змінити за допомогою цієї властивості.
 
 {{EmbedInteractiveExample("pages/css/caret-color.html")}}
 
@@ -41,7 +41,8 @@ caret-color: unset;
 
   - : Користувацький агент обирає відповідний колір для каретки. Зазвичай це {{cssxref("&lt;color&gt;","currentcolor","#kliuchove-slovo-currentcolor")}}, але користувацький агент може обрати інший колір, щоб забезпечити хорошу видимість і контрастність щодо навколишнього вмісту, враховуючи значення `currentcolor`, фон, тіні та інші чинники.
 
-    > **Примітка:** Попри те, що користувацькі агенти можуть використовувати значення `currentcolor` (яке зазвичай анімується) для значення `auto`, `auto` не інтерполюється в переходах та анімаціях.
+    > [!NOTE]
+    > Попри те, що користувацькі агенти можуть використовувати значення `currentcolor` (яке зазвичай анімується) для значення `auto`, `auto` не інтерполюється в переходах та анімаціях.
 
 - {{cssxref("&lt;color&gt;")}}
   - : Колір каретки.
@@ -103,4 +104,4 @@ p.custom {
 - Елемент {{HTMLElement("input")}}
 - Атрибут HTML [`contenteditable`](/uk/docs/Web/HTML/Global_attributes#contenteditable), завдяки якому можна зробити редаговним текст будь-якого елемента
 - Тип даних {{cssxref("&lt;color&gt;")}}
-- Інші властивості, пов'язані з кольором: {{cssxref("color")}}, {{cssxref("background-color")}}, {{cssxref("border-color")}}, {{cssxref("outline-color")}}, {{cssxref("text-decoration-color")}}, {{cssxref("text-emphasis-color")}}, {{cssxref("text-shadow")}}, {{cssxref("caret-color")}} і {{cssxref("column-rule-color")}}
+- Інші властивості, пов'язані з кольором: {{cssxref("color")}}, {{cssxref("background-color")}}, {{cssxref("border-color")}}, {{cssxref("outline-color")}}, {{cssxref("text-decoration-color")}}, {{cssxref("text-emphasis-color")}}, {{cssxref("text-shadow")}} і {{cssxref("column-rule-color")}}


### PR DESCRIPTION
Оригінальний вміст: [caret-color@MDN](https://developer.mozilla.org/en-us/docs/Web/CSS/caret-color), [сирці caret-color@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/css/caret-color/index.md)

Нові зміни:
- [Remove self links, other pages (#35041)](https://github.com/mdn/content/commit/9231a7046973685f4600e1891fa644ecce41ef3b)
- [chore: convert noteblocks for `/web/css` (part 2) (#35148)](https://github.com/mdn/content/commit/4e508e2f543c0d77c9c04f406ebc8e9db7e965be)
- [Fix CSS Properties with no link (#33620)](https://github.com/mdn/content/commit/aac4966bd12c77281f9374bbfaf4e17e2680ac3b)