### PR TITLE
update(HTML): web/html/element/input/datetime-local

### DIFF
--- a/files/uk/web/html/element/input/datetime-local/index.md
+++ b/files/uk/web/html/element/input/datetime-local/index.md
@@ -279,5 +279,4 @@ input:valid + span::after {
 - Узагальнений елемент {{HTMLElement("input")}}, а також інтерфейс, що використовується для роботи з ним, – {{domxref("HTMLInputElement")}}
 - [`<input type="date">`](/uk/docs/Web/HTML/Element/input/date) і [`<input type="time">`](/uk/docs/Web/HTML/Element/input/time)
 - [Формати дати й часу, що використовуються в HTML](/uk/docs/Web/HTML/Date_and_time_formats)
-- [Підручник з інтерфейсу вибору дати та часу](/uk/docs/Learn/Forms/HTML5_input_types#interfeis-vyboru-daty-ta-chasu)
-- [Сумісність властивостей CSS](/uk/docs/Learn/Forms/Property_compatibility_table_for_form_controls)
+- [Підручник з інтерфейсу вибору дати та часу](/uk/docs/Learn_web_development/Extensions/Forms/HTML5_input_types#interfeis-vyboru-daty-ta-chasu)


### PR DESCRIPTION
Оригінальний вміст: [&lt;input type="datetime-local"&gt;@MDN](https://developer.mozilla.org/en-us/docs/Web/HTML/Element/input/datetime-local), [сирці &lt;input type="datetime-local"&gt;@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/html/element/input/datetime-local/index.md)

Нові зміни:
- [chore(learn): Move MDN Curriculum into Learning Area (#36967)](https://github.com/mdn/content/commit/5b20f5f4265f988f80f513db0e4b35c7e0cd70dc)