### PR TITLE
update(CSS): web/css/gradient/linear-gradient

### DIFF
--- a/files/uk/web/css/gradient/linear-gradient/index.md
+++ b/files/uk/web/css/gradient/linear-gradient/index.md
@@ -7,7 +7,7 @@ browser-compat: css.types.gradient.linear-gradient
 
 {{CSSRef}}
 
-[Функція](/uk/docs/Web/CSS/CSS_Functions) [CSS](/uk/docs/Web/CSS) **`linear-gradient()`** (лінійний градієнт) створює зображення, що складається з поступового переходу між двома або більше кольорами уздовж прямої лінії. Її результатом є об'єкт типу даних {{CSSxRef("&lt;gradient&gt;")}}, котрий є особливим різновидом {{CSSxRef("&lt;image&gt;")}}.
+[Функція](/uk/docs/Web/CSS/CSS_Values_and_Units/CSS_Value_Functions) [CSS](/uk/docs/Web/CSS) **`linear-gradient()`** (лінійний градієнт) створює зображення, що складається з поступового переходу між двома або більше кольорами уздовж прямої лінії. Її результатом є об'єкт типу даних {{CSSxRef("&lt;gradient&gt;")}}, котрий є особливим різновидом {{CSSxRef("&lt;image&gt;")}}.
 
 {{EmbedInteractiveExample("pages/css/function-linear-gradient.html")}}
 


### PR DESCRIPTION
Оригінальний вміст: [linear-gradient()@MDN](https://developer.mozilla.org/en-us/docs/Web/CSS/gradient/linear-gradient), [сирці linear-gradient()@GitHub](https://github.com/mdn/content/blob/main/files/en-us/web/css/gradient/linear-gradient/index.md)

Нові зміни:
- [moved three guides to be under their module (#38258)](https://github.com/mdn/content/commit/891bc513a3349040a16c4896197d6a3a910ca42b)