### PR TITLE
update(JS): web/javascript/reference/template_literals

### DIFF
--- a/files/uk/web/javascript/reference/template_literals/index.md
+++ b/files/uk/web/javascript/reference/template_literals/index.md
@@ -362,7 +362,7 @@ const bad = `неправильна екранована послідовніс�
 
 ## Дивіться також
 
-- Посібник [Форматування тексту](/uk/docs/Web/JavaScript/Guide/Text_formatting)
+- Посібник [Числа та рядки](/uk/docs/Web/JavaScript/Guide/Numbers_and_strings)
 - {{jsxref("String")}}
 - {{jsxref("String.raw()")}}
 - [Лексична граматика](/uk/docs/Web/JavaScript/Reference/Lexical_grammar)


### PR DESCRIPTION
Оригінальний вміст: [Шаблонні літерали (Шаблонні рядки)@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Template_literals), [сирці Шаблонні літерали (Шаблонні рядки)@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/template_literals/index.md)

Нові зміни:
- [Reorganize JS numbers/dates/strings guides (#37563)](https://github.com/mdn/content/commit/c16a0ee78e5142b3bfcdaf57d595add3ce825f13)