### PR TITLE
update(JS): web/javascript/reference/global_objects/object/defineproperty

### DIFF
--- a/files/uk/web/javascript/reference/global_objects/object/defineproperty/index.md
+++ b/files/uk/web/javascript/reference/global_objects/object/defineproperty/index.md
@@ -382,20 +382,20 @@ const pattern = {
     return "Я завжди повертаю цей рядок, незалежно від того, що мені присвоєно";
   },
   set() {
-    this.myname = "це рядок із моїм іменем";
+    this.myName = "це рядок із моїм іменем";
   },
 };
 
 function TestDefineSetAndGet() {
-  Object.defineProperty(this, "myproperty", pattern);
+  Object.defineProperty(this, "myProperty", pattern);
 }
 
 const instance = new TestDefineSetAndGet();
-instance.myproperty = "test";
-console.log(instance.myproperty);
+instance.myProperty = "test";
+console.log(instance.myProperty);
 // Я завжди повертаю цей рядок, незалежно від того, що мені присвоєно
 
-console.log(instance.myname); // це рядок із моїм іменем
+console.log(instance.myName); // це рядок із моїм іменем
 ```
 
 ### Успадкування властивостей


### PR DESCRIPTION
Оригінальний вміст: [Object.defineProperty()@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty), [сирці Object.defineProperty()@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/global_objects/object/defineproperty/index.md)

Нові зміни:
- [Fix typos and pseudo-typos 4 (#36245)](https://github.com/mdn/content/commit/2c762771070a207d410a963166adf32213bc3a45)