### PR TITLE
update(CSS): web/css/backdrop-filter

### DIFF
--- a/files/uk/web/css/backdrop-filter/index.md
+++ b/files/uk/web/css/backdrop-filter/index.md
@@ -18,7 +18,7 @@ browser-compat: css.properties.backdrop-filter
 backdrop-filter: none;
 
 /* Фільтр з URL до SVG */
-backdrop-filter: url(commonfilters.svg#filter);
+backdrop-filter: url(common-filters.svg#filter);
 
 /* Значення <filter-function> */
 backdrop-filter: blur(2px);


### PR DESCRIPTION
Оригінальний вміст: [backdrop-filter@MDN](https://developer.mozilla.org/en-us/docs/Web/CSS/backdrop-filter), [сирці backdrop-filter@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/css/backdrop-filter/index.md)

Нові зміни:
- [Fix typos and pseudo-typos 6 (#36247)](https://github.com/mdn/content/commit/50c8e290f11b061bbf2267e1a3279f28180a5fcb)