### PR TITLE
update(CSS): web/css/used_value

### DIFF
--- a/files/uk/web/css/used_value/index.md
+++ b/files/uk/web/css/used_value/index.md
@@ -11,7 +11,8 @@ spec-urls: https://www.w3.org/TR/CSS22/cascade.html#used-value
 
 Після того, як {{glossary("User agent", "користувацький агент")}} завершив усі необхідні обчислення, кожна властивість CSS отримує вжите значення. Вжиті значення розмірностей (наприклад, {{cssxref("width")}}, {{cssxref("line-height")}}) – у пікселях. Вжиті значення властивостей-скорочень (наприклад, {{cssxref("background")}}) узгоджені зі значеннями своїх властивостей-складових (наприклад, {{cssxref("background-color")}} або {{cssxref("background-size")}}) та зі значеннями {{cssxref("position")}} та {{cssxref("float")}}.
 
-> **Примітка:** API DOM {{domxref("Window.getComputedStyle", "getComputedStyle()")}} повертає [вирішене значення](/uk/docs/Web/CSS/resolved_value), котре може бути або [обчисленим значенням](/uk/docs/Web/CSS/computed_value), або вжитим значенням, залежно від властивості.
+> [!NOTE]
+> API DOM {{domxref("Window.getComputedStyle", "getComputedStyle()")}} повертає [вирішене значення](/uk/docs/Web/CSS/resolved_value), котре може бути або [обчисленим значенням](/uk/docs/Web/CSS/computed_value), або вжитим значенням, залежно від властивості.
 
 ## Приклад
 
@@ -113,7 +114,7 @@ window.addEventListener("resize", updateAllUsedWidths);
   - Значення
     - [Початкові значення](/uk/docs/Web/CSS/initial_value)
     - [Обчислені значення](/uk/docs/Web/CSS/computed_value)
-    - **Вжиті значення**
+    - [Вирішені значення](/uk/docs/Web/CSS/resolved_value)
     - [Фактичні значення](/uk/docs/Web/CSS/actual_value)
   - [Синтаксис визначення значень](/uk/docs/Web/CSS/Value_definition_syntax)
   - [Властивості-скорочення](/uk/docs/Web/CSS/Shorthand_properties)


### PR DESCRIPTION
Оригінальний вміст: [Вжите значення@MDN](https://developer.mozilla.org/en-us/docs/Web/CSS/used_value), [сирці Вжите значення@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/css/used_value/index.md)

Нові зміни:
- [Add consistently formatted "see also" links to all CSS value pages (#35210)](https://github.com/mdn/content/commit/24c2196fd3f32dd271a8b5e9a34d38a2060484d5)
- [chore: convert noteblocks for `/web/css` (part 4) (#35150)](https://github.com/mdn/content/commit/fc1cc5684c98d19816d5cc81702d70f2a0debbad)