### PR TITLE
update(JS): web/javascript/reference/operators/destructuring_assignment

### DIFF
--- a/files/uk/web/javascript/reference/operators/destructuring_assignment/index.md
+++ b/files/uk/web/javascript/reference/operators/destructuring_assignment/index.md
@@ -116,7 +116,8 @@ const obj = { a: 1, b: 2 };
 // Властивості `a` й `b` присвоюються властивостям `numbers`
 ```
 
-> **Примітка:** Дужки `( ... )` навколо інструкції присвоєння є обов'язковими, коли деструктурування присвоєння літерала об'єкта використовується без оголошення.
+> [!NOTE]
+> Дужки `( ... )` навколо інструкції присвоєння є обов'язковими, коли деструктурування присвоєння літерала об'єкта використовується без оголошення.
 >
 > `{ a, b } = { a: 1, b: 2 }` не є дійсним синтаксисом сам по собі, оскільки `{a, b}` зліва вважається блоком коду, а не літералом об'єкта, згідно з правилами [інструкцій-виразів](/uk/docs/Web/JavaScript/Reference/Statements/Expression_statement). Проте `({ a, b } = { a: 1, b: 2 })` є дійсним, як і `const { a, b } = { a: 1, b: 2 }`.
 >
@@ -306,7 +307,7 @@ function parseProtocol(url) {
   // ["https://webdoky.org/uk/docs/Web/JavaScript",
   // "https", "webdoky.org", "uk/docs/Web/JavaScript"]
 
-  const [, protocol, fullhost, fullpath] = parsedURL;
+  const [, protocol, fullHost, fullPath] = parsedURL;
   return protocol;
 }
 


### PR DESCRIPTION
Оригінальний вміст: [Присвоєння з деструктуруванням@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment), [сирці Присвоєння з деструктуруванням@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/operators/destructuring_assignment/index.md)

Нові зміни:
- [Fix typos and pseudo-typos 4 (#36245)](https://github.com/mdn/content/commit/2c762771070a207d410a963166adf32213bc3a45)
- [Convert noteblocks for web/javascript/reference/operators folder (#35092)](https://github.com/mdn/content/commit/8cb0caef8175e1772f13ef7bc761f9616e2c5a4b)
- [Renamed "bracket" to "parenthesis" (#29481)](https://github.com/mdn/content/commit/e3faa375b0179de77a5eff00074e3d168a0a904c)