### PR TITLE
update(Glossary): glossary/render_blocking

### DIFF
--- a/files/uk/glossary/render_blocking/index.md
+++ b/files/uk/glossary/render_blocking/index.md
@@ -14,4 +14,3 @@ page-type: glossary-definition
 
 - [Оптимізація продуктивності CSS](/uk/docs/Learn/Performance/CSS)
 - [Оптимізація продуктивності JavaScript](/uk/docs/Learn/Performance/JavaScript)
-- [Що таке візуалізаційно-блокувальні ресурси, та як виправити проблеми блокування візуалізації](https://drukarnia.com.ua/articles/sho-take-vizualizaciino-blokuvalni-resursi-ta-yak-vipraviti-problemi-z-blokuvannyam-vizualizaciyi-pere-qXKs9) – переклад на Друкарні (2023) статті зі Speckyboy (2018)


### PR DESCRIPTION
Оригінальний вміст: [Візуалізаційно-блокувальне@MDN](https://developer.mozilla.org/en-us/docs/Glossary/Render_blocking), [сирці Візуалізаційно-блокувальне@GitHub](https://github.com/mdn/content/blob/main/files/en-us/glossary/render_blocking/index.md)

Нові зміни:
- [chore(learn): Move MDN Curriculum into Learning Area (#36967)](https://github.com/mdn/content/commit/5b20f5f4265f988f80f513db0e4b35c7e0cd70dc)
- [remove 404 link (#33915)](https://github.com/mdn/content/commit/6b56cb7daf7092f325f98dc9f53b3d80c700adb6)