### PR TITLE
update(SVG): web/svg/attribute

### DIFF
--- a/files/uk/web/svg/attribute/index.md
+++ b/files/uk/web/svg/attribute/index.md
@@ -9,7 +9,7 @@ page-type: landing-page
 
 Елементи SVG можуть бути модифіковані за допомогою атрибутів, що задають деталі того, як саме елемент повинен бути оброблений або візуалізований.
 
-Нижче - список усіх атрибутів, доступних у SVG, а також посилання на довідкову документацію, щоб допомогти вам дізнатися, які елементи їх підтримують і як вони працюють.
+Нижче – список усіх атрибутів, доступних у SVG, а також посилання на довідкову документацію, щоб допомогти вам дізнатися, які елементи їх підтримують і як вони працюють.
 
 ## Атрибути SVG від A до Z
 
@@ -58,7 +58,9 @@ page-type: landing-page
 ### D
 
 - {{SVGAttr("d")}}
+- {{SVGAttr("data-*")}}
 - {{SVGAttr("decelerate")}}
+- {{SVGAttr("decoding")}}
 - {{SVGAttr("descent")}}
 - {{SVGAttr("diffuseConstant")}}
 - {{SVGAttr("direction")}}
@@ -117,6 +119,7 @@ page-type: landing-page
 - {{SVGAttr("hreflang")}}
 - {{SVGAttr("horiz-adv-x")}}
 - {{SVGAttr("horiz-origin-x")}}
+- {{SVGAttr("horiz-origin-y")}}
 
 ### I
 
@@ -228,6 +231,7 @@ page-type: landing-page
 - {{SVGAttr("scale")}}
 - {{SVGAttr("seed")}}
 - {{SVGAttr("shape-rendering")}}
+- {{SVGAttr("side")}}
 - {{SVGAttr("slope")}}
 - {{SVGAttr("spacing")}}
 - {{SVGAttr("specularConstant")}}
@@ -365,7 +369,8 @@ page-type: landing-page
 
 ### Атрибути представлення
 
-> **Примітка:** Всі атрибути представлення SVG можуть бути використані як властивості CSS.
+> [!NOTE]
+> Всі атрибути представлення SVG можуть бути використані як властивості CSS.
 
 - {{SVGAttr("alignment-baseline")}}
 - {{SVGAttr("baseline-shift")}}


### PR DESCRIPTION
Оригінальний вміст: [Довідка атрибутів SVG@MDN](https://developer.mozilla.org/en-us/docs/Web/SVG/Attribute), [сирці Довідка атрибутів SVG@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/svg/attribute/index.md)

Нові зміни:
- [Add missing links from parent page to child page (#35652)](https://github.com/mdn/content/commit/c640274a19227cd5790912ea76841732baa6731f)
- [Convert noteblocks for web/svg/attribute folder (#35100)](https://github.com/mdn/content/commit/a7615ee2f9e22946edff7633962bc1d9eee9e0ad)