### PR TITLE
update(HTML): web/html/element/audio

### DIFF
--- a/files/uk/web/html/element/audio/index.md
+++ b/files/uk/web/html/element/audio/index.md
@@ -269,7 +269,7 @@ navigator.mediaDevices
 - Елементи `<audio>` не можуть мати субтитрів або підписів, пов'язаних з ними, як це можуть елементи `<video>`. Корисна інформація про це та обхідні шляхи – в статті Яна Девліна [WebVTT та аудіо](https://www.iandevlin.com/blog/2015/12/html5/webvtt-and-audio/).
 - Щоб перевірити запасний вміст у браузерах, що підтримують цей елемент, можна замінити `<audio>` на відсутній елемент, наприклад, `<notanaudio>`.
 
-Добре загальне джерело інформації щодо використання `<audio>` HTML – це підручник для початківців [Відео та аудіо вміст](/uk/docs/Learn/HTML/Multimedia_and_embedding/Video_and_audio_content).
+Добре загальне джерело інформації щодо використання `<audio>` HTML – це підручник для початківців [Відео й аудіо вміст](/uk/docs/Learn_web_development/Core/Structuring_content/HTML_video_and_audio).
 
 ### Оформлення засобами CSS
 
@@ -467,5 +467,5 @@ elem.audioTrackList.onremovetrack = (event) => {
 - {{domxref("HTMLAudioElement")}}
 - {{htmlelement("source")}}
 - {{htmlelement("video")}}
-- [Зона навчання – Аудіо та відео вміст](/uk/docs/Learn/HTML/Multimedia_and_embedding/Video_and_audio_content)
-- [Кросбраузерні основи аудіо](/uk/docs/Web/Media/Audio_and_video_delivery/Cross-browser_audio_basics)
+- [Зона навчання – Відео й аудіо вміст](/uk/docs/Learn_web_development/Core/Structuring_content/HTML_video_and_audio)
+- [Основи кросбраузерного аудіо](/uk/docs/Web/Media/Audio_and_video_delivery/Cross-browser_audio_basics)


### PR DESCRIPTION
Оригінальний вміст: [&lt;audio&gt; – елемент вбудованого аудіо@MDN](https://developer.mozilla.org/en-us/docs/Web/HTML/Element/audio), [сирці &lt;audio&gt; – елемент вбудованого аудіо@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/html/element/audio/index.md)

Нові зміни:
- [chore(ia): reorg Web/Media (#37898)](https://github.com/mdn/content/commit/27bceead8e9b1fe9c92df0fa5e418f81bd5b9fdf)
- [chore(learn): Move MDN Curriculum into Learning Area (#36967)](https://github.com/mdn/content/commit/5b20f5f4265f988f80f513db0e4b35c7e0cd70dc)