### PR TITLE
update(HTML): web/html/element/iframe

### DIFF
--- a/files/uk/web/html/element/iframe/index.md
+++ b/files/uk/web/html/element/iframe/index.md
@@ -214,7 +214,7 @@ browser-compat: html.elements.iframe
 
 ## Приклади
 
-### Простий \<iframe>
+### Базовий \<iframe>
 
 Цей приклад вбудовує сторінку <https://example.org> в супутній фрейм. Це поширений випадок для використання супутніх фреймів: вбудовування вмісту з іншого сайту. Наприклад, як у самому живому зразку нижче, так і в прикладі ["спробуйте його в дії"](#sprobuite-yoho-v-dii) нагорі, `<iframe>` вбудовує вміст з іншого сайту WebDoky.
 
@@ -231,7 +231,7 @@ browser-compat: html.elements.iframe
 
 #### Результат
 
-{{EmbedLiveSample('prostyi-iframe', 640,400)}}
+{{EmbedLiveSample('bazovyi-iframe', 640,400)}}
 
 ### Вбудовування в \<iframe> вихідного коду
 


### PR DESCRIPTION
Оригінальний вміст: ["&lt;iframe&gt;: Елемент супутнього фрейму"@MDN](https://developer.mozilla.org/en-us/docs/Web/HTML/Element/iframe), [сирці "&lt;iframe&gt;: Елемент супутнього фрейму"@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/html/element/iframe/index.md)

Нові зміни:
- [Remove "simple" part 4: change to "basic" (#36763)](https://github.com/mdn/content/commit/f10015d1752d5668d8fe0de29f9d9807de475d58)