### PR TITLE
update(CSS): web/css/height

### DIFF
--- a/files/uk/web/css/height/index.md
+++ b/files/uk/web/css/height/index.md
@@ -64,7 +64,7 @@ height: unset;
   - : Використовує формулу fit-content щодо доступного простору, заміненого вказаним аргументом, тобто `min(max-content, max(min-content, <length-percentage>))`.
 - `stretch`
 
-  - : Задає висоті [рамки зовнішніх відступів](/uk/docs/Learn/CSS/Building_blocks/The_box_model#chastyny-ramky) елемента висоту його [контейнерного блока](/uk/docs/Web/CSS/Containing_block#vybir-konteinernoho-bloka). Намагається змусити рамку зовнішніх відступів заповнити доступний у контейнерному блоці простір так, щоб це вийшло схоже на `100%`, але застосовуючи результівний розмір до рамки зовнішніх відступів, а не рамки, визначеної [box-sizing](/uk/docs/Web/CSS/box-sizing).
+  - : Задає висоті [рамки зовнішніх відступів](/uk/docs/Learn_web_development/Core/Styling_basics/Box_model#chastyny-ramky) елемента висоту його [контейнерного блока](/uk/docs/Web/CSS/Containing_block#vybir-konteinernoho-bloka). Намагається змусити рамку зовнішніх відступів заповнити доступний у контейнерному блоці простір так, щоб це вийшло схоже на `100%`, але застосовуючи результівний розмір до рамки зовнішніх відступів, а не рамки, визначеної [box-sizing](/uk/docs/Web/CSS/box-sizing).
 
     > [!NOTE]
     > Аби перевірити псевдоніми значення `stretch`, що використовуються браузерами, та статус реалізації цього значення, дивіться наш розділ [Сумісності з браузерами](#sumisnist-iz-brauzeramy).


### PR DESCRIPTION
Оригінальний вміст: [height@MDN](https://developer.mozilla.org/en-us/docs/Web/CSS/height), [сирці height@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/css/height/index.md)

Нові зміни:
- [chore(learn): Move MDN Curriculum into Learning Area (#36967)](https://github.com/mdn/content/commit/5b20f5f4265f988f80f513db0e4b35c7e0cd70dc)