### PR TITLE
update(CSS): web/css/_colon_read-only

### DIFF
--- a/files/uk/web/css/_colon_read-only/index.md
+++ b/files/uk/web/css/_colon_read-only/index.md
@@ -44,8 +44,13 @@ browser-compat: css.selectors.read-only
       >
     </div>
     <div>
-      <label for="pcode">Поштовий індекс: </label>
-      <input id="pcode" name="pcode" type="text" value="76002" readonly />
+      <label for="postal-code">Поштовий індекс: </label>
+      <input
+        id="postal-code"
+        name="postal-code"
+        type="text"
+        value="76002"
+        readonly />
     </div>
   </fieldset>
 
@@ -189,4 +194,4 @@ p:read-write {
 ## Дивіться також
 
 - {{cssxref(":read-write")}}
-- Атрибут HTML [`contenteditable`](/uk/docs/Web/HTML/Global_attributes#contenteditable)
+- Атрибут HTML [`contenteditable`](/uk/docs/Web/HTML/Global_attributes/contenteditable)


### PR DESCRIPTION
Оригінальний вміст: [":read-only"@MDN](https://developer.mozilla.org/en-us/docs/Web/CSS/:read-only), [сирці ":read-only"@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/css/_colon_read-only/index.md)

Нові зміни:
- [Fix typos and pseudo-typos 6 (#36247)](https://github.com/mdn/content/commit/50c8e290f11b061bbf2267e1a3279f28180a5fcb)
- [Replace DT link with real target | part II (#36267)](https://github.com/mdn/content/commit/92447fec056cc89b7f28445851bea0c981fcbc12)