### PR TITLE
update(CSS): web/css/css_selectors

### DIFF
--- a/files/uk/web/css/css_selectors/index.md
+++ b/files/uk/web/css/css_selectors/index.md
@@ -135,7 +135,7 @@ spec-urls: https://drafts.csswg.org/selectors/
 
   - : Вивчіть різні псевдокласи користувацького інтерфейсу, доступні для оформлення форм у різних станах.
 
-- [Віднаходження елементів DOM за допомогою селекторів](/uk/docs/Web/API/Document_object_model/Locating_DOM_elements_using_selectors)
+- [Віднаходження елементів DOM за допомогою селекторів](/uk/docs/Web/API/Document_Object_Model/Locating_DOM_elements_using_selectors)
 
   - : API селекторів дає змогу використовувати селектори в JavaScript для отримання вузлів елементів з DOM.
 
@@ -144,9 +144,7 @@ spec-urls: https://drafts.csswg.org/selectors/
 - Псевдоклас {{CSSXref(":popover-open")}}
 - Псевдоклас {{CSSXref(":state","state()")}}
 - Модуль [Вкладеності CSS](/uk/docs/Web/CSS/CSS_nesting)
-
-  - : [Селектор вкладеності `&`](/uk/docs/Web/CSS/Nesting_selector)
-
+  - [Селектор вкладеності `&`](/uk/docs/Web/CSS/Nesting_selector)
 - Модуль [Контексту CSS](/uk/docs/Web/CSS/CSS_scoping)
 
   - Псевдоклас {{CSSXref(":host")}}
@@ -179,7 +177,6 @@ spec-urls: https://drafts.csswg.org/selectors/
 - Інші [псевдоелементи](/uk/docs/Web/CSS/Pseudo-elements)
 
   - {{CSSxRef("::cue")}}
-  - {{CSSxRef("::cue-region")}}
 
 - Директива {{CSSXref("@namespace")}}
 


### PR DESCRIPTION
Оригінальний вміст: [Селектори CSS@MDN](https://developer.mozilla.org/en-us/docs/Web/CSS/CSS_selectors), [сирці Селектори CSS@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/css/css_selectors/index.md)

Нові зміни:
- [Fix bad DL (#35188)](https://github.com/mdn/content/commit/4904c4f3e4ea8f8efd27e9cf51b51d5c5a03de26)
- [WebVTT - general restructure to match normal API docs (#34034)](https://github.com/mdn/content/commit/3975bcf6caa09c9c5f7fddf2eef2be6c021d00f6)
- [Fix slug casing (#33744)](https://github.com/mdn/content/commit/e099e74fe5c09c46f0dfe044894692721a713d29)