### PR TITLE
update(JS): web/javascript/reference/global_objects/string/split

### DIFF
--- a/files/uk/web/javascript/reference/global_objects/string/split/index.md
+++ b/files/uk/web/javascript/reference/global_objects/string/split/index.md
@@ -37,9 +37,11 @@ split(separator, limit)
 
 Якщо `separator` – порожній рядок (`""`), то `str` перетворюється на масив своїх "символів" UTF-16, котрий не містить порожніх рядків на жодному зі своїх кінців.
 
-> **Примітка:** Таким чином, при передачі рядка як `separator` і `limit` зі значенням 0 – `"".split("")` є єдиним способом отримати порожній масив.
+> [!NOTE]
+> Таким чином, при передачі рядка як `separator` і `limit` зі значенням 0 – `"".split("")` є єдиним способом отримати порожній масив.
 
-> **Застереження:** Коли як розділювач використовується порожній рядок (`""`), то рядок **не** ділиться на _видимі символи_ ([графемні кластери (англ.)](https://unicode.org/reports/tr29/#Grapheme_Cluster_Boundaries)) чи символи Unicode (кодові точки), натомість – на кодові одиниці UTF-16. Отже – руйнуються [сурогатні пари (англ.)](https://unicode.org/faq/utf_bom.html#utf16-2). Дивіться ["Як на JavaScript отримати з рядка масив символів?" на StackOverflow (англ.)](https://stackoverflow.com/questions/4547609/how-to-get-character-array-from-a-string/34717402#34717402).
+> [!WARNING]
+> Коли як розділювач використовується порожній рядок (`""`), то рядок **не** ділиться на _видимі символи_ ([графемні кластери](https://unicode.org/reports/tr29/#Grapheme_Cluster_Boundaries)) чи символи Unicode (кодові точки), натомість – на кодові одиниці UTF-16. Отже – руйнуються [сурогатні пари](https://unicode.org/faq/utf_bom.html#utf16-2). Дивіться ["Як на JavaScript отримати з рядка масив символів?" на Stack Overflow](https://stackoverflow.com/questions/4547609/how-to-get-character-array-from-a-string/34717402#34717402).
 
 Якщо `separator` є регулярним виразом, що дає збіг з порожніми рядками, то те, чи розбивається збіг на кодові одиниці UTF-16, чи на кодові точки Unicode, залежить від того, чи [враховує регулярний вираз Unicode](/uk/docs/Web/JavaScript/Reference/Global_Objects/RegExp/unicode#rezhym-vrakhuvannia-unicode).
 
@@ -172,7 +174,9 @@ console.log(splits);
 ["Здрастуй ", "1", " слово. Речення номер ", "2", "."];
 ```
 
-> **Примітка:** `\d` шукає збіги з [класом символів](/uk/docs/Web/JavaScript/Guide/Regular_expressions/Character_classes), що відповідає цифрам від 0 до 9.
+> [!NOTE]
+>
+> `\d` шукає збіги з [класом символів](/uk/docs/Web/JavaScript/Guide/Regular_expressions/Character_classes), що відповідає цифрам від 0 до 9.
 
 ### Використання власного розщеплювача
 


### PR DESCRIPTION
Оригінальний вміст: [String.prototype.split()@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Global_Objects/String/split), [сирці String.prototype.split()@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/global_objects/string/split/index.md)

Нові зміни:
- [Pedantic capitalization (#36840)](https://github.com/mdn/content/commit/5f76b99045f87349ed030bbd6a3c2e43badb3c22)
- [Convert noteblocks for web/javascript/reference/global_objects folder (#35091)](https://github.com/mdn/content/commit/8421c0cd94fa5aa237c833ac6d24885edbc7d721)