### PR TITLE
update(HTML): web/html/element/input/date

### DIFF
--- a/files/uk/web/html/element/input/date/index.md
+++ b/files/uk/web/html/element/input/date/index.md
@@ -275,6 +275,5 @@ input:valid + span::after {
 ## Додаткова інформація
 
 - Загальний елемент {{HTMLElement("input")}} та інтерфейс для керування ним, {{domxref("HTMLInputElement")}}
-- [Настанови з віджетів вибору дати й часу](/uk/docs/Learn/Forms/HTML5_input_types#date_and_time_pickers)
+- [Настанови з віджетів вибору дати й часу](/uk/docs/Learn_web_development/Extensions/Forms/HTML5_input_types#date_and_time_pickers)
 - [Вживані в HTML формати дати й часу](/uk/docs/Web/HTML/Date_and_time_formats)
-- [Сумісність властивостей CSS](/uk/docs/Learn/Forms/Property_compatibility_table_for_form_controls)


### PR DESCRIPTION
Оригінальний вміст: [&lt;input type="date"&gt;@MDN](https://developer.mozilla.org/en-us/docs/Web/HTML/Element/input/date), [сирці &lt;input type="date"&gt;@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/html/element/input/date/index.md)

Нові зміни:
- [chore(learn): Move MDN Curriculum into Learning Area (#36967)](https://github.com/mdn/content/commit/5b20f5f4265f988f80f513db0e4b35c7e0cd70dc)