### PR TITLE
update(CSS): web/css/overflow

### DIFF
--- a/files/uk/web/css/overflow/index.md
+++ b/files/uk/web/css/overflow/index.md
@@ -208,6 +208,7 @@ p.overlay {
 - {{Cssxref("overflow-x")}}, {{Cssxref("overflow-y")}}
 - {{Cssxref("overflow-block")}}, {{Cssxref("overflow-clip-margin")}}, {{Cssxref("overflow-inline")}}
 - {{Cssxref("clip")}}, {{Cssxref("display")}}, {{cssxref("text-overflow")}}, {{cssxref("white-space")}}
-- [Переповнення CSS](/uk/docs/Web/CSS/CSS_overflow)
+- Атрибут SVG {{SVGAttr("overflow")}}
+- Модуль [Переповнення CSS](/uk/docs/Web/CSS/CSS_overflow)
 - [Keyboard-only scrolling areas](https://adrianroselli.com/2022/06/keyboard-only-scrolling-areas.html) on adrianroselli.com (November 28, 2022)
 - [Області прокручення лише клавіатурою](https://adrianroselli.com/2022/06/keyboard-only-scrolling-areas.html) на adrianroselli.com (28 листопада 2022 року)


### PR DESCRIPTION
Оригінальний вміст: [overflow@MDN](https://developer.mozilla.org/en-us/docs/Web/CSS/overflow), [сирці overflow@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/css/overflow/index.md)

Нові зміни:
- [Add links for svg presentation attributes (#37614)](https://github.com/mdn/content/commit/64d85b74ce1cce6a24ae8979da4f3f4a01a47229)