### PR TITLE
update(HTML): web/html/element/picture

### DIFF
--- a/files/uk/web/html/element/picture/index.md
+++ b/files/uk/web/html/element/picture/index.md
@@ -104,7 +104,7 @@ browser-compat: html.elements.picture
 
 ### Атрибут `type`
 
-Атрибут `type` визначає [MIME тип](/uk/docs/Web/HTTP/Basics_of_HTTP/MIME_types) для URL-адреси, вказаної в атрибуті `srcset` елемента {{HTMLElement("source")}}. Якщо користувацький агент не підтримує заданий тип, то елемент {{HTMLElement("source")}} пропускається.
+Атрибут `type` визначає [MIME тип](/uk/docs/Web/HTTP/MIME_types) для URL-адреси, вказаної в атрибуті `srcset` елемента {{HTMLElement("source")}}. Якщо користувацький агент не підтримує заданий тип, то елемент {{HTMLElement("source")}} пропускається.
 
 ```html
 <picture>


### PR DESCRIPTION
Оригінальний вміст: ["&lt;picture&gt;: Елемент зображення"@MDN](https://developer.mozilla.org/en-us/docs/Web/HTML/Element/picture), [сирці "&lt;picture&gt;: Елемент зображення"@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/html/element/picture/index.md)

Нові зміни:
- [chore(http): delete "Basics of HTTP" page in favor of HTTP landing page, reorganize index (#35774)](https://github.com/mdn/content/commit/f75b2c86ae4168e59416aed4c7121f222afc201d)