### PR TITLE
update(CSS): web/css/css_colors

### DIFF
--- a/files/uk/web/css/css_colors/index.md
+++ b/files/uk/web/css/css_colors/index.md
@@ -48,7 +48,6 @@ spec-urls:
   - [`oklab()`](/uk/docs/Web/CSS/color_value/oklab)
   - [`oklch()`](/uk/docs/Web/CSS/color_value/oklch)
   - [`color()`](/uk/docs/Web/CSS/color_value/color)
-- [`color-contrast()`](/uk/docs/Web/CSS/color_value/color-contrast) {{experimental_inline}}
 - [`color-mix()`](/uk/docs/Web/CSS/color_value/color-mix)
 - [`device-cmyk()`](/uk/docs/Web/CSS/color_value/device-cmyk)
 - {{CSSXref("color_value/light-dark", "light-dark()")}}


### PR DESCRIPTION
Оригінальний вміст: [Кольори CSS@MDN](https://developer.mozilla.org/en-us/docs/Web/CSS/CSS_colors), [сирці Кольори CSS@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/css/css_colors/index.md)

Нові зміни:
- [fix(css): remove experimental color-contrast() function page (#36973)](https://github.com/mdn/content/commit/31e158bf22cece84ba7de3de3551f2807fe587d0)