### PR TITLE
update(JS): web/javascript/reference/global_objects/string/substr

### DIFF
--- a/files/uk/web/javascript/reference/global_objects/string/substr/index.md
+++ b/files/uk/web/javascript/reference/global_objects/string/substr/index.md
@@ -11,7 +11,8 @@ browser-compat: javascript.builtins.String.substr
 
 Метод **`substr()`** (підрядок) значень {{jsxref("String")}} повертає порцію рядка, яка починається за вказаним індексом і продовжується протягом заданої кількості символів.
 
-> **Примітка:** `substr` не є частиною специфікації ECMAScript: він означений в [Додатку B: Додаткових можливостях ECMAScript для веббраузерів](https://tc39.es/ecma262/multipage/additional-ecmascript-features-for-web-browsers.html), котрий є нормативним необов'язковим для небраузерних платформ. Таким чином, краще користуватися замість нього стандартними методами [`String.prototype.substring()`](/uk/docs/Web/JavaScript/Reference/Global_Objects/String/substring) і [`String.prototype.slice()`](/uk/docs/Web/JavaScript/Reference/Global_Objects/String/slice), аби код виходив якнайкраще кросплатформовим. [Сторінка `String.prototype.substring()`](/uk/docs/Web/JavaScript/Reference/Global_Objects/String/substring#riznytsia-mizh-metodamy-substring-ta-substr) містить порівняння цих трьох методів.
+> [!NOTE]
+> Метод `substr` не є частиною специфікації ECMAScript: він означений в [Додатку B: Додаткових можливостях ECMAScript для веббраузерів](https://tc39.es/ecma262/multipage/additional-ecmascript-features-for-web-browsers.html), котрий є нормативним необов'язковим для небраузерних платформ. Таким чином, краще користуватися замість нього стандартними методами [`String.prototype.substring()`](/uk/docs/Web/JavaScript/Reference/Global_Objects/String/substring) і [`String.prototype.slice()`](/uk/docs/Web/JavaScript/Reference/Global_Objects/String/slice), аби код виходив якнайкраще кросплатформовим. [Сторінка `String.prototype.substring()`](/uk/docs/Web/JavaScript/Reference/Global_Objects/String/substring#riznytsia-mizh-metodamy-substring-ta-substr) містить порівняння цих трьох методів.
 
 {{EmbedInteractiveExample("pages/js/string-substr.html")}}
 
@@ -49,6 +50,8 @@ substr(start, length)
 ## Приклади
 
 ### Застосування substr()
+
+<!-- cSpell:ignore ozilla -->
 
 ```js
 const aString = "Mozilla";


### PR DESCRIPTION
Оригінальний вміст: [String.prototype.substr()@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Global_Objects/String/substr), [сирці String.prototype.substr()@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/global_objects/string/substr/index.md)

Нові зміни:
- [Fix typos and pseudo-typos 4 (#36245)](https://github.com/mdn/content/commit/2c762771070a207d410a963166adf32213bc3a45)