### PR TITLE
update(HTML): web/html/attributes/readonly

### DIFF
--- a/files/uk/web/html/attributes/readonly/index.md
+++ b/files/uk/web/html/attributes/readonly/index.md
@@ -1,5 +1,6 @@
 ---
-title: "Атрибут HTML: readonly"
+title: Атрибут HTML – readonly
+short-title: readonly
 slug: Web/HTML/Attributes/readonly
 page-type: html-attribute
 browser-compat:
@@ -17,11 +18,12 @@ browser-compat:
 
 Якщо атрибут `readonly` заданий на елементі поля, то, оскільки користувач не може редагувати поле, такий елемент не бере участі в перевірці обмежень.
 
-Атрибут `readonly` підтримується типами {{HTMLElement("input")}} `{{HTMLElement("input/text","text")}}`, `{{HTMLElement("input/search","search")}}`, `{{HTMLElement("input/url","url")}}`, `{{HTMLElement("input/tel","tel")}}`, `{{HTMLElement("input/email","email")}}`, `{{HTMLElement("input/password","password")}}`, `{{HTMLElement("input/date","date")}}`, `{{HTMLElement("input/month","month")}}`, `{{HTMLElement("input/week","week")}}`, `{{HTMLElement("input/time","time")}}`, `{{HTMLElement("input/datetime-local","datetime-local")}}` і `{{HTMLElement("input/number","number")}}`, а також контрольним елементом форм {{HTMLElement("textarea")}}. Коли він присутній на будь-якому з них, спрацьовує збіг з псевдокласом {{cssxref(':read-only')}}. Якщо його немає, то спрацьовує збіг з псевдокласом {{cssxref(':read-write')}}.
+Атрибут `readonly` підтримується типами {{HTMLElement("input")}} {{HTMLElement("input/text","text")}}, {{HTMLElement("input/search","search")}}, {{HTMLElement("input/url","url")}}, {{HTMLElement("input/tel","tel")}}, {{HTMLElement("input/email","email")}}, {{HTMLElement("input/password","password")}}, {{HTMLElement("input/date","date")}}, {{HTMLElement("input/month","month")}}, {{HTMLElement("input/week","week")}}, {{HTMLElement("input/time","time")}}, {{HTMLElement("input/datetime-local","datetime-local")}} і {{HTMLElement("input/number","number")}}, а також контрольним елементом форм {{HTMLElement("textarea")}}. Коли він присутній на будь-якому з них, спрацьовує збіг з псевдокласом {{cssxref(':read-only')}}. Якщо його немає, то спрацьовує збіг з псевдокласом {{cssxref(':read-write')}}.
 
-Цей атрибут не підтримується та не стосується {{HTMLElement("select")}} і типів полів, які й так не можуть змінюватися, наприклад, `{{HTMLElement("input/checkbox","checkbox")}}` і `{{HTMLElement("input/radio","radio")}}`, або за визначенням не можуть зразу з'являтися зі значенням, наприклад, `{{HTMLElement("input/file","file")}}`. `{{HTMLElement("input/range","range")}}` і `{{HTMLElement("input/color","color")}}`, оскільки обидва ці типи мають усталені значення. Також не підтримується на `{{HTMLElement("input/hidden","hidden")}}`, адже не можна очікувати, що користувач заповнить поле, що є прихованим. Він також не підтримується на будь-якому з типів кнопок, включно з `image`.
+Цей атрибут не підтримується та не стосується {{HTMLElement("select")}} і типів полів, які й так не можуть змінюватися, наприклад, {{HTMLElement("input/checkbox","checkbox")}} і {{HTMLElement("input/radio","radio")}}, або за визначенням не можуть зразу з'являтися зі значенням, наприклад, {{HTMLElement("input/file","file")}}. {{HTMLElement("input/range","range")}} і {{HTMLElement("input/color","color")}}, оскільки обидва ці типи мають усталені значення. Також не підтримується на {{HTMLElement("input/hidden","hidden")}}, адже не можна очікувати, що користувач заповнить поле, що є прихованим. Він також не підтримується на будь-якому з типів кнопок, включно з `image`.
 
-> **Примітка:** Лише текстові контрольні елементи можуть стати лише для зчитування, адже для решти контрольних елементів (як то полів для галочки та кнопок) немає змістовної відмінності між станами лише для зчитування та вимкненості, тому атрибут `readonly` не застосовується.
+> [!NOTE]
+> Лише текстові контрольні елементи можуть стати лише для зчитування, адже для решти контрольних елементів (як то полів для галочки та кнопок) немає змістовної відмінності між станами лише для зчитування та вимкненості, тому атрибут `readonly` не застосовується.
 
 Коли поле має атрибут `readonly`, то до нього також застосовується псевдоклас {{cssxref(":read-only")}}. І навпаки, поля, які підтримують атрибут `readonly`, але не мають його, відповідають псевдокласу {{cssxref(":read-write")}}.
 
@@ -33,7 +35,8 @@ browser-compat:
 
 Єдиний спосіб динамічно змінити значення атрибута `readonly` — це за допомогою сценарію.
 
-> **Примітка:** Атрибут `required` не дозволяється на полях, на яких заданий атрибут `readonly`.
+> [!NOTE]
+> Атрибут `required` не дозволяється на полях, на яких заданий атрибут `readonly`.
 
 ### Використовність
 


### PR DESCRIPTION
Оригінальний вміст: ["Атрибут HTML: readonly"@MDN](https://developer.mozilla.org/en-us/docs/Web/HTML/Attributes/readonly), [сирці "Атрибут HTML: readonly"@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/html/attributes/readonly/index.md)

Нові зміни:
- [chore(short-title): HTML and HTML attributes (#35336)](https://github.com/mdn/content/commit/067a40e4ed27ea6e1f3b8bbfec15cd9dc3078f4c)
- [Convert noteblocks for web/html/attributes folder (#35084)](https://github.com/mdn/content/commit/aee2bd82de11cb7331134e48e8bd548bbedafcc5)