### PR TITLE
update(CSS): web/css/transform-function/translate

### DIFF
--- a/files/uk/web/css/transform-function/translate/index.md
+++ b/files/uk/web/css/transform-function/translate/index.md
@@ -72,11 +72,9 @@ transform: translate(30%, 50%);
    </tbody>
 </table>
 
-### Формальний синтаксис
+## Формальний синтаксис
 
-```plain
-translate({{cssxref("&lt;length-percentage&gt;")}}, {{cssxref("&lt;length-percentage&gt;")}}?)
-```
+{{CSSSyntax}}
 
 ## Приклади
 


### PR DESCRIPTION
Оригінальний вміст: [translate()@MDN](https://developer.mozilla.org/en-us/docs/Web/CSS/transform-function/translate), [сирці translate()@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/css/transform-function/translate/index.md)

Нові зміни:
- [Add missing Formal syntax section for css functions [s-z] (#37210)](https://github.com/mdn/content/commit/c9f96f06d4fbd265808f298eb9b2773f739860c5)