### PR TITLE
update(CSS): web/css/css_transitions

### DIFF
--- a/files/uk/web/css/css_transitions/index.md
+++ b/files/uk/web/css/css_transitions/index.md
@@ -34,4 +34,5 @@ spec-urls: https://drafts.csswg.org/css-transitions/
 
 ## Дивіться також
 
-- Споріднені з Переходами CSS [Анімації CSS](/uk/docs/Web/CSS/CSS_animations) пропонують більш детальне керування анімованими властивостями.
+- Властивість {{cssxref("interpolate-size")}} і функція {{cssxref("calc-size()")}} для вмикання переходів до та від [значень природного розміру](/uk/docs/Glossary/Intrinsic_Size).
+- Модуль [Анімацій CSS](/uk/docs/Web/CSS/CSS_animations).


### PR DESCRIPTION
Оригінальний вміст: [Переходи CSS@MDN](https://developer.mozilla.org/en-us/docs/Web/CSS/CSS_transitions), [сирці Переходи CSS@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/css/css_transitions/index.md)

Нові зміни:
- [Editorial review: add interpolate-size and calc-size() (#35934)](https://github.com/mdn/content/commit/c0daf1f038fdbdb62d71bfdeaf3a0a083660792c)