### PR TITLE
update(HTML): web/html/element/video

### DIFF
--- a/files/uk/web/html/element/video/index.md
+++ b/files/uk/web/html/element/video/index.md
@@ -32,7 +32,7 @@ browser-compat: html.elements.video
   - : Якщо присутній цей атрибут, то браузер запропонує користувачеві контрольні засоби для керування відтворенням відео, в тому числі гучністю, перемоткою та паузою-відновленням відтворення.
 - `controlslist`
 
-  - : Атрибут [`controlslist` (англ.)](https://wicg.github.io/controls-list/explainer.html), бувши вказаним, допомагає браузеру обрати, які контрольні елементи показати на елементі `video`, коли браузер показує власний набір контрольних елементів (тобто коли вказаний атрибут `controls`).
+  - : Атрибут [`controlslist`](https://wicg.github.io/controls-list/explainer.html), бувши вказаним, допомагає браузеру обрати, які контрольні елементи показати на елементі `video`, коли браузер показує власний набір контрольних елементів (тобто коли вказаний атрибут `controls`).
 
     Дозволені значення: `nodownload`, `nofullscreen` і `noremoteplayback`.
 
@@ -55,10 +55,10 @@ browser-compat: html.elements.video
 
   - : Булів атрибут, що використовується для вимкнення можливості віддаленого відтворення на пристроях, що під'єднані за допомогою провідних (HDMI, DVI тощо) та безпровідних технологій (Miracast, Chromecast, DLNA, AirPlay тощо).
 
-    У Safari як запасний варіант можна використати [`x-webkit-airplay="deny"` (англ.)](https://developer.apple.com/library/archive/documentation/AudioVideo/Conceptual/AirPlayGuide/OptingInorOutofAirPlay/OptingInorOutofAirPlay.html).
+    У Safari як запасний варіант можна використати [`x-webkit-airplay="deny"`](https://developer.apple.com/library/archive/documentation/AudioVideo/Conceptual/AirPlayGuide/OptingInorOutofAirPlay/OptingInorOutofAirPlay.html).
 
 - `height`
-  - : Висота області відтворення відео, задана в [пікселях CSS (англ.)](https://drafts.csswg.org/css-values/#px) (приймаються лише абсолютні значення; [жодних відсотків (англ.)](https://html.spec.whatwg.org/multipage/embedded-content.html#dimension-attributes)).
+  - : Висота області відтворення відео, задана в [пікселях CSS](https://drafts.csswg.org/css-values/#px) (приймаються лише абсолютні значення; [жодних відсотків](https://html.spec.whatwg.org/multipage/embedded-content.html#dimension-attributes)).
 - `loop`
   - : Булів атрибут; коли вказаний, браузер автоматично перемотуватиме на початок після досягнення кінця відео.
 - `muted`
@@ -86,7 +86,7 @@ browser-compat: html.elements.video
 - `src`
   - : URL відео, що має бути вбудоване. Цей атрибут необов'язковий; натомість для вказівки, яке відео вбудовувати, можна використати елемент {{HTMLElement("source")}} всередині блока `<video>`.
 - `width`
-  - : Ширина області відтворення відео, задана в [пікселях CSS (англ.)](https://drafts.csswg.org/css-values/#px) (приймаються лише абсолютні значення; [жодних відсотків (англ.)](https://html.spec.whatwg.org/multipage/embedded-content.html#dimension-attributes)).
+  - : Ширина області відтворення відео, задана в [пікселях CSS](https://drafts.csswg.org/css-values/#px) (приймаються лише абсолютні значення; [жодних відсотків](https://html.spec.whatwg.org/multipage/embedded-content.html#dimension-attributes)).
 
 ## Події
 
@@ -399,7 +399,7 @@ AddType video/webm .webm
 #### HTML
 
 ```html
-<!-- Простий приклад відео -->
+<!-- Базовий приклад відео -->
 <!-- 'Big Buck Bunny' ліцензовано Blender foundation під CC 3.0. Розміщено на archive.org -->
 <!-- Анонс із peach.blender.org -->
 <video
@@ -531,4 +531,4 @@ AddType video/webm .webm
 - {{htmlelement("audio")}}
 - [Використання аудіо й відео HTML](/uk/docs/Learn/HTML/Multimedia_and_embedding/Video_and_audio_content)
 - [Взаємодія з відео за допомогою полотна](/uk/docs/Web/API/Canvas_API/Manipulating_video_using_canvas)
-- [Налаштування серверів для мультимедійних даних Ogg](/uk/docs/Web/HTTP/Configuring_servers_for_Ogg_media)
+- [Налаштування серверів для мультимедійних даних Ogg](/uk/docs/Web/Media/Formats/Configuring_servers_for_Ogg_media)


### PR DESCRIPTION
Оригінальний вміст: [&lt;video&gt; – елемент вбудованого відео@MDN](https://developer.mozilla.org/en-us/docs/Web/HTML/Element/video), [сирці &lt;video&gt; – елемент вбудованого відео@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/html/element/video/index.md)

Нові зміни:
- [chore(http): Move Ogg guide, HTTP method fixes (#37026)](https://github.com/mdn/content/commit/4d12b3e4f9afb311f2656641260e42c0b6f8f4c6)
- [Remove "simple" part 4: change to "basic" (#36763)](https://github.com/mdn/content/commit/f10015d1752d5668d8fe0de29f9d9807de475d58)