### PR TITLE
update(JS): web/javascript/reference/global_objects/string/substring

### DIFF
--- a/files/uk/web/javascript/reference/global_objects/string/substring/index.md
+++ b/files/uk/web/javascript/reference/global_objects/string/substring/index.md
@@ -47,6 +47,8 @@ substring(indexStart, indexEnd)
 
 Наступний приклад використовує метод `substring()` для показування символів з рядка `'Mozilla'`:
 
+<!-- cSpell:ignore Mozill -->
+
 ```js
 const anyString = "Mozilla";
 
@@ -63,6 +65,8 @@ console.log(anyString.substring(0, 10)); // 'Mozilla'
 ### Застосування методу substring() з властивістю довжини
 
 Наступний приклад застосовує метод `substring()` з властивістю {{jsxref("String/length", "length")}} для вибирання останніх символів певного рядка. Ймовірно запам'ятати цей метод буде простіше аніж попередні приклади, оскільки тут не потрібно знати початковий та кінцевий індекси.
+
+<!-- cSpell:ignore illa zilla -->
 
 ```js
 const text = "Mozilla";


### PR DESCRIPTION
Оригінальний вміст: [String.prototype.substring()@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Global_Objects/String/substring), [сирці String.prototype.substring()@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/global_objects/string/substring/index.md)

Нові зміни:
- [Fix typos and pseudo-typos 4 (#36245)](https://github.com/mdn/content/commit/2c762771070a207d410a963166adf32213bc3a45)