### PR TITLE
update(JS): web/javascript/reference/global_objects/string/codepointat

### DIFF
--- a/files/uk/web/javascript/reference/global_objects/string/codepointat/index.md
+++ b/files/uk/web/javascript/reference/global_objects/string/codepointat/index.md
@@ -66,7 +66,7 @@ for (let i = 0; i < str.length; i++) {
 // '1f40e', 'dc0e', '1f471', 'dc71', '2764'
 ```
 
-Натомість краще вжити інструкцію [`for...of`](/uk/docs/Web/JavaScript/Guide/Loops_and_iteration#instruktsiia-forof) або [розгорнути рядок](/uk/docs/Web/JavaScript/Reference/Operators/Spread_syntax), – обидва способи закликають [`@@iterator`](/uk/docs/Web/JavaScript/Reference/Global_Objects/String/@@iterator) рядка, що ітерує за кодовими точками. Потім – використати `codePointAt(0)`, щоб отримати кодову точку кожного елемента.
+Натомість краще вжити інструкцію [`for...of`](/uk/docs/Web/JavaScript/Guide/Loops_and_iteration#instruktsiia-forof) або [розгорнути рядок](/uk/docs/Web/JavaScript/Reference/Operators/Spread_syntax), – обидва способи закликають [`[Symbol.iterator]()`](/uk/docs/Web/JavaScript/Reference/Global_Objects/String/Symbol.iterator) рядка, що ітерує за кодовими точками. Потім – використати `codePointAt(0)`, щоб отримати кодову точку кожного елемента.
 
 ```js
 for (const codePoint of str) {


### PR DESCRIPTION
Оригінальний вміст: [String.prototype.codePointAt()@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Global_Objects/String/codePointAt), [сирці String.prototype.codePointAt()@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/global_objects/string/codepointat/index.md)

Нові зміни:
- [Remove all `@@notation` from page slugs (#34824)](https://github.com/mdn/content/commit/6fbdb78c1362fae31fbd545f4b2d9c51987a6bca)
- [Remove all @@notation in JS prose (#34817)](https://github.com/mdn/content/commit/6e93ec8fc9e1f3bd83bf2f77e84e1a39637734f8)