### PR TITLE
update(CSS): web/css/_doublecolon_placeholder

### DIFF
--- a/files/uk/web/css/_doublecolon_placeholder/index.md
+++ b/files/uk/web/css/_doublecolon_placeholder/index.md
@@ -66,7 +66,7 @@ browser-compat: css.selectors.placeholder
 
 ### Підписи
 
-Заповнювачі – це не заміна для елемента {{htmlelement("label")}}. Без підпису, який був програмно пов'язаний із полем введення за допомогою комбінації атрибутів [`for`](/uk/docs/Web/HTML/Element/label#for) і [`id`](/uk/docs/Web/HTML/Global_attributes#id), допоміжні технології, як то читачі з екрана, не можуть розібрати елементи {{htmlelement("input")}}.
+Заповнювачі – це не заміна для елемента {{htmlelement("label")}}. Без підпису, який був програмно пов'язаний із полем введення за допомогою комбінації атрибутів [`for`](/uk/docs/Web/HTML/Element/label#for) і [`id`](/uk/docs/Web/HTML/Global_attributes/id), допоміжні технології, як то читачі з екрана, не можуть розібрати елементи {{htmlelement("input")}}.
 
 - [Заповнювачі в полях форми – шкідливі, – Nielsen Norman Group](https://www.nngroup.com/articles/form-design-placeholders/)
 


### PR DESCRIPTION
Оригінальний вміст: ["::placeholder"@MDN](https://developer.mozilla.org/en-us/docs/Web/CSS/::placeholder), [сирці "::placeholder"@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/css/_doublecolon_placeholder/index.md)

Нові зміни:
- [Replace DT link with real target | part II (#36267)](https://github.com/mdn/content/commit/92447fec056cc89b7f28445851bea0c981fcbc12)