### PR TITLE
update(JS): web/javascript/reference/global_objects/math/log2e

### DIFF
--- a/files/uk/web/javascript/reference/global_objects/math/log2e/index.md
+++ b/files/uk/web/javascript/reference/global_objects/math/log2e/index.md
@@ -7,13 +7,17 @@ browser-compat: javascript.builtins.Math.LOG2E
 
 {{JSRef}}
 
-Статична властивість даних **`Math.LOG2E`** відображає логарифм [e](/uk/docs/Web/JavaScript/Reference/Global_Objects/Math/E) за основою 2, що наближено дорівнює 1.442.
+Статична властивість даних **`Math.LOG2E`** відображає логарифм [e](/uk/docs/Web/JavaScript/Reference/Global_Objects/Math/E) за основою 2, що наближено дорівнює 1,443.
 
 {{EmbedInteractiveExample("pages/js/math-log2e.html", "shorter")}}
 
 ## Значення
 
-<math display="block"><semantics><mrow><mi>𝙼𝚊𝚝𝚑.𝙻𝙾𝙶𝟸𝙴</mi><mo>=</mo><msub><mo lspace="0em" rspace="0em">log</mo><mn>2</mn></msub><mo stretchy="false">(</mo><mi mathvariant="normal">e</mi><mo stretchy="false">)</mo><mo>≈</mo><mn>1.442</mn></mrow><annotation encoding="TeX">\mathtt{\mi{Math.LOG2E}} = \log_2(\mathrm{e}) \approx 1.442</annotation></semantics></math>
+<!-- prettier-ignore-start -->
+<math display="block">
+  <semantics><mrow><mi>𝙼𝚊𝚝𝚑.𝙻𝙾𝙶𝟸𝙴</mi><mo>=</mo><msub><mo lspace="0em" rspace="0em">log</mo><mn>2</mn></msub><mo stretchy="false">(</mo><mi mathvariant="normal">e</mi><mo stretchy="false">)</mo><mo>≈</mo><mn>1.443</mn></mrow><annotation encoding="TeX">\mathtt{Math.LOG2E} = \log_2(\mathrm{e}) \approx 1.443</annotation></semantics>
+</math>
+<!-- prettier-ignore-end -->
 
 {{js_property_attributes(0, 0, 0)}}
 


### PR DESCRIPTION
Оригінальний вміст: [Math.LOG2E@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Global_Objects/Math/LOG2E), [сирці Math.LOG2E@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/global_objects/math/log2e/index.md)

Нові зміни:
- [fix: wrong log approximation (#37176)](https://github.com/mdn/content/commit/2ec170b6264d51a15be498ac99b8a30b3dadec15)
- [Format block MathML (#34751)](https://github.com/mdn/content/commit/761b9047d78876cbd153be811efb1aa77b419877)
- [Format and clean up MathML (#34430)](https://github.com/mdn/content/commit/4f263d8dfb90fa2253e090ee339ae14d1907fa63)