### PR TITLE
update(CSS): web/css/css_flexible_box_layout

### DIFF
--- a/files/uk/web/css/css_flexible_box_layout/index.md
+++ b/files/uk/web/css/css_flexible_box_layout/index.md
@@ -7,9 +7,9 @@ spec-urls: https://drafts.csswg.org/css-flexbox/
 
 {{CSSRef}}
 
-Модуль **Компонування гнучкої рамки CSS** (також відомий під назвою "флексбокс") визначає рамкову модель CSS, оптимізовану для дизайну користувацьких інтерфейсів та компонування елементів в одному вимірі. При моделі гнучкого компонування, дочірні елементи гнучкого контейнера можуть бути розкладені в будь-якому напрямку, а їх розміри є "гнучкими", можуть або збільшуватися – для заповнення невикористаного простору, або зменшуватися – для запобігання переповнення батьківського елемента. Можна легко керувати як горизонтальним, так і вертикальним шикуванням дочірніх елементів.
+Модуль **Компонування гнучкої рамки CSS** (також відомий під назвою "флексбокс") визначає рамкову модель CSS, оптимізовану для дизайну користувацьких інтерфейсів та компонування елементів в одному вимірі. При моделі гнучкого компонування, дочірні елементи гнучкого контейнера можуть бути розкладені в будь-якому напрямку, а їх розміри є "гнучкими", можуть або збільшуватися – для заповнення невикористаного простору, або зменшуватися – для запобігання переповнення батьківського елемента. Можна легко керувати як горизонтальним, так і вертикальним вирівнюванням дочірніх елементів.
 
-## Базовий приклад
+## Компонування гнучкої рамки в дії
 
 В наступному прикладі контейнер отримує `display: flex`, що означає, що три дочірні елементи стають гнучкими елементами. Значенням `justify-content` стало `space-between`, щоб розташувати елементи рівномірно на головній осі. Однакова кількість простору розташовується між всіма елементами, а лівий і правий елементи знаходяться на краях гнучкого контейнера. Також можна спостерігати, що елементи розтягуються вздовж поперечної осі, адже значення `align-items` – `stretch`. Елементи розтягуються до висоти гнучкого контейнера, тобто кожен з них стає настільки ж високим, як найвищий елемент.
 
@@ -19,6 +19,9 @@ spec-urls: https://drafts.csswg.org/css-flexbox/
 
 ### Властивості
 
+- {{cssxref("align-content")}}
+- {{cssxref("align-items")}}
+- {{cssxref("align-self")}}
 - {{cssxref("flex")}}
 - {{cssxref("flex-basis")}}
 - {{cssxref("flex-direction")}}
@@ -26,38 +29,81 @@ spec-urls: https://drafts.csswg.org/css-flexbox/
 - {{cssxref("flex-grow")}}
 - {{cssxref("flex-shrink")}}
 - {{cssxref("flex-wrap")}}
-- {{cssxref("order")}}
-
-### Властивості для шикування
-
-Властивості `align-content`, `align-self`, `align-items` і `justify-content` спершу з'явилися в специфікації Флексбоксу, однак тепер – означені в Рамковому шикуванні. Специфікація Флексбоксу тепер посилається на специфікацію Рамкового шикування щодо актуальних означень. Крім цього, тепер в Рамковому шикуванні означені додаткові властивості шикування.
-
 - {{cssxref("justify-content")}}
-- {{cssxref("align-content")}}
-- {{cssxref("align-items")}}
-- {{cssxref("align-self")}}
-- {{cssxref("place-content")}}
-- {{cssxref("place-items")}}
-- {{cssxref("row-gap")}}
-- {{cssxref("column-gap")}}
-- {{cssxref("gap")}}
+
+### Терміни глосарія
+
+- {{Glossary("Flexbox", "Флексбокс")}}
+- {{Glossary("Flex Container", "Гнучкий контейнер")}}
+- {{Glossary("Flex Item", "Гнучкий елемент")}}
+- {{Glossary("Main Axis", "Головна вісь")}}
+- {{Glossary("Cross Axis", "Перехресна вісь")}}
+- {{Glossary("Flex", "Гнучкий")}}
 
 ## Посібники
 
 - [Базові концепції флексбоксу](/uk/docs/Web/CSS/CSS_flexible_box_layout/Basic_concepts_of_flexbox)
+
   - : Огляд можливостей Флексбоксу
+
 - [Взаємини між флексбоксом та іншими способами компонування](/uk/docs/Web/CSS/CSS_flexible_box_layout/Relationship_of_flexbox_to_other_layout_methods)
+
   - : Порівняння Флексбоксу з іншими способами компонування та іншими специфікаціями CSS
