### PR TITLE
update(CSS): web/css/css_backgrounds_and_borders

### DIFF
--- a/files/uk/web/css/css_backgrounds_and_borders/index.md
+++ b/files/uk/web/css/css_backgrounds_and_borders/index.md
@@ -19,11 +19,63 @@ spec-urls: https://drafts.csswg.org/css-backgrounds/
 
 Цей зразок меж, фонів і рамкових тіней складається з відцентрованих зображень фонів, зроблених з лінійних і радіальних градієнтів. Низка рамкових тіней змушує межу ніби "виступати". В елемента зліва задано зображення межі. Елемент справа має закруглену пунктирну межу.
 
-{{EmbedGHLiveSample("css-examples/modules/backgrounds.html", '100%', 430)}}
+```html hidden live-sample___backgrounds
+<article>
+  <div></div>
+  <div></div>
+</article>
+```
+
+```css hidden live-sample___backgrounds
+article {
+  display: flex;
+  gap: 10px;
+}
+div {
+  color: #58ade3;
+  height: 320px;
+  width: 240px;
+  padding: 20px;
+  margin: 10px;
+  border: dotted 15px; /* усталено `currentcolor` */
+  border-radius: 100px 0;
+  background-image: radial-gradient(
+      circle,
+      transparent 60%,
+      currentcolor 60% 70%,
+      transparent 70%
+    ),
+    linear-gradient(45deg, currentcolor, white),
+    linear-gradient(transparent, transparent);
+  /* третє фонове зображення (прозоре) додано для того, щоб фоновий колір міг проступати */
+  background-color: currentcolor;
+  background-position: center;
+  background-size:
+    60px 60px,
+    120px 120px;
+  background-clip: content-box, content-box, padding-box;
+  box-shadow:
+    inset 5px 5px 5px rgb(0 0 0 / 0.4),
+    inset -5px -5px 5px rgb(0 0 0 / 0.4),
+    5px 5px 5px rgb(0 0 0 / 0.4),
+    -5px -5px 5px rgb(0 0 0 / 0.4);
+}
+div:first-of-type {
+  border-radius: 0;
+  border-image-source: repeating-conic-gradient(
+    from 3deg at 25% 25%,
+    currentColor 0 3deg,
+    transparent 3deg 6deg
+  );
+  border-image-slice: 30;
+}
+```
+
+{{EmbedLiveSample("backgrounds", "", "450px")}}
 
 Фонові зображення визначені за допомогою {{cssxref("background-image")}}. Вони відцентровані за допомогою {{cssxref("background-position")}}. Різні значення властивості {{cssxref("background-clip")}} для кількох фонових зображень використовуються для того, щоб ці фонові зображення залишалися всередині рамки вмісту. Колір фону обрізається до рамки внутрішніх відступів, що не дає фону проступати крізь прозорі секції для {{cssxref("border-image")}} та {{cssxref("border-style", "пунктирний")}} {{cssxref("border")}}. Закруглені кути в елементі справа створюються за допомогою властивості {{cssxref("border-radius")}}. Одне оголошення {{cssxref("box-shadow")}} використовується для задання всіх тіней, як внутрішніх, так і зовнішніх.
 
-Щоб переглянути код цього зразка, [дивіться його вихідний код на GitHub](https://github.com/webdoky/css-examples/blob/main/modules/backgrounds.html).
+Клацніть "Відтворити" в прикладі вище, щоб переглянути або відредагувати код для анімації на Ігровому майданчику MDN.
 
 ## Довідка
 


### PR DESCRIPTION
Оригінальний вміст: [Фони та межі CSS@MDN](https://developer.mozilla.org/en-us/docs/Web/CSS/CSS_backgrounds_and_borders), [сирці Фони та межі CSS@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/css/css_backgrounds_and_borders/index.md)

Нові зміни:
- [chore(learn): Move MDN Curriculum into Learning Area (#36967)](https://github.com/mdn/content/commit/5b20f5f4265f988f80f513db0e4b35c7e0cd70dc)
- [chore(css): Move CSS examples - Modules, filter functions, flow layout, grid layout (#36752)](https://github.com/mdn/content/commit/5755d6dfbac15abc29ddcd924cee110c4139b073)