### PR TITLE
update(CSS): web/css/text-decoration

### DIFF
--- a/files/uk/web/css/text-decoration/index.md
+++ b/files/uk/web/css/text-decoration/index.md
@@ -128,4 +128,5 @@ text-decoration: unset;
 
 - Окремі властивості text-decoration: {{cssxref("text-decoration-line")}}, {{cssxref("text-decoration-color")}}, {{cssxref("text-decoration-style")}}, and {{cssxref("text-decoration-thickness")}}.
 - Властивості {{cssxref("text-decoration-skip-ink")}}, {{cssxref("text-underline-offset")}} і {{cssxref("text-underline-position")}} також впливають на text-decoration, але не включені в скорочення.
-- Атрибут {{cssxref("list-style")}} контролює вигляд елементів у списках HTML {{HTMLElement("ol")}} та {{HTMLElement("ul")}}.
+- Властивість {{cssxref("list-style")}} контролює вигляд елементів у списках HTML {{HTMLElement("ol")}} та {{HTMLElement("ul")}}.
+- Атрибут SVG {{SVGAttr("text-decoration")}}


### PR DESCRIPTION
Оригінальний вміст: [text-decoration@MDN](https://developer.mozilla.org/en-us/docs/Web/CSS/text-decoration), [сирці text-decoration@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/css/text-decoration/index.md)

Нові зміни:
- [Add links for svg presentation attributes (#37614)](https://github.com/mdn/content/commit/64d85b74ce1cce6a24ae8979da4f3f4a01a47229)