### PR TITLE
update(HTML): web/html/element/area

### DIFF
--- a/files/uk/web/html/element/area/index.md
+++ b/files/uk/web/html/element/area/index.md
@@ -1,5 +1,5 @@
 ---
-title: "<area> – Елемент області на карті зображення"
+title: <area> – Елемент області на карті зображення
 slug: Web/HTML/Element/area
 page-type: html-element
 browser-compat: html.elements.area
@@ -60,7 +60,7 @@ browser-compat: html.elements.area
     - `unsafe-url`: Посилач уміщатиме походження _та_ шлях (але не [фрагмент](/uk/docs/Web/API/HTMLAnchorElement/hash), не [пароль](/uk/docs/Web/API/HTMLAnchorElement/password) і не [ім'я користувача](/uk/docs/Web/API/HTMLAnchorElement/username)).
       **Це значення є небезпечним**, оскільки воно випускає походження та шляхи з ресурсів, захищених TLS, до незахищених походжень.
 
-- `rel`
+- [`rel`](/uk/docs/Web/HTML/Attributes/rel)
   - : Для якорів, що вміщають атрибут [`href`](#href), цей атрибут визначає відношення об'єкта-цілі до об'єкта-посилання.
     Значення – список типів посилань, розділених пробілами.
     Значення та їхня семантика реєструються певним органом, що може мати значення для автора документа.
@@ -81,7 +81,8 @@ browser-compat: html.elements.area
 
     Цей атрибут слід використовувати лише тоді, коли присутній атрибут [`href`](#href).
 
-    > **Примітка:** Задання на елементах `<area>` `target="_blank"` неявно задає таку ж логіку `rel`, як задання [`rel="noopener"`](/uk/docs/Web/HTML/Attributes/rel/noopener), який не задає `window.opener`. Дивіться статус підтримки у [Сумісності з браузерами](#sumisnist-iz-brauzeramy).
+    > [!NOTE]
+    > Задання на елементах `<area>` `target="_blank"` неявно задає таку ж логіку `rel`, як задання [`rel="noopener"`](/uk/docs/Web/HTML/Attributes/rel/noopener), який не задає `window.opener`. Дивіться статус підтримки у [Сумісності з браузерами](#sumisnist-iz-brauzeramy).
 
 ## Приклади
 
@@ -100,7 +101,7 @@ browser-compat: html.elements.area
 </map>
 <img
   usemap="#primary"
-  src="https://via.placeholder.com/350x150"
+  src="https://dummyimage.com/350x150"
   alt="350 x 150 pic" />
 ```
 


### PR DESCRIPTION
Оригінальний вміст: ["&lt;area&gt; – Елемент області на карті зображення"@MDN](https://developer.mozilla.org/en-us/docs/Web/HTML/Element/area), [сирці "&lt;area&gt; – Елемент області на карті зображення"@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/html/element/area/index.md)

Нові зміни:
- [Convert noteblocks for web/html folder (#35114)](https://github.com/mdn/content/commit/9c09b183a5ce844a75c2f22e909d03f71ca329fc)
- [Replace placeholder.com service with dummyimage (#34568)](https://github.com/mdn/content/commit/6f361249ffb14fd9e82f6bd369d7c7889eeb9475)
- [HTML element attr list should link to attr page (#34523)](https://github.com/mdn/content/commit/991385e7cfb9ac8589332b07aadcc4b38edea512)