### PR TITLE
update(HTML): web/html/attributes

### DIFF
--- a/files/uk/web/html/attributes/index.md
+++ b/files/uk/web/html/attributes/index.md
@@ -35,7 +35,7 @@ page-type: landing-page
       </td>
       <td>{{HTMLElement("form")}}</td>
       <td>
-      Список кодувань, що підтримуються.
+      Набір символів, який, якщо заданий, повинен бути <code>"UTF-8"</code>.
       </td>
     </tr>
     <tr>


### PR DESCRIPTION
Оригінальний вміст: [Довідка атрибутів HTML@MDN](https://developer.mozilla.org/en-us/docs/Web/HTML/Attributes), [сирці Довідка атрибутів HTML@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/html/attributes/index.md)

Нові зміни:
- [Accept-Charset HTTP header removed - not sent by any browser for many years and deprecated (#36854)](https://github.com/mdn/content/commit/56cbe48e4426172461d9297523b68716922690e5)