### PR TITLE
update(CSS): web/css/using_css_custom_properties

### DIFF
--- a/files/uk/web/css/using_css_custom_properties/index.md
+++ b/files/uk/web/css/using_css_custom_properties/index.md
@@ -379,6 +379,8 @@ div {
 
 Фактично ми це вже бачили в розділі [Успадкування з `@property`](#vykorystannia-property-dlia-keruvannia-uspadkuvanniam).
 
+<!-- cSpell:ignore aqumarine -->
+
 Наступний приклад за допомогою правила `@property` задає початкове значення `--box-color` як `cornflowerblue`.
 У наборі правил, що стоїть після директиви, хотілося задати `--box-color` як `aquamarine`, але в назві значення є хибодрук.
 Те саме істинно для третього `<div>`, де використано `2rem` для кастомної властивості, яка очікує дійсне [значення `<color>`](/uk/docs/Web/CSS/color_value).


### PR DESCRIPTION
Оригінальний вміст: [Використання кастомних властивостей (змінних) CSS@MDN](https://developer.mozilla.org/en-us/docs/Web/CSS/Using_CSS_custom_properties), [сирці Використання кастомних властивостей (змінних) CSS@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/css/using_css_custom_properties/index.md)

Нові зміни:
- [Fix typos and pseudo-typos 7 (#36248)](https://github.com/mdn/content/commit/b2833ddfd45cae1bb5e050d24637865e9327408d)
- [Fix spacing-related typos (#35401)](https://github.com/mdn/content/commit/bb48907e64eb4bf60f17efd7d39b46c771d220a0)