### PR TITLE
update(CSS): web/css/css_text

### DIFF
--- a/files/uk/web/css/css_text/index.md
+++ b/files/uk/web/css/css_text/index.md
@@ -3,7 +3,6 @@ title: Текст CSS
 slug: Web/CSS/CSS_text
 page-type: css-module
 spec-urls:
-  - https://drafts.csswg.org/css-logical/
   - https://drafts.csswg.org/css-text/
   - https://drafts.csswg.org/css-text-4/
 ---
@@ -17,24 +16,67 @@ spec-urls:
 ### Властивості
 
 - {{cssxref("hanging-punctuation")}}
+- {{cssxref("hyphenate-character")}}
 - {{cssxref("hyphenate-limit-chars")}}
 - {{cssxref("hyphens")}}
 - {{cssxref("letter-spacing")}}
 - {{cssxref("line-break")}}
-- {{cssxref("overflow-wrap")}}
+- {{cssxref("overflow-wrap")}} (вкупі з псевдонімом `word-wrap`)
 - {{cssxref("tab-size")}}
 - {{cssxref("text-align")}}
 - {{cssxref("text-align-last")}}
 - {{cssxref("text-indent")}}
 - {{cssxref("text-justify")}}
-- {{cssxref("text-size-adjust")}}
+- {{cssxref("text-spacing-trim")}} {{Experimental_Inline}}
 - {{cssxref("text-transform")}}
 - {{cssxref("text-wrap")}}
+- {{cssxref("text-wrap-mode")}}
+- {{cssxref("text-wrap-style")}}
 - {{cssxref("white-space")}}
 - {{cssxref("white-space-collapse")}}
 - {{cssxref("word-break")}}
 - {{cssxref("word-spacing")}}
 
+Специфікація також визначає властивості `hyphenate-limit-last`, `hyphenate-limit-lines`, `hyphenate-limit-zone`, `line-padding`, `text-align-all`, `text-autospace`, `text-group-align`, `text-spacing`, `white-space-trim`, `word-space-transform`, `wrap-after`, `wrap-before` та `wrap-inside`, які не підтримуються жодним браузером.
+
+### Посібники
+
+- [Переведення на новий рядок і розривання тексту](/uk/docs/Web/CSS/CSS_text/Wrapping_breaking_text)
+  - : Посібник з різними способами, в які можна керувати в CSS текстом, що не вміщається.
+
+## Споріднені концепції
+
+### Властивості
+
+- {{cssxref("direction")}}
+- {{cssxref("font-feature-settings")}}
+- {{cssxref("initial-letter")}}
+- {{cssxref("orphans")}}
+- {{cssxref("text-combine-upright")}}
+- {{cssxref("text-orientation")}}
+- {{cssxref("text-overflow")}}
+- {{cssxref("text-size-adjust")}} {{Experimental_Inline}}
+- {{cssxref("unicode-bidi")}}
+- {{cssxref("widows")}}
+- {{cssxref("writing-mode")}}
+
+### Значення
+
+- {{cssxref("min-content")}}
+- {{cssxref("max-content")}}
+
+### HTML
+
+- {{htmlelement("pre")}}
+- {{htmlelement("wbr")}}
+
 ## Специфікації
 
 {{Specifications}}
+
+## Дивіться також
+
+- Модуль [Напрямків письма CSS](/uk/docs/Web/CSS/CSS_writing_modes)
+- Модуль [Переповнення CSS](/uk/docs/Web/CSS/CSS_overflow)
+- Модуль [Шрифтів CSS](/uk/docs/Web/CSS/CSS_fonts)
+- Модуль [Компонування рубі CSS](/uk/docs/Web/CSS/CSS_ruby_layout)

--- a/files/uk/web/css/css_text/index.md
+++ b/files/uk/web/css/css_text/index.md
@@ -21,7 +21,7 @@ spec-urls:
 - {{cssxref("hyphens")}}
 - {{cssxref("letter-spacing")}}
 - {{cssxref("line-break")}}
-- {{cssxref("overflow-wrap")}} (вкупі з псевдонімом `word-wrap`)
+- {{cssxref("overflow-wrap")}} (вкупі із псевдонімом `word-wrap`)
 - {{cssxref("tab-size")}}
 - {{cssxref("text-align")}}
 - {{cssxref("text-align-last")}}
@@ -41,8 +41,8 @@ spec-urls:
 
 ### Посібники
 
-- [Переведення на новий рядок і розривання тексту](/uk/docs/Web/CSS/CSS_text/Wrapping_breaking_text)
-  - : Посібник з різними способами, в які можна керувати в CSS текстом, що не вміщається.
+- [Перенесення на новий рядок і розривання тексту](/uk/docs/Web/CSS/CSS_text/Wrapping_breaking_text)
+  - : Посібник із різними способами керування переповненим текстом у CSS.
 
 ## Споріднені концепції
 


### PR DESCRIPTION
Оригінальний вміст: [Текст CSS@MDN](https://developer.mozilla.org/en-us/docs/Web/CSS/CSS_text), [сирці Текст CSS@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/css/css_text/index.md)

Нові зміни:
- [CSS module: css text (#36470)](https://github.com/mdn/content/commit/9a9907307112d53135fbf3863a316c8e7b8c1b55)
- [Add text-spacing-trim ref doc (#34484)](https://github.com/mdn/content/commit/46208a9448a1f51e40b3ee1dfe8dc8a657a74ccd)