### PR TITLE
update(CSS): web/css/margin

### DIFF
--- a/files/uk/web/css/margin/index.md
+++ b/files/uk/web/css/margin/index.md
@@ -154,5 +154,5 @@ margin: auto; /* згори та знизу: 0 відступу     */
 - {{cssxref("margin-block-start")}}, {{cssxref("margin-block-end")}}, {{cssxref("margin-inline-start")}} і {{cssxref("margin-inline-end")}}
 - Скорочення {{cssxref("margin-block")}} і {{cssxref("margin-inline")}}
 - [Опанування перекриття зовнішніх відступів](/uk/docs/Web/CSS/CSS_box_model/Mastering_margin_collapsing)
-- [Вступ до Базової рамкової моделі CSS](/uk/docs/Web/CSS/CSS_box_model/Introduction_to_the_CSS_box_model)
+- [Вступ у Базову рамкову модель CSS](/uk/docs/Web/CSS/CSS_box_model/Introduction_to_the_CSS_box_model)
 - Модуль [Рамкової моделі CSS](/uk/docs/Web/CSS/CSS_box_model)

--- a/files/uk/web/css/margin/index.md
+++ b/files/uk/web/css/margin/index.md
@@ -150,7 +150,9 @@ margin: auto; /* згори та знизу: 0 відступу     */
 
 ## Дивіться також
 
-- [Вступ до Базової рамкової моделі CSS](/uk/docs/Web/CSS/CSS_box_model/Introduction_to_the_CSS_box_model)
-- [Опанування явища складання берегів](/uk/docs/Web/CSS/CSS_box_model/Mastering_margin_collapsing)
 - {{cssxref("margin-top")}}, {{cssxref("margin-right")}}, {{cssxref("margin-bottom")}} і {{cssxref("margin-left")}}
-- Відповідні логічні властивості: {{cssxref("margin-block-start")}}, {{cssxref("margin-block-end")}}, {{cssxref("margin-inline-start")}} і {{cssxref("margin-inline-end")}}, а також скорочення {{cssxref("margin-block")}} і {{cssxref("margin-inline")}}
+- {{cssxref("margin-block-start")}}, {{cssxref("margin-block-end")}}, {{cssxref("margin-inline-start")}} і {{cssxref("margin-inline-end")}}
+- Скорочення {{cssxref("margin-block")}} і {{cssxref("margin-inline")}}
+- [Опанування перекриття зовнішніх відступів](/uk/docs/Web/CSS/CSS_box_model/Mastering_margin_collapsing)
+- [Вступ до Базової рамкової моделі CSS](/uk/docs/Web/CSS/CSS_box_model/Introduction_to_the_CSS_box_model)
+- Модуль [Рамкової моделі CSS](/uk/docs/Web/CSS/CSS_box_model)


### PR DESCRIPTION
Оригінальний вміст: [margin@MDN](https://developer.mozilla.org/en-us/docs/Web/CSS/margin), [сирці margin@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/css/margin/index.md)

Нові зміни:
- [See also: remove text, add modules (#36240)](https://github.com/mdn/content/commit/9a3940b0231838338f65ae1c37d5b874439a3d43)