### PR TITLE
update(JS): web/javascript/reference/global_objects/typeerror

### DIFF
--- a/files/uk/web/javascript/reference/global_objects/typeerror/index.md
+++ b/files/uk/web/javascript/reference/global_objects/typeerror/index.md
@@ -15,7 +15,7 @@ browser-compat: javascript.builtins.TypeError
 - при спробі змінити значення, котре не може бути змінене; або
 - при спробі використати значення у невідповідний спосіб.
 
-`TypeError` – це {{Glossary("serializable object", "серіалізовний об'єкт")}}, тож може бути клонований за допомогою {{domxref("structuredClone()")}} або скопійований між [воркерами](/uk/docs/Web/API/Worker) за допомогою {{domxref("Worker/postMessage()", "postMessage()")}}.
+`TypeError` – це {{Glossary("serializable object", "серіалізовний об'єкт")}}, тож може бути клонований за допомогою {{DOMxRef("Window.structuredClone", "structuredClone()")}} або скопійований між [воркерами](/uk/docs/Web/API/Worker) за допомогою {{domxref("Worker/postMessage()", "postMessage()")}}.
 
 `TypeError` є підкласом {{jsxref("Error")}}.
 


### PR DESCRIPTION
Оригінальний вміст: [TypeError@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Global_Objects/TypeError), [сирці TypeError@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/global_objects/typeerror/index.md)

Нові зміни:
- [Fix globals, part 14: `structuredClone()` (#35951)](https://github.com/mdn/content/commit/8b6cec0ceff01e7a9d6865cf5306788e15cce4b8)