### PR TITLE
update(HTML): web/html/element/input/reset

### DIFF
--- a/files/uk/web/html/element/input/reset/index.md
+++ b/files/uk/web/html/element/input/reset/index.md
@@ -154,7 +154,6 @@ browser-compat: html.elements.input.type_reset
 ## Дивіться також
 
 - {{HTMLElement("input")}} та інтерфейс {{domxref("HTMLInputElement")}}, що його реалізовує.
-- [Форми та кнопки](/uk/docs/Learn/Forms/Basic_native_form_controls#realni-knopky)
-- [Форми HTML](/uk/docs/Learn/Forms)
+- [Форми та кнопки](/uk/docs/Learn_web_development/Extensions/Forms/Basic_native_form_controls#realni-knopky)
+- [Форми HTML](/uk/docs/Learn_web_development/Extensions/Forms)
 - Елемент {{HTMLElement("button")}}
-- [Сумісність властивостей CSS](/uk/docs/Learn/Forms/Property_compatibility_table_for_form_controls)


### PR DESCRIPTION
Оригінальний вміст: [&lt;input type="reset"&gt;@MDN](https://developer.mozilla.org/en-us/docs/Web/HTML/Element/input/reset), [сирці &lt;input type="reset"&gt;@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/html/element/input/reset/index.md)

Нові зміни:
- [chore(learn): Move MDN Curriculum into Learning Area (#36967)](https://github.com/mdn/content/commit/5b20f5f4265f988f80f513db0e4b35c7e0cd70dc)