### PR TITLE
update(HTML): web/html/element/a

### DIFF
--- a/files/uk/web/html/element/a/index.md
+++ b/files/uk/web/html/element/a/index.md
@@ -194,22 +194,34 @@ browser-compat: html.elements.a
 
 #### Посилання на не-HTML ресурс
 
-```html
-<a href="2017-annual-report.ppt">2017 Річний звіт (PowerPoint)</a>
-```
-
-Якщо призначення посилання позначено іконкою, слід пересвідчитись, що ця іконка має [_текстову альтернативу_](/uk/docs/Web/HTML/Element/img#alt):
+Якщо для позначення поведінки посилання застосована піктограма, слід пересвідчитись, що ця піктограма має [атрибут `alt`](/uk/docs/Web/HTML/Element/img#alt), який описує її призначення. Коли ця піктограма буде відсутня, то вміст атрибута `alt` усе одно пояснить поведінку посилання.
 
 ```html
-<a target="_blank" href="https://uk.wikipedia.org">
-  Вікіпедія
-  <img alt="(відкривається в новій вкладці)" src="newtab.svg" />
-</a>
-
-<a href="2017-annual-report.ppt">
-  2017 Річний звіт
-  <img alt="(файл PowerPoint)" src="ppt-icon.svg" />
-</a>
+<p>
+  <a href="https://uk.wikipedia.org/" target="_blank">
+    Вікіпедія
+    <img src="new-tab.svg" width="14" alt="(Відкривається в новій вкладці)" />
+  </a>
+  <br />
+  <a href="2017-annual-report.ppt">
+    Річний звіт 2017
+    <img src="powerpoint.svg" width="14" alt="(Файл PowerPoint)" />
+  </a>
+</p>
+<p>
+  <a href="https://uk.wikipedia.org/" target="_blank">
+    Вікіпедія
+    <img
+      src="missing-icon.svg"
+      width="14"
+      alt="(Відкривається в новій вкладці)" />
+  </a>
+  <br />
+  <a href="2017-annual-report.ppt">
+    Річний звіт 2017
+    <img src="missing-icon.svg" width="14" alt="(Файл PowerPoint)" />
+  </a>
+</p>
 ```
 
 ##### Результат

--- a/files/uk/web/html/element/a/index.md
+++ b/files/uk/web/html/element/a/index.md
@@ -82,7 +82,7 @@ browser-compat: html.elements.a
 
     - `no-referrer`: Заголовок {{HTTPHeader("Referer")}} не буде надісланий.
     - `no-referrer-when-downgrade`: Заголовок {{HTTPHeader("Referer")}} не буде надісланий на ті {{Glossary("origin", "походження")}}, що не мають {{Glossary("TLS")}} ({{Glossary("HTTPS")}}).
-    - `origin`: Надісланий посилач буде обмежений походженням сторінки, що містить посилання: її [схемою](/uk/docs/Learn/Common_questions/Web_mechanics/What_is_a_URL), {{Glossary("host", "хостом")}} та {{Glossary("port", "портом")}}.
+    - `origin`: Надісланий посилач буде обмежений походженням сторінки, що містить посилання: її [схемою](/uk/docs/Learn_web_development/Howto/Web_mechanics/What_is_a_URL), {{Glossary("host", "хостом")}} та {{Glossary("port", "портом")}}.
     - `origin-when-cross-origin`: Посилач, надісланий іншим походженням, буде обмежений схемою, хостом та портом. Переходи в межах того самого походження включатимуть увесь шлях.
     - `same-origin`: Посилач буде надісланий, якщо {{Glossary("Same-origin policy", "збігається походження")}}, натомість запити між різними походженнями не міститимуть інформації про посилача.
     - `strict-origin`: Надсилати як посилач походження документа, коли рівень протоколу захисту залишається сталим (HTTPS→HTTPS), але не надсилати його за менш захищеною адресою (HTTPS→HTTP).
@@ -358,7 +358,7 @@ a {
 
 {{EmbedLiveSample('posylannia-na-adresu-elektronnoi-poshty')}}
 
-Для деталей щодо URL `mailto:`, наприклад, включення в них теми чи тіла листа, читайте [посилання електронної пошти](/uk/docs/Learn/HTML/Introduction_to_HTML/Creating_hyperlinks#posylannia-elektronnoi-poshty) чи {{RFC(6068)}}.
+Для деталей щодо URL `mailto:`, наприклад, включення в них теми чи тіла листа, читайте [посилання електронної пошти](/uk/docs/Learn_web_development/Core/Structuring_content/Creating_links#posylannia-elektronnoi-poshty) чи {{RFC(6068)}}.
 
 ### Посилання на номери телефонів
 

--- a/files/uk/web/html/element/a/new-tab.svg
+++ b/files/uk/web/html/element/a/new-tab.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <!--!Font Awesome Free 6.7.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.-->
+  <path fill="linktext"
+    d="M320 0c-17.7 0-32 14.3-32 32s14.3 32 32 32l82.7 0L201.4 265.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L448 109.3l0 82.7c0 17.7 14.3 32 32 32s32-14.3 32-32l0-160c0-17.7-14.3-32-32-32L320 0zM80 32C35.8 32 0 67.8 0 112L0 432c0 44.2 35.8 80 80 80l320 0c44.2 0 80-35.8 80-80l0-112c0-17.7-14.3-32-32-32s-32 14.3-32 32l0 112c0 8.8-7.2 16-16 16L80 448c-8.8 0-16-7.2-16-16l0-320c0-8.8 7.2-16 16-16l112 0c17.7 0 32-14.3 32-32s-14.3-32-32-32L80 32z" />
+</svg>

--- a/files/uk/web/html/element/a/powerpoint.svg
+++ b/files/uk/web/html/element/a/powerpoint.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 384 512">
+  <!--!Font Awesome Free 6.7.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.-->
+  <path fill="linktext"
+    d="M64 464c-8.8 0-16-7.2-16-16L48 64c0-8.8 7.2-16 16-16l160 0 0 80c0 17.7 14.3 32 32 32l80 0 0 288c0 8.8-7.2 16-16 16L64 464zM64 0C28.7 0 0 28.7 0 64L0 448c0 35.3 28.7 64 64 64l256 0c35.3 0 64-28.7 64-64l0-293.5c0-17-6.7-33.3-18.7-45.3L274.7 18.7C262.7 6.7 246.5 0 229.5 0L64 0zm72 208c-13.3 0-24 10.7-24 24l0 104 0 56c0 13.3 10.7 24 24 24s24-10.7 24-24l0-32 44 0c42 0 76-34 76-76s-34-76-76-76l-68 0zm68 104l-44 0 0-56 44 0c15.5 0 28 12.5 28 28s-12.5 28-28 28z" />
+</svg>


### PR DESCRIPTION
Оригінальний вміст: [&lt;a&gt; – якірний елемент@MDN](https://developer.mozilla.org/en-us/docs/Web/HTML/Element/a), [сирці &lt;a&gt; – якірний елемент@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/html/element/a/index.md)

Нові зміни:
- [chore(learn): Move MDN Curriculum into Learning Area (#36967)](https://github.com/mdn/content/commit/5b20f5f4265f988f80f513db0e4b35c7e0cd70dc)
- [Improve example with links and icons (#36934)](https://github.com/mdn/content/commit/58f0feea3a1220e0835604639efe330ee0f93368)