### PR TITLE
update(JS): web/javascript/reference/global_objects/string/split

### DIFF
--- a/files/uk/web/javascript/reference/global_objects/string/split/index.md
+++ b/files/uk/web/javascript/reference/global_objects/string/split/index.md
@@ -286,8 +286,8 @@ console.log(commands.split(splitCommands, 3)); // ["світло увімкну�
 ## Дивіться також
 
 - [Поліфіл `String.prototype.split` у складі `core-js`, з виправленнями й реалізацією сучасної логіки, як то підтримки `Symbol.split`](https://github.com/zloirock/core-js#ecmascript-string-and-regexp)
+- Посібник [Регулярні вирази](/uk/docs/Web/JavaScript/Guide/Regular_expressions)
 - {{jsxref("String.prototype.charAt()")}}
 - {{jsxref("String.prototype.indexOf()")}}
 - {{jsxref("String.prototype.lastIndexOf()")}}
 - {{jsxref("Array.prototype.join()")}}
-- Посібник [Регулярні вирази](/uk/docs/Web/JavaScript/Guide/Regular_expressions)


### PR DESCRIPTION
Оригінальний вміст: [String.prototype.split()@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Global_Objects/String/split), [сирці String.prototype.split()@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/global_objects/string/split/index.md)

Нові зміни:
- [Add Regex Guide to See Also sections of common functions that use Regexes (#37710)](https://github.com/mdn/content/commit/7d09807ed7594cf5c7b93afc1fa0424a26663b9b)