### PR TITLE
update(HTML): web/html/element/script/type

### DIFF
--- a/files/uk/web/html/element/script/type/index.md
+++ b/files/uk/web/html/element/script/type/index.md
@@ -1,5 +1,5 @@
 ---
-title: "<script> – Атрибут type"
+title: <script> – Атрибут type
 slug: Web/HTML/Element/script/type
 page-type: html-attribute
 browser-compat: html.elements.script.type
@@ -16,7 +16,7 @@ browser-compat: html.elements.script.type
 - **Атрибут не заданий (усталено), порожній рядок або MIME-тип JavaScript**
   - : Вказує на те, що цей сценарій є "класичним сценарієм", що вміщає код JavaScript.
     Розробникам рекомендується пропускати цей атрибут, якщо сценарій вказує на код JavaScript, а не вказувати MIME-тип.
-    MIME-типи JavaScript [перераховані в специфікації типів медіа IANA](/uk/docs/Web/HTTP/Basics_of_HTTP/MIME_types#textjavascript).
+    MIME-типи JavaScript [перераховані в специфікації типів медіа IANA](/uk/docs/Web/HTTP/MIME_types#textjavascript).
 - [`importmap`](/uk/docs/Web/HTML/Element/script/type/importmap)
   - : Це значення вказує на те, що тіло цього елемента містить карту імпортування.
     Карта імпортування – це об'єкт JSON, який розробники можуть використовувати для керування тим, як браузер розв'язує специфікатори модулів при імпортуванні [модулів JavaScript](/uk/docs/Web/JavaScript/Guide/Modules#import-moduliv-za-dopomohoiu-kart-importuvannia).
@@ -34,7 +34,8 @@ browser-compat: html.elements.script.type
     Розробники повинні використовувати дійсні MIME-типи, які не є MIME-типом JavaScript, позначаючи блоки даних
     Усі інші атрибути ігноруються, включно з атрибутом `src`.
 
-> **Примітка:** В раніших браузерах тип ідентифікував мову сценарію вбудованого або імпортованого (за допомогою атрибута `src`) коду.
+> [!NOTE]
+> В раніших браузерах тип ідентифікував мову сценарію вбудованого або імпортованого (за допомогою атрибута `src`) коду.
 
 ## Специфікації
 


### PR DESCRIPTION
Оригінальний вміст: ["&lt;script&gt; – Атрибут type"@MDN](https://developer.mozilla.org/en-us/docs/Web/HTML/Element/script/type), [сирці "&lt;script&gt; – Атрибут type"@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/html/element/script/type/index.md)

Нові зміни:
- [chore(http): delete "Basics of HTTP" page in favor of HTTP landing page, reorganize index (#35774)](https://github.com/mdn/content/commit/f75b2c86ae4168e59416aed4c7121f222afc201d)
- [Convert noteblocks for web/html/element folder (#35085)](https://github.com/mdn/content/commit/b7955e77cd4293adf45ef23686df50b0305f02ad)