### PR TITLE
update(JS): web/javascript/reference/operators

### DIFF
--- a/files/uk/web/javascript/reference/operators/index.md
+++ b/files/uk/web/javascript/reference/operators/index.md
@@ -52,9 +52,9 @@ browser-compat: javascript.operators
   - : Оператор необов'язкового зв'язування повертає `undefined` замість спричинення помилки, коли посилання є [порожнім](/uk/docs/Glossary/Nullish) (дорівнює [`null`](/uk/docs/Web/JavaScript/Reference/Operators/null) або [`undefined`](/uk/docs/Web/JavaScript/Reference/Global_Objects/undefined)).
 - {{jsxref("Operators/new", "new")}} (нове)
   - : Оператор `new` створює новий екземпляр об'єкта за допомогою переданого конструктора.
-- {{jsxref("Operators/new%2Etarget", "new.target")}} (нове.цільовий)
+- {{jsxref("Operators/new.target", "new.target")}} (нове.цільовий)
   - : Всередині конструктора `new.target` посилається на конструктор, який було викликано оператором {{jsxref("Operators/new", "new")}}.
-- {{jsxref("Operators/import%2Emeta", "import.meta")}} (імпорт.метадані)
+- {{jsxref("Operators/import.meta", "import.meta")}} (імпорт.метадані)
   - : Об'єкт, що розкриває контекстно-специфічні метадані JavaScript-модуля.
 - {{jsxref("Operators/super", "super")}} (вищий)
   - : Ключове слово `super` викликає батьківський конструктор або дає змогу звертатися до властивостей батьківського об'єкта.
@@ -129,7 +129,7 @@ browser-compat: javascript.operators
 - {{jsxref("Operators/in", "in")}}
   - : Оператор `in` встановлює, чи має об'єкт дану властивість.
 
-> **Примітка:** `=>` — це не оператор, а позначення для [стрілкових функцій](/uk/docs/Web/JavaScript/Reference/Functions/Arrow_functions).
+> [!NOTE] > `=>` — це не оператор, а позначення для [стрілкових функцій](/uk/docs/Web/JavaScript/Reference/Functions/Arrow_functions).
 
 ### Оператори рівності
 

--- a/files/uk/web/javascript/reference/operators/index.md
+++ b/files/uk/web/javascript/reference/operators/index.md
@@ -129,7 +129,9 @@ browser-compat: javascript.operators
 - {{jsxref("Operators/in", "in")}}
   - : Оператор `in` встановлює, чи має об'єкт дану властивість.
 
-> [!NOTE] > `=>` — це не оператор, а позначення для [стрілкових функцій](/uk/docs/Web/JavaScript/Reference/Functions/Arrow_functions).
+> [!NOTE]
+>
+> `=>` — це не оператор, а позначення для [стрілкових функцій](/uk/docs/Web/JavaScript/Reference/Functions/Arrow_functions).
 
 ### Оператори рівності
 


### PR DESCRIPTION
Оригінальний вміст: [Вирази та оператори@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Operators), [сирці Вирази та оператори@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/operators/index.md)

Нові зміни:
- [convert to the new dot handling logic on jsxref (#36663)](https://github.com/mdn/content/commit/65c47ca4811ecd225b826e00fcf64f7d93043591)