### PR TITLE
update(CSS): web/css/_colon_blank

### DIFF
--- a/files/uk/web/css/_colon_blank/index.md
+++ b/files/uk/web/css/_colon_blank/index.md
@@ -4,7 +4,7 @@ slug: Web/CSS/:blank
 page-type: css-pseudo-class
 status:
   - experimental
-browser-compat: css.selectors.blank
+spec-urls: https://drafts.csswg.org/selectors/#blank-pseudo
 ---
 
 {{CSSRef}}{{SeeCompatTable}}
@@ -54,7 +54,7 @@ textarea:blank {
 
 ## Сумісність із браузерами
 
-{{Compat}}
+Наразі ще жодний браузер не реалізував цю можливість.
 
 ## Дивіться також
 


### PR DESCRIPTION
Оригінальний вміст: [":blank"@MDN](https://developer.mozilla.org/en-us/docs/Web/CSS/:blank), [сирці ":blank"@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/css/_colon_blank/index.md)

Нові зміни:
- [Fix bcd key for removing unimplemented selectors data (#36936)](https://github.com/mdn/content/commit/d278eda568df670011d4e89c1f30f57b66a8a850)