### PR TITLE
update(CSS): web/css/_colon_placeholder-shown

### DIFF
--- a/files/uk/web/css/_colon_placeholder-shown/index.md
+++ b/files/uk/web/css/_colon_placeholder-shown/index.md
@@ -96,7 +96,7 @@ input:placeholder-shown {
       pattern="[0-9]{8}"
       title="8-цифровий номер"
       id="sid"
-      class="studentid"
+      class="student-id"
       placeholder="8-цифровий номер" />
   </p>
   <input type="submit" />
@@ -111,7 +111,7 @@ input {
   color: black;
 }
 
-input.studentid:placeholder-shown {
+input.student-id:placeholder-shown {
   background-color: yellow;
   color: red;
   font-style: italic;


### PR DESCRIPTION
Оригінальний вміст: [":placeholder-shown"@MDN](https://developer.mozilla.org/en-us/docs/Web/CSS/:placeholder-shown), [сирці ":placeholder-shown"@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/css/_colon_placeholder-shown/index.md)

Нові зміни:
- [Fix typos and pseudo-typos 6 (#36247)](https://github.com/mdn/content/commit/50c8e290f11b061bbf2267e1a3279f28180a5fcb)