### PR TITLE
update(CSS): web/css/pseudo-classes

### DIFF
--- a/files/uk/web/css/pseudo-classes/index.md
+++ b/files/uk/web/css/pseudo-classes/index.md
@@ -275,6 +275,7 @@ O
 
 - {{CSSxRef(":only-child")}}
 - {{CSSxRef(":only-of-type")}}
+- {{CSSxRef(":open")}}
 - {{CSSxRef(":optional")}}
 - {{CSSxRef(":out-of-range")}}
 


### PR DESCRIPTION
Оригінальний вміст: [Псевдокласи@MDN](https://developer.mozilla.org/en-us/docs/Web/CSS/Pseudo-classes), [сирці Псевдокласи@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/css/pseudo-classes/index.md)

Нові зміни:
- [Add docs for :open pseudo-class (#37869)](https://github.com/mdn/content/commit/41f2977624562dde84c0ef5956a80ee2575c80f0)