### PR TITLE
update(HTML): web/html/element/optgroup

### DIFF
--- a/files/uk/web/html/element/optgroup/index.md
+++ b/files/uk/web/html/element/optgroup/index.md
@@ -1,5 +1,5 @@
 ---
-title: "<optgroup> – елемент групи варіантів"
+title: <optgroup> – елемент групи варіантів
 slug: Web/HTML/Element/optgroup
 page-type: html-element
 browser-compat: html.elements.optgroup
@@ -11,13 +11,14 @@ browser-compat: html.elements.optgroup
 
 {{EmbedInteractiveExample("pages/tabbed/optgroup.html", "tabbed-standard")}}
 
-> **Примітка:** Елементи optgroup не можна вкладати один в одного.
+> [!NOTE]
+> Елементи optgroup не можна вкладати один в одного.
 
 ## Атрибути
 
 Цей елемент приймає [глобальні атрибути](/uk/docs/Web/HTML/Global_attributes).
 
-- `disabled`
+- [`disabled`](/uk/docs/Web/HTML/Attributes/disabled)
   - : Якщо задано цей Булів атрибут, то жоден з елементів цієї групи варіантів не може бути вибраним. Зазвичай браузери позначають такі контрольні елементи сірим кольором і не передають їм жодних браузерних подій, таких як клацання мишею або події, пов'язані з фокусом.
 - `label`
   - : Назва групи варіантів, яку браузер може використовувати при позначенні варіантів у користувацькому інтерфейсі. Цей атрибут є обов'язковим, якщо цей елемент використовується.


### PR DESCRIPTION
Оригінальний вміст: ["&lt;optgroup&gt; – елемент групи варіантів"@MDN](https://developer.mozilla.org/en-us/docs/Web/HTML/Element/optgroup), [сирці "&lt;optgroup&gt; – елемент групи варіантів"@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/html/element/optgroup/index.md)

Нові зміни:
- [Convert noteblocks for web/html/element folder (#35085)](https://github.com/mdn/content/commit/b7955e77cd4293adf45ef23686df50b0305f02ad)
- [HTML element attr list should link to attr page (#34523)](https://github.com/mdn/content/commit/991385e7cfb9ac8589332b07aadcc4b38edea512)