### PR TITLE
translation(CSS): web/css/css_values_and_units/value_definition_syntax

### DIFF
--- a/files/uk/web/css/css_values_and_units/value_definition_syntax/index.md
+++ b/files/uk/web/css/css_values_and_units/value_definition_syntax/index.md
@@ -1,6 +1,6 @@
 ---
 title: Синтаксис визначення значення
-slug: Web/CSS/Value_definition_syntax
+slug: Web/CSS/CSS_Values_and_Units/Value_definition_syntax
 page-type: guide
 spec-urls: https://drafts.csswg.org/css-values/#value-defs
 ---


### PR DESCRIPTION
Оригінальний вміст: [Синтаксис визначення значення@MDN](https://developer.mozilla.org/en-us/docs/Web/CSS/CSS_Values_and_Units/Value_definition_syntax), [сирці Синтаксис визначення значення@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/css/css_values_and_units/value_definition_syntax/index.md)