### PR TITLE
update(CSS): web/css/height

### DIFF
--- a/files/uk/web/css/height/index.md
+++ b/files/uk/web/css/height/index.md
@@ -139,11 +139,12 @@ div {
 
 ## Дивіться також
 
-- [Блокова модель](/uk/docs/Web/CSS/CSS_box_model/Introduction_to_the_CSS_box_model)
 - {{cssxref("width")}}
 - {{cssxref("box-sizing")}}
 - {{cssxref("min-height")}}, {{cssxref("max-height")}}
-- Відповідні логічні властивості: {{cssxref("block-size")}}, {{cssxref("inline-size")}}
+- {{cssxref("block-size")}}, {{cssxref("inline-size")}}
 - {{cssxref("anchor-size()")}}
 - {{cssxref("clamp", "clamp()")}}
 - {{cssxref("clamp", "minmax()")}}
+- [Вступ у Базову рамкову модель CSS](/uk/docs/Web/CSS/CSS_box_model/Introduction_to_the_CSS_box_model)
+- Модуль [Рамкової моделі CSS](/uk/docs/Web/CSS/CSS_box_model)


### PR DESCRIPTION
Оригінальний вміст: [height@MDN](https://developer.mozilla.org/en-us/docs/Web/CSS/height), [сирці height@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/css/height/index.md)

Нові зміни:
- [See also: remove text, add modules (#36240)](https://github.com/mdn/content/commit/9a3940b0231838338f65ae1c37d5b874439a3d43)