### PR TITLE
update(JS): web/javascript/reference/errors/not_defined

### DIFF
--- a/files/uk/web/javascript/reference/errors/not_defined/index.md
+++ b/files/uk/web/javascript/reference/errors/not_defined/index.md
@@ -23,7 +23,8 @@ ReferenceError: Can't find variable: x (Safari)
 
 Десь відбувається звертання до відсутньої змінної. Така змінна повинна бути оголошена, тобто слід пересвідчитися, що вона доступна для поточних сценарію та [області видимості](/uk/docs/Glossary/Scope).
 
-> **Примітка:** При завантаженні бібліотеки (наприклад, jQuery) слід пересвідчитися, що вона завантажується до звертання до змінних цієї бібліотеки, як то "$". Слід поставити елемент {{HTMLElement("script")}}, котрий завантажує цю бібліотеку, до власного коду, що її використовує.
+> [!NOTE]
+> При завантаженні бібліотеки (наприклад, jQuery) слід пересвідчитися, що вона завантажується до звертання до змінних цієї бібліотеки, як то "$". Слід поставити елемент {{HTMLElement("script")}}, котрий завантажує цю бібліотеку, до власного коду, що її використовує.
 
 ## Приклади
 
@@ -71,4 +72,4 @@ console.log(numbers()); // 5
 
 - [Область видимості](/uk/docs/Glossary/Scope)
 - [Оголошення змінних у Посібнику JavaScript](/uk/docs/Web/JavaScript/Guide/Grammar_and_types#oholoshennia-zminnykh)
-- [Функційна область видимості в Посібнику JavaScript](/uk/docs/Web/JavaScript/Guide/Functions#funktsiina-oblast-vydymosti)
+- [Функційна область видимості в Посібнику JavaScript](/uk/docs/Web/JavaScript/Guide/Functions#funktsiini-oblasti-vydymosti-ta-zamykannia)


### PR DESCRIPTION
Оригінальний вміст: ['ReferenceError: "x" is not defined'@MDN](https://developer.mozilla.org/en-us/docs/Web/JavaScript/Reference/Errors/Not_defined), [сирці 'ReferenceError: "x" is not defined'@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/errors/not_defined/index.md)

Нові зміни:
- [Streamline explanation for closures (#37826)](https://github.com/mdn/content/commit/8f10db5cabb50ee778f781f96adadc8cff98761a)
- [Convert noteblocks for web/javascript/reference folder (#35095)](https://github.com/mdn/content/commit/1b2c87c20466d2a3eec9b3551c269f9aff8f5762)