### PR TITLE
update(HTML): web/html/attributes/min

### DIFF
--- a/files/uk/web/html/attributes/min/index.md
+++ b/files/uk/web/html/attributes/min/index.md
@@ -1,5 +1,6 @@
 ---
-title: "Атрибут HTML – min"
+title: Атрибут HTML – min
+short-title: min
 slug: Web/HTML/Attributes/min
 page-type: html-attribute
 browser-compat:
@@ -15,7 +16,7 @@ browser-compat:
 
 Цей атрибут прийнятний для типів полів, серед яких {{HTMLElement("input/date", "date")}}, {{HTMLElement("input/month", "month")}}, {{HTMLElement("input/week", "week")}}, {{HTMLElement("input/time", "time")}}, {{HTMLElement("input/datetime-local", "datetime-local")}}, {{HTMLElement("input/number", "number")}} and {{HTMLElement("input/range", "range")}}, а також елемент {{htmlelement('meter')}}.
 
-### Синтаксис
+## Синтаксис
 
 <table class="no-markdown">
   <caption>
@@ -48,14 +49,14 @@ browser-compat:
     </tr>
     <tr>
       <td>{{HTMLElement("input/time", "time")}}</td>
-      <td><code>hh:mm</code></td>
+      <td><code>HH:mm</code></td>
       <td><code>&#x3C;input type="time" min="09:00" step="900"></code></td>
     </tr>
     <tr>
       <td>
         {{HTMLElement("input/datetime-local", "datetime-local")}}
       </td>
-      <td><code>yyyy-mm-ddThh:mm</code></td>
+      <td><code>yyyy-mm-ddTHH:mm</code></td>
       <td>
         <code>&#x3C;input type="datetime-local" min="2019-12-25T19:30"></code>
       </td>
@@ -77,11 +78,12 @@ browser-compat:
   </tbody>
 </table>
 
-> **Примітка:** Коли дані, введені користувачем, не відповідають заданому мінімальному значенню, то значення поля вважається неприйнятним при валідації обмежень і дає збіг з псевдокласами {{cssxref(':invalid')}} і {{cssxref(':out-of-range')}}.
+> [!NOTE]
+> Коли дані, введені користувачем, не відповідають заданому мінімальному значенню, то значення поля вважається неприйнятним при валідації обмежень і дає збіг з псевдокласами {{cssxref(':invalid')}} і {{cssxref(':out-of-range')}}.
 
 Дивіться докладніше у [Валідації на клієнтському боці](/uk/docs/Web/HTML/Constraint_validation) та {{domxref("ValidityState.rangeUnderflow", "rangeUnderflow")}}.
 
-У випадку елемента {{htmlelement('meter')}} атрибут `min` визначає нижню числову межу вимірюваного діапазону. Це значення повинно бути меншим за мінімальне значення (атрибут [`max`](/uk/docs/Web/HTML/Attributes/max)), якщо воно задане. В обох випадках у разі відсутності цього атрибута береться усталене значення 1.
+У випадку елемента {{htmlelement('meter')}} атрибут `min` визначає нижню числову межу вимірюваного діапазону. Це значення повинно бути меншим за максимальне значення (атрибут [`max`](/uk/docs/Web/HTML/Attributes/max)), якщо воно задане. В обох випадках у разі відсутності цього атрибута береться усталене значення 1.
 
 <table class="no-markdown">
   <caption>


### PR DESCRIPTION
Оригінальний вміст: ["Атрибут HTML – min"@MDN](https://developer.mozilla.org/en-us/docs/Web/HTML/Attributes/min), [сирці "Атрибут HTML – min"@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/html/attributes/min/index.md)

Нові зміни:
- [Update datetime-local format (#35769)](https://github.com/mdn/content/commit/77e46a5b43f828fcc6bd30facddc6fc4bfe84f9b)
- [chore(short-title): HTML and HTML attributes (#35336)](https://github.com/mdn/content/commit/067a40e4ed27ea6e1f3b8bbfec15cd9dc3078f4c)
- [Convert noteblocks for web/html/attributes folder (#35084)](https://github.com/mdn/content/commit/aee2bd82de11cb7331134e48e8bd548bbedafcc5)
- [Fix syntax section structure of various references (#34332)](https://github.com/mdn/content/commit/8ac73df2fbe2c88d8649fcb006dcde098616c723)
- [HTML(min): Fix typo (#33139)](https://github.com/mdn/content/commit/4f001002691c7f16785c8fa191eff40a59a47cbb)