### PR TITLE
update(JS): web/javascript/reference/global_objects/proxy

### DIFF
--- a/files/uk/web/javascript/reference/global_objects/proxy/index.md
+++ b/files/uk/web/javascript/reference/global_objects/proxy/index.md
@@ -148,7 +148,8 @@ console.log(proxy3.message2); // світе
 - {{jsxref("Proxy/Proxy", "Proxy()")}}
   - : Створює новий об'єкт `Proxy`.
 
-> **Примітка:** Властивості `Proxy.prototype` немає, тож примірники `Proxy` не мають жодних особливих властивостей або методів.
+> [!NOTE]
+> Властивості `Proxy.prototype` немає, тож примірники `Proxy` не мають жодних особливих властивостей або методів.
 
 ## Статичні методи
 
@@ -307,20 +308,20 @@ const view = new Proxy(
     selected: null,
   },
   {
-    set(obj, prop, newval) {
-      const oldval = obj[prop];
+    set(obj, prop, newVal) {
+      const oldVal = obj[prop];
 
       if (prop === "selected") {
-        if (oldval) {
-          oldval.setAttribute("aria-selected", "false");
+        if (oldVal) {
+          oldVal.setAttribute("aria-selected", "false");
         }
-        if (newval) {
-          newval.setAttribute("aria-selected", "true");
+        if (newVal) {
+          newVal.setAttribute("aria-selected", "true");
         }
       }
 
       // Усталена логіка для збереження значення
-      obj[prop] = newval;
+      obj[prop] = newVal;
 
       // Повідомити про успіх
       return true;


### PR DESCRIPTION
Оригінальний вміст: [Proxy@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Global_Objects/Proxy), [сирці Proxy@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/global_objects/proxy/index.md)

Нові зміни:
- [Fix typos and pseudo-typos 4 (#36245)](https://github.com/mdn/content/commit/2c762771070a207d410a963166adf32213bc3a45)
- [Convert noteblocks for web/javascript/reference/global_objects folder (#35091)](https://github.com/mdn/content/commit/8421c0cd94fa5aa237c833ac6d24885edbc7d721)