### PR TITLE
update(HTML): web/html/element/textarea

### DIFF
--- a/files/uk/web/html/element/textarea/index.md
+++ b/files/uk/web/html/element/textarea/index.md
@@ -102,7 +102,7 @@ browser-compat: html.elements.textarea
 
 `<textarea>` є [заміщеним елементом](/uk/docs/Web/CSS/Replaced_element): він має природні розміри, як растрове зображення. Усталено його значення {{cssxref("display")}} – `inline-block`. У порівнянні з іншими елементами форми його порівняно легко оформлювати, адже його рамкову модель, шрифти, колірну гаму тощо легко змінити за допомогою звичайного CSS.
 
-[Оформлення форм HTML](/uk/docs/Learn/Forms/Styling_web_forms) пропонує трохи корисних порад щодо оформлення елементів `<textarea>`.
+[Оформлення форм HTML](/uk/docs/Learn_web_development/Extensions/Forms/Styling_web_forms) пропонує трохи корисних порад щодо оформлення елементів `<textarea>`.
 
 ### Ненадійність базової лінії
 


### PR DESCRIPTION
Оригінальний вміст: [&lt;textarea&gt; – елемент текстової області@MDN](https://developer.mozilla.org/en-us/docs/Web/HTML/Element/textarea), [сирці &lt;textarea&gt; – елемент текстової області@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/html/element/textarea/index.md)

Нові зміни:
- [chore(learn): Move MDN Curriculum into Learning Area (#36967)](https://github.com/mdn/content/commit/5b20f5f4265f988f80f513db0e4b35c7e0cd70dc)