### PR TITLE
update(JS): web/javascript/reference/global_objects/string/matchall

### DIFF
--- a/files/uk/web/javascript/reference/global_objects/string/matchall/index.md
+++ b/files/uk/web/javascript/reference/global_objects/string/matchall/index.md
@@ -152,6 +152,7 @@ str.matchAll({
 ## Дивіться також
 
 - Поліфіл методу `String.prototype.matchAll` доступний у [`core-js`](https://github.com/zloirock/core-js#ecmascript-string-and-regexp)
+- Посібник [Регулярні вирази](/uk/docs/Web/JavaScript/Guide/Regular_expressions)
 - {{jsxref("String.prototype.match()")}}
 - Посібник [Регулярні вирази](/uk/docs/Web/JavaScript/Guide/Regular_expressions)
 - Посібник [Групи та зворотні посилання](/uk/docs/Web/JavaScript/Guide/Regular_expressions/Groups_and_backreferences)


### PR DESCRIPTION
Оригінальний вміст: [String.prototype.matchAll()@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Global_Objects/String/matchAll), [сирці String.prototype.matchAll()@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/global_objects/string/matchall/index.md)

Нові зміни:
- [Add Regex Guide to See Also sections of common functions that use Regexes (#37710)](https://github.com/mdn/content/commit/7d09807ed7594cf5c7b93afc1fa0424a26663b9b)