-- [Шикування елементів у гнучкому контейнері](/uk/docs/Web/CSS/CSS_flexible_box_layout/Aligning_items_in_a_flex_container)
-  - : Те, як властивості Рамкового шикування працюють зі Флексбоксом.
+
+- [Вирівнювання елементів у гнучкому контейнері](/uk/docs/Web/CSS/CSS_flexible_box_layout/Aligning_items_in_a_flex_container)
+
+  - : Те, як властивості рамкового вирівнювання працюють зі Флексбоксом.
+
 - [Упорядкування гнучких елементів](/uk/docs/Web/CSS/CSS_flexible_box_layout/Ordering_flex_items)
+
   - : Пояснення різних способів для змінювання порядку й напряму елементів, а також роз'яснення потенційних негативних наслідків цього.
+
 - [Контроль співвідношень гнучких елементів за головною віссю](/uk/docs/Web/CSS/CSS_flexible_box_layout/Controlling_ratios_of_flex_items_along_the_main_axis)
+
   - : Пояснення властивостей flex-grow, flex-shrink і flex-basis.
+
 - [Освоєння загортання гнучких елементів](/uk/docs/Web/CSS/CSS_flexible_box_layout/Mastering_wrapping_of_flex_items)
+
   - : Про те, як створювати гнучкі контейнери з багатьма рядами й контролювати виведення елементів на цих рядах.
+
 - [Типові ситуації для використання флексбоксу](/uk/docs/Web/CSS/CSS_flexible_box_layout/Typical_use_cases_of_flexbox)
+
   - : Поширені патерни проєктування, котрі є типовими випадками для використання Флексбоксу.
+
+- [Компонування CSS – флексбокс](/uk/docs/Learn/CSS/CSS_layout/Flexbox)
+
+  - : Дізнайтеся, як користуватися для створення макетів у вебі компонуванням флексбоксу.
+
+- [Рамкове вирівнювання у флексбоксі](/uk/docs/Web/CSS/CSS_box_alignment/Box_alignment_in_flexbox)
+
+  - : Детально описує можливості [Рамкового вирівнювання CSS](/uk/docs/Web/CSS/CSS_box_alignment), що є притаманними саме флексбоксу.
+
+## Споріднені концепції
+
+[Модуль Виведення CSS](/uk/docs/Web/CSS/CSS_display)
+
+- {{cssxref("display")}}
+- {{cssxref("order")}}
+
+Модуль [Рамкового вирівнювання CSS](/uk/docs/Web/CSS/CSS_box_alignment)
+
+- {{cssxref("align-content")}}
+- {{cssxref("align-items")}}
+- {{cssxref("align-self")}}
+- {{cssxref("column-gap")}}
+- {{cssxref("gap")}}
+- {{cssxref("justify-items")}}
+- {{cssxref("place-content")}}
+- {{cssxref("place-items")}}
+- {{cssxref("row-gap")}}
+
+Модуль [Розмірів рамок CSS](/uk/docs/Web/CSS/CSS_box_sizing)
+
+- {{cssxref("aspect-ratio")}}
+- Значення {{cssxref("max-content")}}
+- Значення {{cssxref("min-content")}}
+- Значення {{cssxref("fit-content")}}
+- Термін глосарія: {{glossary("intrinsic size", "природний розмір")}}
 
 ## Специфікації
 
@@ -65,12 +111,5 @@ spec-urls: https://drafts.csswg.org/css-flexbox/
 
 ## Дивіться також
 
-- Модуль [Відображення CSS](/uk/docs/Web/CSS/CSS_display)
+- Модуль [Напрямків письма CSS](/uk/docs/Web/CSS/CSS_writing_modes)
 - [Використання синтаксису із кількома значеннями у Відображенні CSS](/uk/docs/Web/CSS/display/multi-keyword_syntax_of_display)
-- Терміни Глосарія:
-  - {{Glossary("Flexbox", "Флексбокс")}}
-  - {{Glossary("Flex Container", "Гнучкий контейнер")}}
-  - {{Glossary("Flex Item", "Гнучкий елемент")}}
-  - {{Glossary("Main Axis", "Головна вісь")}}
-  - {{Glossary("Cross Axis", "Перехресна вісь")}}
-  - {{Glossary("Flex", "Гнучкий")}}

--- a/files/uk/web/css/css_flexible_box_layout/index.md
+++ b/files/uk/web/css/css_flexible_box_layout/index.md
@@ -13,7 +13,32 @@ spec-urls: https://drafts.csswg.org/css-flexbox/
 
 В наступному прикладі контейнер отримує `display: flex`, що означає, що три дочірні елементи стають гнучкими елементами. Значенням `justify-content` стало `space-between`, щоб розташувати елементи рівномірно на головній осі. Однакова кількість простору розташовується між всіма елементами, а лівий і правий елементи знаходяться на краях гнучкого контейнера. Також можна спостерігати, що елементи розтягуються вздовж поперечної осі, адже значення `align-items` – `stretch`. Елементи розтягуються до висоти гнучкого контейнера, тобто кожен з них стає настільки ж високим, як найвищий елемент.
 
