### PR TITLE
update(CSS): web/css/display

### DIFF
--- a/files/uk/web/css/display/index.md
+++ b/files/uk/web/css/display/index.md
@@ -457,7 +457,8 @@ updateDisplay();
 
 ## Дивіться також
 
-- [Блокове та рядкове компонування у звичайному потоці](/uk/docs/Web/CSS/CSS_flow_layout/Block_and_inline_layout_in_normal_flow)
-- [Вступ до контекстів форматування](/uk/docs/Web/CSS/CSS_flow_layout/Introduction_to_formatting_contexts)
 - {{CSSxRef("visibility")}}, {{CSSxRef("float")}}, {{CSSxRef("position")}}
 - {{CSSxRef("grid")}}, {{CSSxRef("flex")}}
+- Атрибут SVG {{SVGAttr("display")}}
+- [Блокове та рядне компонування у звичайному потоці](/uk/docs/Web/CSS/CSS_flow_layout/Block_and_inline_layout_in_normal_flow)
+- [Вступ до контекстів форматування](/uk/docs/Web/CSS/CSS_flow_layout/Introduction_to_formatting_contexts)


### PR DESCRIPTION
Оригінальний вміст: [display@MDN](https://developer.mozilla.org/en-us/docs/Web/CSS/display), [сирці display@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/css/display/index.md)

Нові зміни:
- [Add links for svg presentation attributes (#37614)](https://github.com/mdn/content/commit/64d85b74ce1cce6a24ae8979da4f3f4a01a47229)