### PR TITLE
update(JS): web/javascript/reference

### DIFF
--- a/files/uk/web/javascript/reference/index.md
+++ b/files/uk/web/javascript/reference/index.md
@@ -210,8 +210,8 @@ page-type: landing-page
 - {{jsxref("Operators/Property_accessors", "Доступ до властивостей", "", 1)}}
 - {{jsxref("Operators/Optional_chaining", "?.")}}
 - {{jsxref("Operators/new", "new")}}
-- {{jsxref("Operators/new%2Etarget", "new.target")}}
-- {{jsxref("Operators/import%2Emeta", "import.meta")}}
+- {{jsxref("Operators/new.target", "new.target")}}
+- {{jsxref("Operators/import.meta", "import.meta")}}
 - {{jsxref("Operators/super", "super")}}
 - {{jsxref("Operators/import", "import()")}}
 


### PR DESCRIPTION
Оригінальний вміст: [Довідник з JavaScript@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference), [сирці Довідник з JavaScript@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/index.md)

Нові зміни:
- [convert to the new dot handling logic on jsxref (#36663)](https://github.com/mdn/content/commit/65c47ca4811ecd225b826e00fcf64f7d93043591)