### PR TITLE
update(JS): web/javascript/reference/global_objects/string/matchall

### DIFF
--- a/files/uk/web/javascript/reference/global_objects/string/matchall/index.md
+++ b/files/uk/web/javascript/reference/global_objects/string/matchall/index.md
@@ -38,7 +38,7 @@ matchAll(regexp)
 
 ## Опис
 
-Реалізація `String.prototype.matchAll` робить небагато, крім виклику метода `Symbol.matchAll` свого аргументу з вихідним рядком як першим параметром (коли не рахувати додаткової валідації вихідних даних на предмет того, що регулярний вираз є глобальним). Фактична реалізація надходить із [`RegExp.prototype[Symbol.matchAll]`](/uk/docs/Web/JavaScript/Reference/Global_Objects/RegExp/Symbol.matchAll).
+Реалізація `String.prototype.matchAll` робить небагато, крім виклику метода `Symbol.matchAll` свого аргументу з вихідним рядком як першим параметром (коли не рахувати додаткової валідації вихідних даних щодо того, що регулярний вираз є глобальним). Фактична реалізація надходить із [`RegExp.prototype[Symbol.matchAll]`](/uk/docs/Web/JavaScript/Reference/Global_Objects/RegExp/Symbol.matchAll).
 
 ## Приклади
 

--- a/files/uk/web/javascript/reference/global_objects/string/matchall/index.md
+++ b/files/uk/web/javascript/reference/global_objects/string/matchall/index.md
@@ -38,7 +38,7 @@ matchAll(regexp)
 
 ## Опис
 
-Реалізація `String.prototype.matchAll` сама по собі є дуже простою: цей метод просто викликає метод `Symbol.matchAll` свого аргументу з вихідним рядком як першим параметром (коли не рахувати додаткової валідації вихідних даних на предмет того, що регулярний вираз є глобальним). Фактична реалізація надходить із [`RegExp.prototype[Symbol.matchAll]`](/uk/docs/Web/JavaScript/Reference/Global_Objects/RegExp/Symbol.matchAll).
+Реалізація `String.prototype.matchAll` робить небагато, крім виклику метода `Symbol.matchAll` свого аргументу з вихідним рядком як першим параметром (коли не рахувати додаткової валідації вихідних даних на предмет того, що регулярний вираз є глобальним). Фактична реалізація надходить із [`RegExp.prototype[Symbol.matchAll]`](/uk/docs/Web/JavaScript/Reference/Global_Objects/RegExp/Symbol.matchAll).
 
 ## Приклади
 


### PR DESCRIPTION
Оригінальний вміст: [String.prototype.matchAll()@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Global_Objects/String/matchAll), [сирці String.prototype.matchAll()@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/global_objects/string/matchall/index.md)

Нові зміни:
- [Remove "simple" part 6: javascript (#36777)](https://github.com/mdn/content/commit/5bdcf72ed6ffc7d4fa878060a548869ed6ae149b)