### PR TITLE
update(JS): web/javascript/reference/global_objects/regexp/test

### DIFF
--- a/files/uk/web/javascript/reference/global_objects/regexp/test/index.md
+++ b/files/uk/web/javascript/reference/global_objects/regexp/test/index.md
@@ -53,8 +53,8 @@ console.log(result); // true
 
 ```js
 function testInput(re, str) {
-  const midstring = re.test(str) ? "містить" : "не містить";
-  console.log(`${str} ${midstring} ${re.source}`);
+  const midString = re.test(str) ? "містить" : "не містить";
+  console.log(`${str} ${midString} ${re.source}`);
 }
 ```
 
@@ -64,7 +64,8 @@ function testInput(re, str) {
 
 Подальші виклики `test(str)` відновлять пошук у `str`, починаючи від `lastIndex`. Властивість `lastIndex` збільшуватиметься далі щоразу, коли `test()` повертатиме `true`.
 
-> **Примітка:** Поки `test()` повертає `true`, `lastIndex` _не_ буде скинуто – навіть при перевірці іншого рядка!
+> [!NOTE]
+> Поки `test()` повертає `true`, `lastIndex` _не_ буде скинуто – навіть при перевірці іншого рядка!
 
 Коли `test()` повертає `false`, властивість `lastIndex` регулярного виразу виклику скидається до `0`.
 


### PR DESCRIPTION
Оригінальний вміст: [RegExp.prototype.test()@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Global_Objects/RegExp/test), [сирці RegExp.prototype.test()@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/global_objects/regexp/test/index.md)

Нові зміни:
- [Fix typos and pseudo-typos 4 (#36245)](https://github.com/mdn/content/commit/2c762771070a207d410a963166adf32213bc3a45)
- [Convert noteblocks for web/javascript/reference/global_objects folder (#35091)](https://github.com/mdn/content/commit/8421c0cd94fa5aa237c833ac6d24885edbc7d721)