### PR TITLE
update(CSS): web/css/css_nesting

### DIFF
--- a/files/uk/web/css/css_nesting/index.md
+++ b/files/uk/web/css/css_nesting/index.md
@@ -40,6 +40,6 @@ spec-urls: https://drafts.csswg.org/css-nesting-1/
 
 ## Дивіться також
 
-- [Специфічність](/uk/docs/Web/CSS/Specificity)
-- [Модуль Каскадності та успадкування CSS](/uk/docs/Web/CSS/CSS_cascade)
+- [Специфічність](/uk/docs/Web/CSS/CSS_cascade/Specificity)
+- [Модуль Каскадування та успадкування CSS](/uk/docs/Web/CSS/CSS_cascade)
 - [Модуль Селекторів CSS](/uk/docs/Web/CSS/CSS_selectors)


### PR DESCRIPTION
Оригінальний вміст: [Вкладеність CSS@MDN](https://developer.mozilla.org/en-us/docs/Web/CSS/CSS_nesting), [сирці Вкладеність CSS@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/css/css_nesting/index.md)

Нові зміни:
- [Move specificity and cascade under CSS cascade module (#38125)](https://github.com/mdn/content/commit/a29769d6d10261f771321eb60f3990029c160924)
- [wrong module name of CSS cascade (#37538)](https://github.com/mdn/content/commit/c9c86abc12c3bdd3fdb07c73a0d1cf88cdd0e1bc)