### PR TITLE
update(CSS): web/css/class_selectors

### DIFF
--- a/files/uk/web/css/class_selectors/index.md
+++ b/files/uk/web/css/class_selectors/index.md
@@ -7,7 +7,7 @@ browser-compat: css.selectors.class
 
 {{CSSRef}}
 
-**Селектор класу** [CSS](/uk/docs/Web/CSS) дає збіг з елементами на основі їхнього атрибута [`class`](/uk/docs/Web/HTML/Global_attributes#class).
+**Селектор класу** [CSS](/uk/docs/Web/CSS) дає збіг з елементами на основі їхнього атрибута [`class`](/uk/docs/Web/HTML/Global_attributes/class).
 
 ```css
 /* Усі елементи з class="spacious" */


### PR DESCRIPTION
Оригінальний вміст: [Селектори класу@MDN](https://developer.mozilla.org/en-us/docs/Web/CSS/Class_selectors), [сирці Селектори класу@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/css/class_selectors/index.md)

Нові зміни:
- [Replace DT link with real target | part II (#36267)](https://github.com/mdn/content/commit/92447fec056cc89b7f28445851bea0c981fcbc12)