-{{EmbedGHLiveSample("css-examples/flexbox/basics/simple-example.html", '100%', 600)}}
+```html live-sample___simple-example
+<div class="box">
+  <div>Один</div>
+  <div>Два</div>
+  <div>Три <br />містить <br />додатковий <br />текст</div>
+</div>
+```
+
+```css live-sample___simple-example
+body {
+  font-family: sans-serif;
+}
+.box {
+  border: 2px dotted rgb(96 139 168);
+  display: flex;
+  justify-content: space-between;
+}
+.box > * {
+  border: 2px solid rgb(96 139 168);
+  border-radius: 5px;
+  background-color: rgb(96 139 168 / 0.2);
+  padding: 1em;
+}
+```
+
+{{EmbedLiveSample("simple-example")}}
 
 ## Довідка
 
@@ -43,39 +68,22 @@ spec-urls: https://drafts.csswg.org/css-flexbox/
 ## Посібники
 
 - [Базові концепції флексбоксу](/uk/docs/Web/CSS/CSS_flexible_box_layout/Basic_concepts_of_flexbox)
-
   - : Огляд можливостей Флексбоксу
-
 - [Взаємини між флексбоксом та іншими способами компонування](/uk/docs/Web/CSS/CSS_flexible_box_layout/Relationship_of_flexbox_to_other_layout_methods)
-
   - : Порівняння Флексбоксу з іншими способами компонування та іншими специфікаціями CSS
-
 - [Вирівнювання елементів у гнучкому контейнері](/uk/docs/Web/CSS/CSS_flexible_box_layout/Aligning_items_in_a_flex_container)
-
   - : Те, як властивості рамкового вирівнювання працюють зі Флексбоксом.
-
 - [Упорядкування гнучких елементів](/uk/docs/Web/CSS/CSS_flexible_box_layout/Ordering_flex_items)
-
   - : Пояснення різних способів для змінювання порядку й напряму елементів, а також роз'яснення потенційних негативних наслідків цього.
-
 - [Контроль співвідношень гнучких елементів за головною віссю](/uk/docs/Web/CSS/CSS_flexible_box_layout/Controlling_ratios_of_flex_items_along_the_main_axis)
-
   - : Пояснення властивостей flex-grow, flex-shrink і flex-basis.
-
 - [Освоєння загортання гнучких елементів](/uk/docs/Web/CSS/CSS_flexible_box_layout/Mastering_wrapping_of_flex_items)
-
   - : Про те, як створювати гнучкі контейнери з багатьма рядами й контролювати виведення елементів на цих рядах.
-
 - [Типові ситуації для використання флексбоксу](/uk/docs/Web/CSS/CSS_flexible_box_layout/Typical_use_cases_of_flexbox)
-
   - : Поширені патерни проєктування, котрі є типовими випадками для використання Флексбоксу.
-
 - [Компонування CSS – флексбокс](/uk/docs/Learn/CSS/CSS_layout/Flexbox)
-
   - : Дізнайтеся, як користуватися для створення макетів у вебі компонуванням флексбоксу.
-
 - [Рамкове вирівнювання у флексбоксі](/uk/docs/Web/CSS/CSS_box_alignment/Box_alignment_in_flexbox)
-
   - : Детально описує можливості [Рамкового вирівнювання CSS](/uk/docs/Web/CSS/CSS_box_alignment), що є притаманними саме флексбоксу.
 
 ## Споріднені концепції


### PR DESCRIPTION
Оригінальний вміст: [Компонування гнучкої рамки CSS@MDN](https://developer.mozilla.org/en-us/docs/Web/CSS/CSS_flexible_box_layout), [сирці Компонування гнучкої рамки CSS@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/css/css_flexible_box_layout/index.md)

Нові зміни:
- [chore(learn): Move MDN Curriculum into Learning Area (#36967)](https://github.com/mdn/content/commit/5b20f5f4265f988f80f513db0e4b35c7e0cd70dc)
- [chore(css): Move CSS examples - Flexbox, Flow (#36671)](https://github.com/mdn/content/commit/8a7e911652fcb4a61cc95f458d53f39ad08c0946)
- [CSS flexbox module: add links to two guides (#34238)](https://github.com/mdn/content/commit/dbb206b01855808bffd7756bbc20100fefe4fbdb)
- [CSS module: flexible box layout (#34152)](https://github.com/mdn/content/commit/8291cdae8cedfccb786494a1364749b8cc9a9fc4)