### PR TITLE
update(CSS): web/css/_colon_indeterminate

### DIFF
--- a/files/uk/web/css/_colon_indeterminate/index.md
+++ b/files/uk/web/css/_colon_indeterminate/index.md
@@ -7,7 +7,7 @@ browser-compat: css.selectors.indeterminate
 
 {{CSSRef}}
 
-[Псевдоклас](/uk/docs/Web/CSS/Pseudo-classes) [CSS](/uk/docs/Web/CSS) **`:indeterminate`** (невизначене) представляє будь-який елемент форми, чий стан – невизначений, наприклад, поля для галочки, які мають стан [`indeterminate`](/uk/docs/Web/HTML/Element/input/checkbox#polia-dlia-halochok-z-nevyznachenym-stanom), заданий за допомогою JavaScript, кнопки-перемикачі, які є членами групи, в якій всі кнопки-перемикачі не вибрані, та елементи {{HTMLElement("progress")}} без атрибута `value`.
+[Псевдоклас](/uk/docs/Web/CSS/Pseudo-classes) [CSS](/uk/docs/Web/CSS) **`:indeterminate`** (невизначене) представляє будь-який елемент форми, чий стан – невизначений, наприклад, поля для галочки, які мають стан [`indeterminate`](/uk/docs/Web/API/HTMLInputElement/indeterminate), заданий за допомогою JavaScript, кнопки-перемикачі, які є членами групи, в якій всі кнопки-перемикачі не вибрані, та елементи {{HTMLElement("progress")}} без атрибута `value`.
 
 ```css
 /* Вибирає всі елементи <input>, стан яких є невизначеним */
@@ -18,7 +18,7 @@ input:indeterminate {
 
 Елементи, на які націлюється цей селектор:
 
-- Елементи [`<input type="checkbox">`](/uk/docs/Web/HTML/Element/input/checkbox), чиїй властивості `indeterminate` присвоєно `true` за допомогою [JavaScript](/uk/docs/Web/JavaScript)
+- Елементи [`<input type="checkbox">`](/uk/docs/Web/HTML/Element/input/checkbox), чиїй властивості [`indeterminate`](/uk/docs/Web/API/HTMLInputElement/indeterminate) задано значення `true`
 - Елементи [`<input type="radio">`](/uk/docs/Web/HTML/Element/input/radio), коли всі радіокнопки з однаковим значенням `name` в формі не вибрані
 - Елементи {{HTMLElement("progress")}} у невизначеному стані
 
@@ -137,6 +137,6 @@ progress:indeterminate {
 
 - [Вебформи – Робота з користувацькими даними](/uk/docs/Learn/Forms)
 - [Оформлення вебформ](/uk/docs/Learn/Forms/Styling_web_forms)
-- Властивість [`indeterminate`](/uk/docs/Web/HTML/Element/input/checkbox#polia-dlia-halochok-z-nevyznachenym-stanom) елемента [`<input type="checkbox">`](/uk/docs/Web/HTML/Element/input/checkbox)
+- Властивість [`indeterminate`](/uk/docs/Web/API/HTMLInputElement/indeterminate) елемента [`<input type="checkbox">`](/uk/docs/Web/HTML/Element/input/checkbox)
 - Елемент {{HTMLElement("input")}} і інтерфейс {{domxref("HTMLInputElement")}}, який його реалізує.
 - Селектор CSS {{cssxref(":checked")}} дає змогу оформлювати поля для галочок на основі того, чи є вони вибраними, чи ні


### PR DESCRIPTION
Оригінальний вміст: [":indeterminate"@MDN](https://developer.mozilla.org/en-us/docs/Web/CSS/:indeterminate), [сирці ":indeterminate"@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/css/_colon_indeterminate/index.md)

Нові зміни:
- [New page for HTMLInputElement.indeterminate (#35967)](https://github.com/mdn/content/commit/a4974693ac80bb2872d52610e13737430d9377a6)