### PR TITLE
update(CSS): web/css/padding

### DIFF
--- a/files/uk/web/css/padding/index.md
+++ b/files/uk/web/css/padding/index.md
@@ -13,7 +13,8 @@ browser-compat: css.properties.padding
 
 Розмах внутрішніх відступів елемента – простір між елементом та його межами.
 
-> **Примітка:** Зовнішні відступи створюють додатковий простір всередині елемента. На відміну від них, {{cssxref("margin", "зовнішні відступи")}} створюють додатковий простір _навколо_ елемента.
+> [!NOTE]
+> Зовнішні відступи створюють додатковий простір всередині елемента. На відміну від них, {{cssxref("margin", "зовнішні відступи")}} створюють додатковий простір _навколо_ елемента.
 
 ## Складові властивості
 
@@ -133,6 +134,8 @@ padding: 1em 3px 30px 5px;
 
 ## Дивіться також
 
+- {{cssxref("padding-top")}}, {{cssxref("padding-right")}}, {{cssxref("padding-bottom")}} і {{cssxref("padding-left")}}
+- {{cssxref("padding-block-start")}}, {{cssxref("padding-block-end")}}, {{cssxref("padding-inline-start")}} і {{cssxref("padding-inline-end")}}
+- Скорочення {{cssxref("padding-block")}} і {{cssxref("padding-inline")}}
 - [Вступ до базової рамкової моделі CSS](/uk/docs/Web/CSS/CSS_box_model/Introduction_to_the_CSS_box_model)
-- {{cssxref("padding-top")}}, {{cssxref("padding-right")}}, {{cssxref("padding-bottom")}} та {{cssxref("padding-left")}}.
-- Відповідні логічні властивості: {{cssxref("padding-block-start")}}, {{cssxref("padding-block-end")}}, {{cssxref("padding-inline-start")}} та {{cssxref("padding-inline-end")}}, а також скорочення {{cssxref("padding-block")}} і {{cssxref("padding-inline")}}
+- Модуль [Рамкової моделі CSS](/uk/docs/Web/CSS/CSS_box_model)


### PR DESCRIPTION
Оригінальний вміст: [padding@MDN](https://developer.mozilla.org/en-us/docs/Web/CSS/padding), [сирці padding@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/css/padding/index.md)

Нові зміни:
- [See also: remove text, add modules (#36240)](https://github.com/mdn/content/commit/9a3940b0231838338f65ae1c37d5b874439a3d43)
- [chore: convert noteblocks for `/web/css` (part 4) (#35150)](https://github.com/mdn/content/commit/fc1cc5684c98d19816d5cc81702d70f2a0debbad)