### PR TITLE
update(HTML): web/html/element/span

### DIFF
--- a/files/uk/web/html/element/span/index.md
+++ b/files/uk/web/html/element/span/index.md
@@ -7,7 +7,7 @@ browser-compat: html.elements.span
 
 {{HTMLSidebar}}
 
-Елемент [HTML](/uk/docs/Web/HTML) **`<span>`** (розмах, відрізок, проліт, інтервал) – це узагальнений рядковий контейнер для оповідального вмісту, котрий по суті нічого не представляє. Він може застосовуватися для групування елементів для потреб оформлення (за допомогою атрибутів [`class`](/uk/docs/Web/HTML/Global_attributes#class) і [`id`](/uk/docs/Web/HTML/Global_attributes#id)), або через те, що вони поділяють значення атрибутів, як то [`lang`](/uk/docs/Web/HTML/Global_attributes#lang). Повинен застосовуватися лише тоді, коли жодний семантичний елемент не є доречним. `<span>` вельми подібний до елемента {{HTMLElement("div")}}, крім того, що {{HTMLElement("div")}} є [елементом блокового рівня](/uk/docs/Glossary/Block-level_content), а `<span>` – [елементом рядкового](/uk/docs/Glossary/Inline-level_content).
+Елемент [HTML](/uk/docs/Web/HTML) **`<span>`** (розмах, відрізок, проліт, інтервал) – це узагальнений рядковий контейнер для оповідального вмісту, котрий по суті нічого не представляє. Він може застосовуватися для групування елементів для потреб оформлення (за допомогою атрибутів [`class`](/uk/docs/Web/HTML/Global_attributes/class) і [`id`](/uk/docs/Web/HTML/Global_attributes/id)), або через те, що вони поділяють значення атрибутів, як то [`lang`](/uk/docs/Web/HTML/Global_attributes/lang). Повинен застосовуватися лише тоді, коли жодний семантичний елемент не є доречним. `<span>` вельми подібний до елемента {{HTMLElement("div")}}, крім того, що {{HTMLElement("div")}} є [елементом блокового рівня](/uk/docs/Glossary/Block-level_content), а `<span>` – [елементом рядкового](/uk/docs/Glossary/Inline-level_content).
 
 {{EmbedInteractiveExample("pages/tabbed/span.html", "tabbed-shorter")}}
 


### PR DESCRIPTION
Оригінальний вміст: ["&lt;span&gt;: Елемент відрізка вмісту"@MDN](https://developer.mozilla.org/en-us/docs/Web/HTML/Element/span), [сирці "&lt;span&gt;: Елемент відрізка вмісту"@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/html/element/span/index.md)

Нові зміни:
- [Update HTML global attributes link: Global_attributes#** -&gt; Global_attributes/** | part I (#36220)](https://github.com/mdn/content/commit/5026c14bd6d2b6b377289aadac7eceae9282e806)