### PR TITLE
update(CSS): web/css/initial_value

### DIFF
--- a/files/uk/web/css/initial_value/index.md
+++ b/files/uk/web/css/initial_value/index.md
@@ -14,7 +14,8 @@ spec-urls: https://www.w3.org/TR/CSS22/cascade.html#specified-value
 
 Використання початкового значення можна задати явно за допомогою ключового слова {{cssxref("initial")}}.
 
-> **Примітка:** Не слід плутати початкове значення зі значенням, заданим у таблиці стилів браузера.
+> [!NOTE]
+> Не слід плутати початкове значення зі значенням, заданим у таблиці стилів браузера.
 
 ## Специфікації
 
@@ -36,6 +37,7 @@ spec-urls: https://www.w3.org/TR/CSS22/cascade.html#specified-value
   - Значення
     - [Обчислені значення](/uk/docs/Web/CSS/computed_value)
     - [Застосовані значення](/uk/docs/Web/CSS/used_value)
+    - [Вирішені значення](/uk/docs/Web/CSS/resolved_value)
     - [Фактичні значення](/uk/docs/Web/CSS/actual_value)
   - [Синтаксис визначення значень](/uk/docs/Web/CSS/Value_definition_syntax)
   - [Властивості-скорочення](/uk/docs/Web/CSS/Shorthand_properties)


### PR DESCRIPTION
Оригінальний вміст: [Початкове значення@MDN](https://developer.mozilla.org/en-us/docs/Web/CSS/initial_value), [сирці Початкове значення@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/css/initial_value/index.md)

Нові зміни:
- [Add consistently formatted "see also" links to all CSS value pages (#35210)](https://github.com/mdn/content/commit/24c2196fd3f32dd271a8b5e9a34d38a2060484d5)
- [Convert noteblocks for web/css folder (part 3) (#35159)](https://github.com/mdn/content/commit/14515827c44f3cb814261a1c6bd487ae8bfcde1b)