### PR TITLE
update(CSS): web/css/computed_value

### DIFF
--- a/files/uk/web/css/computed_value/index.md
+++ b/files/uk/web/css/computed_value/index.md
@@ -16,7 +16,8 @@ spec-urls: https://www.w3.org/TR/CSS22/cascade.html#computed-value
 
 Проте для частини властивостей (тих, чиї відсотки відносні щодо чогось, що може потребувати макета для визначення, як то `width`, `margin-right`, `text-indent` і `top`) задані відсоткові значення перетворюються на обчислені відсоткові значення. Крім цього, безрозмірні числа, задані у властивості `line-height`, стають обчисленим значенням, як задано. Відносні величини, що залишаються в обчисленому значенні, стають абсолютними, коли з'ясовується [застосоване значення](/uk/docs/Web/CSS/used_value)
 
-> **Примітка:** API DOM {{domxref("Window.getComputedStyle", "getComputedStyle()")}} повертає [вирішене значення](/uk/docs/Web/CSS/resolved_value), котре може бути як обчисленим значенням, так і [застосованим значенням](/uk/docs/Web/CSS/used_value), залежно від конкретної властивості.
+> [!NOTE]
+> API DOM {{domxref("Window.getComputedStyle", "getComputedStyle()")}} повертає [вирішене значення](/uk/docs/Web/CSS/resolved_value), котре може бути як обчисленим значенням, так і [застосованим значенням](/uk/docs/Web/CSS/used_value), залежно від конкретної властивості.
 
 ## Специфікації
 
@@ -38,6 +39,7 @@ spec-urls: https://www.w3.org/TR/CSS22/cascade.html#computed-value
   - Значення
     - [Початкові значення](/uk/docs/Web/CSS/initial_value)
     - [Застосовані значення](/uk/docs/Web/CSS/used_value)
+    - [Вирішені значення](/uk/docs/Web/CSS/resolved_value)
     - [Фактичні значення](/uk/docs/Web/CSS/actual_value)
   - [Синтаксис визначення значень](/uk/docs/Web/CSS/Value_definition_syntax)
   - [Властивості-скорочення](/uk/docs/Web/CSS/Shorthand_properties)


### PR DESCRIPTION
Оригінальний вміст: [Обчислене значення@MDN](https://developer.mozilla.org/en-us/docs/Web/CSS/computed_value), [сирці Обчислене значення@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/css/computed_value/index.md)

Нові зміни:
- [Add consistently formatted "see also" links to all CSS value pages (#35210)](https://github.com/mdn/content/commit/24c2196fd3f32dd271a8b5e9a34d38a2060484d5)
- [chore: convert noteblocks for `/web/css` (part 2) (#35148)](https://github.com/mdn/content/commit/4e508e2f543c0d77c9c04f406ebc8e9db7e965be)