### PR TITLE
update(JS): web/javascript/reference/global_objects/object/keys

### DIFF
--- a/files/uk/web/javascript/reference/global_objects/object/keys/index.md
+++ b/files/uk/web/javascript/reference/global_objects/object/keys/index.md
@@ -37,7 +37,7 @@ Object.keys(obj)
 ### Застосування Object.keys()
 
 ```js
-// простий масив
+// Базовий масив
 const arr = ["a", "b", "c"];
 console.log(Object.keys(arr)); // ['0', '1', '2']
 
@@ -77,7 +77,8 @@ console.log(Object.keys("foo")); // ['0', '1', '2']
 console.log(Object.keys(100)); // []
 ```
 
-> **Примітка:** В середовищі ES5 передача необ'єкта в `Object.keys()` призводить до викидання {{jsxref("TypeError")}}.
+> [!NOTE]
+> В середовищі ES5 передача необ'єкта в `Object.keys()` призводить до викидання {{jsxref("TypeError")}}.
 
 ## Специфікації
 


### PR DESCRIPTION
Оригінальний вміст: [Object.keys()@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Global_Objects/Object/keys), [сирці Object.keys()@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/global_objects/object/keys/index.md)

Нові зміни:
- [Remove "simple" part 6: javascript (#36777)](https://github.com/mdn/content/commit/5bdcf72ed6ffc7d4fa878060a548869ed6ae149b)
- [Convert noteblocks for web/javascript/reference/global_objects folder (#35091)](https://github.com/mdn/content/commit/8421c0cd94fa5aa237c833ac6d24885edbc7d721)