### PR TITLE
update(JS): web/javascript/reference/global_objects/math/exp

### DIFF
--- a/files/uk/web/javascript/reference/global_objects/math/exp/index.md
+++ b/files/uk/web/javascript/reference/global_objects/math/exp/index.md
@@ -9,7 +9,11 @@ browser-compat: javascript.builtins.Math.exp
 
 Статичний метод **`Math.exp()`** повертає число [e](/uk/docs/Web/JavaScript/Reference/Global_Objects/Math/E), піднесене до степеня, заданого переданим числом. Тобто
 
-<math display="block"><semantics><mrow><mrow><mo lspace="0em" rspace="0.16666666666666666em">𝙼𝚊𝚝𝚑.𝚎𝚡𝚙</mo><mo stretchy="false">(</mo><mi>𝚡</mi><mo stretchy="false">)</mo></mrow><mo>=</mo><msup><mi mathvariant="normal">e</mi><mi>x</mi></msup></mrow><annotation encoding="TeX">\mathtt{\operatorname{Math.exp}(x)} = \mathrm{e}^x</annotation></semantics></math>
+<!-- prettier-ignore-start -->
+<math display="block">
+  <semantics><mrow><mrow><mo lspace="0em" rspace="0.16666666666666666em">𝙼𝚊𝚝𝚑.𝚎𝚡𝚙</mo><mo stretchy="false">(</mo><mi>𝚡</mi><mo stretchy="false">)</mo></mrow><mo>=</mo><msup><mi mathvariant="normal">e</mi><mi>x</mi></msup></mrow><annotation encoding="TeX">\mathtt{\operatorname{Math.exp}(x)} = \mathrm{e}^x</annotation></semantics>
+</math>
+<!-- prettier-ignore-end -->
 
 {{EmbedInteractiveExample("pages/js/math-exp.html")}}
 


### PR DESCRIPTION
Оригінальний вміст: [Math.exp()@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Global_Objects/Math/exp), [сирці Math.exp()@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/global_objects/math/exp/index.md)

Нові зміни:
- [Format block MathML (#34751)](https://github.com/mdn/content/commit/761b9047d78876cbd153be811efb1aa77b419877)
- [Format and clean up MathML (#34430)](https://github.com/mdn/content/commit/4f263d8dfb90fa2253e090ee339ae14d1907fa63)