### PR TITLE
update(CSS): web/css/css_backgrounds_and_borders

### DIFF
--- a/files/uk/web/css/css_backgrounds_and_borders/index.md
+++ b/files/uk/web/css/css_backgrounds_and_borders/index.md
@@ -122,7 +122,7 @@ spec-urls: https://drafts.csswg.org/css-backgrounds/
 - Властивість {{cssxref("box-decoration-break")}}
 - Властивість {{cssxref("text-shadow")}}
 
-- Функція CSS {{cssxref("url", "url()")}}
+- Тип CSS {{cssxref("url_value", "&lt;url&gt;")}}
 - Тип даних [`<color>`](/uk/docs/Web/CSS/color)
 - Тип даних [`<image>`](/uk/docs/Web/CSS/image)
 - Тип даних [`<position>`](/uk/docs/Web/CSS/position)


### PR DESCRIPTION
Оригінальний вміст: [Фони та межі CSS@MDN](https://developer.mozilla.org/en-us/docs/Web/CSS/CSS_backgrounds_and_borders), [сирці Фони та межі CSS@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/css/css_backgrounds_and_borders/index.md)

Нові зміни:
- [fix(css): new pages for &lt;url&gt; and url() (#35486)](https://github.com/mdn/content/commit/5178e1e7c9edf0c9c652275ae62f090042ce2422)
- [Fix code-links containing spaces in CSS/JS (#35075)](https://github.com/mdn/content/commit/46a2eda1ce316d5c2c789104c28bc4fdaee5ab8b)